### PR TITLE
feat: wire up lerna repository support

### DIFF
--- a/packages/conventional-changelog-core/lib/merge-config.js
+++ b/packages/conventional-changelog-core/lib/merge-config.js
@@ -20,10 +20,21 @@ var _ = require('lodash');
 var rhosts = /github|bitbucket|gitlab/i;
 var rtag = /tag:\s*[v=]?(.+?)[,\)]/gi;
 
+function semverTagsPromise(options) {
+  var semverTagsDeferred = Q.defer();
+  gitSemverTags(function(err, result) {
+    if (err) {
+      semverTagsDeferred.reject(err);
+    } else {
+      semverTagsDeferred.resolve(result);
+    }
+  }, {lernaTags: !!options.lernaPackage, package: options.lernaPackage});
+  return semverTagsDeferred.promise;
+}
+
 function mergeConfig(options, context, gitRawCommitsOpts, parserOpts, writerOpts) {
   var configPromise;
   var pkgPromise;
-  var semverTagsPromise;
   var gitRemoteOriginUrlPromise;
 
   context = context || {};
@@ -53,7 +64,8 @@ function mergeConfig(options, context, gitRawCommitsOpts, parserOpts, writerOpts
       }
 
       cb(null, commit);
-    }
+    },
+    lernaPackage: null
   }, options);
 
   options.warn = options.warn || options.debug;
@@ -74,11 +86,9 @@ function mergeConfig(options, context, gitRawCommitsOpts, parserOpts, writerOpts
     }
   }
 
-  semverTagsPromise = Q.nfcall(gitSemverTags);
-
   gitRemoteOriginUrlPromise = Q(gitRemoteOriginUrl()); // jshint ignore:line
 
-  return Q.allSettled([configPromise, pkgPromise, semverTagsPromise, gitRemoteOriginUrlPromise])
+  return Q.allSettled([configPromise, pkgPromise, semverTagsPromise(options), gitRemoteOriginUrlPromise])
     .spread(function(configObj, pkgObj, tagsObj, gitRemoteOriginUrlObj) {
       var config;
       var pkg;
@@ -148,7 +158,6 @@ function mergeConfig(options, context, gitRawCommitsOpts, parserOpts, writerOpts
       if (tagsObj.state === 'fulfilled') {
         gitSemverTags = context.gitSemverTags = tagsObj.value;
         fromTag = gitSemverTags[options.releaseCount - 1];
-
         var lastTag = gitSemverTags[0];
 
         if (lastTag === context.version || lastTag === 'v' + context.version) {

--- a/packages/conventional-changelog-core/lib/merge-config.js
+++ b/packages/conventional-changelog-core/lib/merge-config.js
@@ -21,15 +21,15 @@ var rhosts = /github|bitbucket|gitlab/i;
 var rtag = /tag:\s*[v=]?(.+?)[,\)]/gi;
 
 function semverTagsPromise(options) {
-  var semverTagsDeferred = Q.defer();
-  gitSemverTags(function(err, result) {
-    if (err) {
-      semverTagsDeferred.reject(err);
-    } else {
-      semverTagsDeferred.resolve(result);
-    }
-  }, {lernaTags: !!options.lernaPackage, package: options.lernaPackage});
-  return semverTagsDeferred.promise;
+  return Q.Promise(function(resolve, reject) {
+    gitSemverTags(function(err, result) {
+      if (err) {
+        reject(err);
+      } else {
+        resolve(result);
+      }
+    }, {lernaTags: !!options.lernaPackage, package: options.lernaPackage});
+  });
 }
 
 function mergeConfig(options, context, gitRawCommitsOpts, parserOpts, writerOpts) {

--- a/packages/conventional-changelog-core/package.json
+++ b/packages/conventional-changelog-core/package.json
@@ -36,6 +36,7 @@
     "istanbul": "^0.4.1",
     "jscs": "^3.0.3",
     "jshint": "^2.9.1",
+    "mkdirp": "^0.5.1",
     "mocha": "*",
     "pinkie-promise": "^2.0.0",
     "semver": "^5.1.0",

--- a/packages/conventional-changelog-core/readme.md
+++ b/packages/conventional-changelog-core/readme.md
@@ -106,6 +106,13 @@ Type: `boolean` Default: `true` if a different version than last release is give
 
 If this value is `true` and `context.version` equals last release then `context.version` will be changed to `'Unreleased'`.
 
+##### lernaPackage
+
+Specify a package in lerna-style monorepo that the CHANGELOG should be generated for.
+
+Lerna tags releases in the format `foo-package@1.0.0` and assumes that packages
+are stored in the directory structure `./package/foo-package`.
+
 #### context
 
 See the [conventional-changelog-writer](https://github.com/conventional-changelog/conventional-changelog-writer) docs. There are some defaults or changes:


### PR DESCRIPTION
makes it possible to pass lerna configuration settings to `gitSemverTags`, and adds tests experimenting with the lerna repository support I've been working on.

see: #168 

## Neat!

```js
var conventionalChangelogCore = require('../conventional-changelog-core');

conventionalChangelogCore({
  lernaPackage: 'git-raw-commits',
  config: require('../conventional-changelog-angular')
}, {}, {
  path: './'
})
  .pipe(process.stdout); // or any writable stream
```

The above code seems to work like a charm.

```md
<a name="1.1.2"></a>
## [1.1.2](https://github.com/stevemao/git-semver-tags/compare/git-semver-tags@1.1.2...v1.1.2) (2017-03-09)


### Features

* add support for listing lerna style tags (project[@version](https://github.com/version)) (#161) ([b245f9d](https://github.com/stevemao/git-semver-tags/commit/b245f9d))
* migrate repo to lerna mono-repo ([793e823](https://github.com/stevemao/git-semver-tags/commit/793e823))
```

## Todo

- [x] if no commits are found matching `lernaPackage` a CHANGELOG is generated with all git commits 🐞 