### PR TITLE
fix(changelog): put commit range into quotes so it can fetch commits with special characters

### DIFF
--- a/lib/git.js
+++ b/lib/git.js
@@ -49,7 +49,7 @@ function getCommits(options, done) {
     cmd, 
     options.grep,
     options.format, 
-    options.from ? options.from+'..'+options.to : ''
+    options.from ? '"'+options.from+'..'+options.to+'"' : ''
   );
 
   return es.child(cp.exec(cmd))


### PR DESCRIPTION
This fixes an issue where `getCommits()` would not recognise tags containing special characters, such as `RC;.;1.59.0`.

It just puts the whole range into quotes.
