### PR TITLE
[WIP] feat(link-compare): generate compare url and simplify templates

### DIFF
--- a/packages/conventional-changelog-angular/templates/header.hbs
+++ b/packages/conventional-changelog-angular/templates/header.hbs
@@ -4,19 +4,7 @@
 {{~else~}}
   #
 {{~/if}} {{#if @root.linkCompare~}}
-  [{{version}}](
-  {{~#if @root.repository~}}
-    {{~#if @root.host}}
-      {{~@root.host}}/
-    {{~/if}}
-    {{~#if @root.owner}}
-      {{~@root.owner}}/
-    {{~/if}}
-    {{~@root.repository}}
-  {{~else}}
-    {{~@root.repoUrl}}
-  {{~/if~}}
-  /compare/{{previousTag}}...{{currentTag}})
+  [{{version}}]({{linkCompare}})
 {{~else}}
   {{~version}}
 {{~/if}}

--- a/packages/conventional-changelog-atom/templates/header.hbs
+++ b/packages/conventional-changelog-atom/templates/header.hbs
@@ -1,2 +1,2 @@
 <a name="{{version}}"></a>
-{{#if isPatch}}##{{else}}#{{/if}} {{#if @root.linkCompare}}[{{version}}]({{@root.host}}/{{#if @root.owner}}{{@root.owner}}/{{/if}}{{@root.repository}}/compare/{{previousTag}}...{{currentTag}}){{else}}{{version}}{{/if}}{{#if title}} "{{title}}"{{/if}}{{#if date}} ({{date}}){{/if}}
+{{#if isPatch}}##{{else}}#{{/if}} {{#if @root.linkCompare}}[{{version}}]({{linkCompare}}){{else}}{{version}}{{/if}}{{#if title}} "{{title}}"{{/if}}{{#if date}} ({{date}}){{/if}}

--- a/packages/conventional-changelog-codemirror/templates/header.hbs
+++ b/packages/conventional-changelog-codemirror/templates/header.hbs
@@ -1,2 +1,2 @@
 <a name="{{version}}"></a>
-{{#if isPatch}}##{{else}}#{{/if}} {{#if @root.linkCompare}}[{{version}}]({{@root.host}}/{{#if @root.owner}}{{@root.owner}}/{{/if}}{{@root.repository}}/compare/{{previousTag}}...{{currentTag}}){{else}}{{version}}{{/if}}{{#if title}} "{{title}}"{{/if}}{{#if date}} ({{date}}){{/if}}
+{{#if isPatch}}##{{else}}#{{/if}} {{#if @root.linkCompare}}[{{version}}]({{linkCompare}}){{else}}{{version}}{{/if}}{{#if title}} "{{title}}"{{/if}}{{#if date}} ({{date}}){{/if}}

--- a/packages/conventional-changelog-core/test/fixtures/_bitbucket-host.json
+++ b/packages/conventional-changelog-core/test/fixtures/_bitbucket-host.json
@@ -1,0 +1,7 @@
+{
+  "version": "0.0.17",
+  "repository": {
+    "type": "git",
+    "url": "https://some-user@bitbucket.org/some-group/some-project.git"
+  }
+}

--- a/packages/conventional-changelog-core/test/test.js
+++ b/packages/conventional-changelog-core/test/test.js
@@ -492,6 +492,27 @@ describe('conventionalChangelogCore', function() {
     }));
   });
 
+  it('should generate correct compare url for bitbucket', function(done) {
+    preparing(18);
+
+    conventionalChangelogCore({
+      releaseCount: 0,
+      pkg: {
+        path: __dirname + '/fixtures/_bitbucket-host.json'
+      },
+      config: require('../../conventional-changelog-angular')
+    }, {
+      version: 'v4.0.0'
+    })
+      .pipe(through(function(chunk) {
+        chunk = chunk.toString();
+
+        expect(chunk).to.include('https://bitbucket.org/some-group/some-project/compare/4.0.0..3.0.0');
+
+        done();
+      }));
+  });
+
   it('should transform the commit', function(done) {
     preparing(5);
 
@@ -1269,5 +1290,6 @@ describe('conventionalChangelogCore', function() {
           done();
         }));
     });
+
   });
 });

--- a/packages/conventional-changelog-ember/templates/header.hbs
+++ b/packages/conventional-changelog-ember/templates/header.hbs
@@ -1,2 +1,2 @@
 <a name="{{version}}"></a>
-{{#if isPatch}}##{{else}}#{{/if}} {{#if @root.linkCompare}}[{{version}}]({{@root.host}}/{{#if @root.owner}}{{@root.owner}}/{{/if}}{{@root.repository}}/compare/{{previousTag}}...{{currentTag}}){{else}}{{version}}{{/if}}{{#if title}} "{{title}}"{{/if}}{{#if date}} ({{date}}){{/if}}
+{{#if isPatch}}##{{else}}#{{/if}} {{#if @root.linkCompare}}[{{version}}]({{linkCompare}}){{else}}{{version}}{{/if}}{{#if title}} "{{title}}"{{/if}}{{#if date}} ({{date}}){{/if}}

--- a/packages/conventional-changelog-eslint/templates/header.hbs
+++ b/packages/conventional-changelog-eslint/templates/header.hbs
@@ -1,2 +1,2 @@
 <a name="{{version}}"></a>
-{{#if isPatch}}##{{else}}#{{/if}} {{#if @root.linkCompare}}[{{version}}]({{@root.host}}/{{#if @root.owner}}{{@root.owner}}/{{/if}}{{@root.repository}}/compare/{{previousTag}}...{{currentTag}}){{else}}{{version}}{{/if}}{{#if title}} "{{title}}"{{/if}}{{#if date}} ({{date}}){{/if}}
+{{#if isPatch}}##{{else}}#{{/if}} {{#if @root.linkCompare}}[{{version}}]({{linkCompare}}){{else}}{{version}}{{/if}}{{#if title}} "{{title}}"{{/if}}{{#if date}} ({{date}}){{/if}}

--- a/packages/conventional-changelog-express/templates/header.hbs
+++ b/packages/conventional-changelog-express/templates/header.hbs
@@ -1,2 +1,2 @@
-{{#if version}}{{#if @root.linkCompare}}[{{version}}]({{@root.host}}/{{#if @root.owner}}{{@root.owner}}/{{/if}}{{@root.repository}}/compare/{{previousTag}}...{{currentTag}}){{else}}{{version}}{{/if}} / {{/if}}{{date}}
+{{#if version}}{{#if @root.linkCompare}}[{{version}}]({{linkCompare}}){{else}}{{version}}{{/if}} / {{/if}}{{date}}
 ===================

--- a/packages/conventional-changelog-jquery/templates/header.hbs
+++ b/packages/conventional-changelog-jquery/templates/header.hbs
@@ -4,11 +4,7 @@
 {{~else~}}
   #
 {{~/if}} {{#if @root.linkCompare~}}
-  [{{version}}]({{@root.host}}/
-  {{~#if @root.owner}}
-    {{~@root.owner}}/
-  {{~/if}}
-  {{~@root.repository}}/compare/{{previousTag}}...{{currentTag}})
+  [{{version}}]({{linkCompare}})
 {{~else}}
   {{~version}}
 {{~/if}}

--- a/packages/conventional-changelog-jshint/templates/header.hbs
+++ b/packages/conventional-changelog-jshint/templates/header.hbs
@@ -1,2 +1,2 @@
 <a name="{{version}}"></a>
-{{#if isPatch}}##{{else}}#{{/if}} {{#if @root.linkCompare}}[{{version}}]({{@root.host}}/{{#if @root.owner}}{{@root.owner}}/{{/if}}{{@root.repository}}/compare/{{previousTag}}...{{currentTag}}){{else}}{{version}}{{/if}}{{#if title}} "{{title}}"{{/if}}{{#if date}} ({{date}}){{/if}}
+{{#if isPatch}}##{{else}}#{{/if}} {{#if @root.linkCompare}}[{{version}}]({{linkCompare}}){{else}}{{version}}{{/if}}{{#if title}} "{{title}}"{{/if}}{{#if date}} ({{date}}){{/if}}


### PR DESCRIPTION
- generate compare url when there are tags
- added test for bitbucket host
- updated templates to use `linkCompare` compare directly

Improves #80 
Fixes #185, conventional-changelog/standard-version#142

Didn't go the template editing route because of:
https://github.com/wycats/handlebars.js/issues/927
and
http://chrismontrois.net/2016/01/30/handlebars-switch/

Prior work:
https://github.com/conventional-changelog-archived-repos/conventional-changelog-core/pull/21