### PR TITLE
feat: context.currentTag should take into account lerna tag format

### DIFF
--- a/packages/conventional-changelog-core/lib/merge-config.js
+++ b/packages/conventional-changelog-core/lib/merge-config.js
@@ -265,7 +265,9 @@ function mergeConfig(options, context, gitRawCommitsOpts, parserOpts, writerOpts
                   context.currentTag = context.currentTag || firstCommitHash;
                 }
               } else {
-                context.currentTag = context.currentTag || 'v' + context.version;
+                if (!context.currentTag) {
+                  context.currentTag = options.lernaPackage ? options.lernaPackage + '@' + context.version : 'v' + context.version;
+                }
               }
             }
 

--- a/packages/conventional-changelog-core/package.json
+++ b/packages/conventional-changelog-core/package.json
@@ -30,6 +30,7 @@
   },
   "devDependencies": {
     "better-than-before": "^1.0.0",
+    "conventional-changelog-angular": "^1.3.2",
     "chai": "^3.4.1",
     "git-dummy-commit": "^1.1.0",
     "git-tails": "^1.0.0",

--- a/packages/conventional-changelog-core/test/test.js
+++ b/packages/conventional-changelog-core/test/test.js
@@ -1149,7 +1149,7 @@ describe('conventionalChangelogCore', function() {
         }));
     });
 
-    it('context.currentTag takes into account lerna tag format', function(done) {
+    it('takes into account lerna tag format when generating context.currentTag', function(done) {
       preparing(16);
 
       conventionalChangelogCore({

--- a/packages/conventional-changelog-core/test/test.js
+++ b/packages/conventional-changelog-core/test/test.js
@@ -83,19 +83,20 @@ betterThanBefore.setups([
     gitDummyCommit('something unreleased yet :)');
   },
   function() { // 16
-    shell.exec('git tag foo@2.0.0');
+    writeFileSync('./package.json', '{"version": "2.0.0"}'); // required by angular preset.
+    shell.exec('git tag foo@1.0.0');
     mkdirp.sync('./packages/foo');
     writeFileSync('./packages/foo/test1', '');
-    shell.exec('git add --all && git commit -m"first lerna style commit hooray"');
+    shell.exec('git add --all && git commit -m"feat: first lerna style commit hooray"');
     mkdirp.sync('./packages/bar');
     writeFileSync('./packages/bar/test1', '');
-    shell.exec('git add --all && git commit -m"another lerna package, this should be skipped"');
+    shell.exec('git add --all && git commit -m"feat: another lerna package, this should be skipped"');
   },
   function() { // 17
-    shell.exec('git tag foo@2.1.0');
+    shell.exec('git tag foo@1.1.0');
     mkdirp.sync('./packages/foo');
     writeFileSync('./packages/foo/test2', '');
-    shell.exec('git add --all && git commit -m"second lerna style commit woo"');
+    shell.exec('git add --all && git commit -m"feat: second lerna style commit woo"');
   }
 ]);
 
@@ -1142,6 +1143,24 @@ describe('conventionalChangelogCore', function() {
           expect(chunk).to.not.include('second lerna style commit woo');
           expect(chunk).to.not.include('another lerna package, this should be skipped');
           expect(chunk).to.not.include('something unreleased yet :)');
+          cb();
+        }, function() {
+          done();
+        }));
+    });
+
+    it('context.currentTag takes into account lerna tag format', function(done) {
+      preparing(16);
+
+      conventionalChangelogCore({
+        lernaPackage: 'foo',
+        config: require('conventional-changelog-angular')
+      }, {}, {path: './packages/foo'})
+        .pipe(through(function(chunk, enc, cb) {
+          chunk = chunk.toString();
+          // confirm that context.currentTag behaves differently when
+          // lerna style tags are applied.
+          expect(chunk).to.include('foo@1.0.0...foo@2.0.0');
           cb();
         }, function() {
           done();


### PR DESCRIPTION
`context.currentTag`, which is used by `conventional-changelog-angular`, should take into account the lerna style tag format.