### PR TITLE
docs: fix typo in `lernaPackage` option docs

### DIFF
--- a/packages/conventional-changelog-core/readme.md
+++ b/packages/conventional-changelog-core/readme.md
@@ -113,7 +113,7 @@ If this value is `true` and `context.version` equals last release then `context.
 Specify a package in lerna-style monorepo that the CHANGELOG should be generated for.
 
 Lerna tags releases in the format `foo-package@1.0.0` and assumes that packages
-are stored in the directory structure `./package/foo-package`.
+are stored in the directory structure `./packages/foo-package`.
 
 #### context
 


### PR DESCRIPTION
There is a typo the `lernaPackage` option docs. It states that the structure should be `./package/foo-package` but according to lerna docs and also the [`conventional-changelog-core` unit tests](https://github.com/conventional-changelog/conventional-changelog/blob/431598a3b12a404aee63f8ab3e51263121cde485/packages/conventional-changelog-core/test/test.js#L1222) it should be `./packages/foo-package`