### PR TITLE
fix: find package.json from cwd upwards

### DIFF
--- a/packages/conventional-changelog-angular/index.js
+++ b/packages/conventional-changelog-angular/index.js
@@ -1,19 +1,10 @@
 'use strict';
 var compareFunc = require('compare-func');
+var gufg = require('github-url-from-git');
+var readPkgUp = require('read-pkg-up');
 var Q = require('q');
 var readFile = Q.denodeify(require('fs').readFile);
 var resolve = require('path').resolve;
-var path = require('path');
-var pkgJson = {};
-var gufg = require('github-url-from-git');
-try {
-  pkgJson = require(path.resolve(
-    process.cwd(),
-    './package.json'
-  ));
-} catch (err) {
-  console.error('no root package.json found');
-}
 
 var parserOpts = {
   headerPattern: /^(\w*)(?:\((.*)\))?\: (.*)$/,
@@ -28,8 +19,10 @@ var parserOpts = {
 };
 
 function issueUrl() {
-  if (pkgJson.repository && pkgJson.repository.url && ~pkgJson.repository.url.indexOf('github.com')) {
-    var gitUrl = gufg(pkgJson.repository.url);
+  var pkg = readPkgUp.sync().pkg;
+
+  if (pkg && pkg.repository && pkg.repository.url && ~pkg.repository.url.indexOf('github.com')) {
+    var gitUrl = gufg(pkg.repository.url);
 
     if (gitUrl) {
       return gitUrl + '/issues/';

--- a/packages/conventional-changelog-angular/package.json
+++ b/packages/conventional-changelog-angular/package.json
@@ -38,6 +38,7 @@
   "dependencies": {
     "compare-func": "^1.3.1",
     "github-url-from-git": "^1.4.0",
-    "q": "^1.4.1"
+    "q": "^1.4.1",
+    "read-pkg-up": "^2.0.0"
   }
 }


### PR DESCRIPTION
* smarten up logic to find a "root" package json a bit
* use pkg-up to find "root"
* use load-json-file for nice error messages
* move module scope procedure to getPkg
* handle missing package.json without logged warning
* propagate possible json errors