### PR TITLE
docs(README): Fix incorrect module name

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Adapted from code originally written by @vojtajina and @btford in [grunt-convent
 Simple usage: 
 
 ```js
-require('changelog')({
+require('conventional-changelog')({
   repository: 'https://github.com/joyent/node',
   version: require('./package.json').version
 }, function(err, log) {


### PR DESCRIPTION
I hope I'm not being stupid, but shouldn't this be the example?
