### PR TITLE
docs: fix links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,23 +16,20 @@ command line.
 
 The conventional-changelog repo is managed as a [monorepo](https://github.com/babel/babel/blob/master/doc/design/monorepo.md); it's composed of many npm packages.
 
-The original `conventional-changelog/conventional-changelog` repo can be
+The original `conventional-changelog/conventional-changelog` API repo can be
 found in [packages/conventional-changelog](https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog).
 
 ## Plugins Supporting Conventional Changelog
 
 [grunt](https://github.com/btford/grunt-conventional-changelog)/[gulp](https://github.com/conventional-changelog/gulp-conventional-changelog)/[atom](https://github.com/conventional-changelog/atom-conventional-changelog).
 
-## Modules of Note
+## Modules Important to Conventional Changelog Ecosystem
 
-- [conventional-changelog-cli](https://github.com/conventional-changelog/conventional-changelog-cli) - the full-featured command line interface
-- [standard-changelog](https://github.com/conventional-changelog/standard-changelog) - command line interface for the angular commit format.
+- [conventional-changelog-cli](https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-cli) - the full-featured command line interface
+- [standard-changelog](https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/standard-changelog) - command line interface for the angular commit format.
 - [conventional-github-releaser](https://github.com/conventional-changelog/conventional-github-releaser) - Make a new GitHub release from git metadata
 - [conventional-recommended-bump](https://github.com/conventional-changelog/conventional-recommended-bump) - Get a recommended version bump based on conventional commits
 - [conventional-commits-detector](https://github.com/conventional-changelog/conventional-commits-detector) - Detect what commit message convention your repository is using
-
 - [commitizen](https://github.com/commitizen/cz-cli) - Simple commit conventions for internet citizens.
-
 - [angular-precommit](https://github.com/ajoslin/angular-precommit) - Pre commit with angular conventions
-
 - [conventional-changelog-lint](https://github.com/marionebl/conventional-changelog-lint) - Lint commit messages against your conventional-changelog preset

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 It's recommended you use the high level [standard-version](https://github.com/conventional-changelog/standard-version) library, which handles the the entire tagging and CHANGELOG
 generation process.
 
-Alternatively, the [conventional-changelog-cli](https://github.com/conventional-changelog/conventional-changelog-cli) allows you to generate a CHANGELOG from the
+Alternatively, the [conventional-changelog-cli](https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-cli) allows you to generate a CHANGELOG from the
 command line.
 
 ## About this Repo


### PR DESCRIPTION
A few of the links in the README were out of date, after monorepo migration.

CC: @Tapppi, @stevemao 