### PR TITLE
Fix first commit being always missing from changelog

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ function generate(options, done) {
     options.log('Generating changelog from %s to %s...', options.from, options.to);
 
     git.getCommits({
-      from: options.from, 
+      from: options.from,
       to: options.to,
     }, function(err, commits) {
       if (err) return done('Failed to read git log.\n'+err);

--- a/lib/git.js
+++ b/lib/git.js
@@ -1,7 +1,7 @@
 var extend = require('lodash.assign');
 var cp = require('child_process');
 var es = require('event-stream');
-var util = require('util'); 
+var util = require('util');
 module.exports = {
   parseRawCommit: parseRawCommit,
   getCommits: getCommits,
@@ -47,9 +47,9 @@ function getCommits(options, done) {
 
   var cmd = 'git log --grep="%s" -E --format=%s %s';
   cmd = util.format(
-    cmd, 
+    cmd,
     options.grep,
-    options.format, 
+    options.format,
     options.from ? '"' + options.from + '..' + options.to + '"' : ''
   );
 


### PR DESCRIPTION
First commit was always being ignored due to setting the from to the first commit when no tags have been set.
