### PR TITLE
feat(options): add option for scoped packages

### DIFF
--- a/packages/conventional-changelog/index.js
+++ b/packages/conventional-changelog/index.js
@@ -4,11 +4,19 @@ var conventionalChangelogCore = require('conventional-changelog-core');
 function conventionalChangelog(options, context, gitRawCommitsOpts, parserOpts, writerOpts) {
   options.warn = options.warn || function() {};
 
+  var scope = '';
+
+  if (options.scope) {
+    scope = options.scope.toLowerCase() + '/';
+  }
+
   if (options.preset) {
     try {
-      options.config = require('conventional-changelog-' + options.preset.toLowerCase());
+      options.config = require(scope + 'conventional-changelog-' + options.preset.toLowerCase());
     } catch (err) {
-      options.warn('Preset: "' + options.preset + '" does not exist');
+      var errMessage = 'Preset: "' + options.preset + '" does not exist';
+      errMessage += scope !== '' ?  ' under scope "' + options.scope + '"' : '';
+      options.warn(errMessage);
     }
   }
 

--- a/packages/conventional-changelog/package.json
+++ b/packages/conventional-changelog/package.json
@@ -39,6 +39,7 @@
   "devDependencies": {
     "chai": "^3.0.0",
     "concat-stream": "^1.4.10",
+    "@yoitsro/conventional-changelog-angular": "^1.0.0",
     "jscs": "^2.0.0",
     "jshint": "^2.8.0",
     "mocha": "*",

--- a/packages/conventional-changelog/test/test.js
+++ b/packages/conventional-changelog/test/test.js
@@ -113,4 +113,72 @@ describe('conventionalChangelog', function() {
         done();
       }));
   });
+
+  it('should work with scoped presets', function(done) {
+    var i = 0;
+
+    conventionalChangelog({
+      preset: 'angular',
+      scope: '@yoitsro'
+    })
+      .on('error', function(err) {
+        done(err);
+      })
+      .pipe(through(function(chunk, enc, cb) {
+        chunk = chunk.toString();
+
+        expect(chunk).to.include('#');
+
+        i++;
+        cb();
+      }, function() {
+        expect(i).to.equal(1);
+        done();
+      }));
+  });
+
+  it('should warn if scoped preset is not found', function(done) {
+    var i = 0;
+
+    conventionalChangelog({
+      preset: 'angular',
+      scope: '@yoitsroo',
+      warn: function(warning) {
+        if (i > 0) {
+          return;
+        }
+
+        expect(warning).to.equal('Preset: "angular" does not exist under scope "@yoitsroo"');
+
+        i++;
+        done();
+      }
+    })
+      .on('error', function(err) {
+        done(err);
+      });
+  });
+
+  it('should still work if scoped preset is not found', function(done) {
+    var i = 0;
+
+    conventionalChangelog({
+      preset: 'angular',
+      scope: '@yoitsroo',
+    })
+      .on('error', function(err) {
+        done(err);
+      })
+      .pipe(through(function(chunk, enc, cb) {
+        chunk = chunk.toString();
+
+        expect(chunk).to.include('#');
+
+        i++;
+        cb();
+      }, function() {
+        expect(i).to.equal(1);
+        done();
+      }));
+  });
 });


### PR DESCRIPTION
This allows for scoped preset packages to be used. Before, only non-scoped packages could be used as a preset, which wasn't great for packages scoped under an organisation's scope name.