### PR TITLE
feat(changelog): add support for scope with spaces

### DIFF
--- a/lib/git.js
+++ b/lib/git.js
@@ -62,7 +62,7 @@ function getCommits(options, done) {
     .pipe(es.writeArray(done));
 }
 
-var COMMIT_PATTERN = /^(\w*)(\(([\w\$\.\-\*]*)\))?\: (.*)$/;
+var COMMIT_PATTERN = /^(\w*)(\(([\w\$\.\-\* ]*)\))?\: (.*)$/;
 var MAX_SUBJECT_LENGTH = 80;
 function parseRawCommit(raw, options) {
   if (!raw) {

--- a/test/git.spec.js
+++ b/test/git.spec.js
@@ -77,5 +77,14 @@ describe('git', function() {
       );
       expect(msg.type).to.equal('chore');
     });
+    it('should parse a scope with spaces', function() {
+      var msg = git.parseRawCommit(
+        '13f31602f396bc269076ab4d389cfd8ca94b20ba\n' +
+        'chore(scope with spaces): some chore\n' +
+        'bla bla bla\n\n' +
+        'BREAKING CHANGE: some breaking change\n'
+      );
+      expect(msg).to.not.equal(null);
+    });
   });
 });


### PR DESCRIPTION
This is pretty self-explanatory. Allows scopes to have spaces:

```
fix(some example scope): some other text
```
