### PR TITLE
chore: switch to version of lerna that supports conventional-commits

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "lerna": "2.0.0-beta.38",
+  "lerna": "2.0.0-beta.38-31-g0749ea6",
   "packages": [
     "packages/*"
   ],

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "homepage": "https://github.com/conventional-changelog/conventional-changelog#readme",
   "devDependencies": {
     "coveralls": "^2.11.16",
-    "lerna": "2.0.0-beta.38",
+    "lerna": "2.0.0-beta.38-31-g0749ea6",
     "nyc": "^10.1.2",
     "standard-version": "^4.0.0"
   }


### PR DESCRIPTION
This switches us to a canary release of conventional-commits that supports conventional commits.