### PR TITLE
Add package.json#files field to all packages

### DIFF
--- a/packages/conventional-changelog-angular/package.json
+++ b/packages/conventional-changelog-angular/package.json
@@ -17,6 +17,10 @@
     "angular",
     "preset"
   ],
+  "files": [
+    "index.js",
+    "templates"
+  ],
   "author": "Steve Mao",
   "license": "ISC",
   "bugs": {

--- a/packages/conventional-changelog-atom/package.json
+++ b/packages/conventional-changelog-atom/package.json
@@ -19,6 +19,10 @@
   ],
   "author": "Steve Mao",
   "license": "ISC",
+  "files": [
+    "index.js",
+    "templates"
+  ],
   "bugs": {
     "url": "https://github.com/stevemao/conventional-changelog-atom/issues"
   },

--- a/packages/conventional-changelog-codemirror/package.json
+++ b/packages/conventional-changelog-codemirror/package.json
@@ -20,6 +20,10 @@
   ],
   "author": "Steve Mao",
   "license": "ISC",
+  "files": [
+    "index.js",
+    "templates"
+  ],
   "bugs": {
     "url": "https://github.com/stevemao/conventional-changelog-codemirror/issues"
   },

--- a/packages/conventional-changelog-core/package.json
+++ b/packages/conventional-changelog-core/package.json
@@ -13,6 +13,11 @@
     "log"
   ],
   "license": "MIT",
+  "files": [
+    "index.js",
+    "lib",
+    "hosts"
+  ],
   "dependencies": {
     "conventional-changelog-writer": "^1.1.0",
     "conventional-commits-parser": "^1.0.0",

--- a/packages/conventional-changelog-ember/package.json
+++ b/packages/conventional-changelog-ember/package.json
@@ -19,6 +19,10 @@
   ],
   "author": "Steve Mao",
   "license": "ISC",
+  "files": [
+    "index.js",
+    "templates"
+  ],
   "bugs": {
     "url": "https://github.com/stevemao/conventional-changelog-ember/issues"
   },

--- a/packages/conventional-changelog-eslint/package.json
+++ b/packages/conventional-changelog-eslint/package.json
@@ -19,6 +19,10 @@
   ],
   "author": "Steve Mao",
   "license": "ISC",
+  "files": [
+    "index.js",
+    "templates"
+  ],
   "bugs": {
     "url": "https://github.com/stevemao/conventional-changelog-eslint/issues"
   },

--- a/packages/conventional-changelog-express/package.json
+++ b/packages/conventional-changelog-express/package.json
@@ -19,6 +19,10 @@
   ],
   "author": "Steve Mao",
   "license": "ISC",
+  "files": [
+    "index.js",
+    "templates"
+  ],
   "bugs": {
     "url": "https://github.com/stevemao/conventional-changelog-express/issues"
   },

--- a/packages/conventional-changelog-jquery/package.json
+++ b/packages/conventional-changelog-jquery/package.json
@@ -19,6 +19,10 @@
   ],
   "author": "Steve Mao",
   "license": "ISC",
+  "files": [
+    "index.js",
+    "templates"
+  ],
   "bugs": {
     "url": "https://github.com/conventional-changelog/conventional-changelog-jquery/issues"
   },

--- a/packages/conventional-changelog-jshint/package.json
+++ b/packages/conventional-changelog-jshint/package.json
@@ -19,6 +19,10 @@
   ],
   "author": "Steve Mao",
   "license": "ISC",
+  "files": [
+    "index.js",
+    "templates"
+  ],
   "bugs": {
     "url": "https://github.com/stevemao/conventional-changelog-jshint/issues"
   },

--- a/packages/conventional-changelog-writer/package.json
+++ b/packages/conventional-changelog-writer/package.json
@@ -10,6 +10,12 @@
   },
   "repository": "conventional-changelog/conventional-changelog-writer",
   "license": "MIT",
+  "files": [
+    "index.js",
+    "cli.js",
+    "lib",
+    "templates"
+  ],
   "keywords": [
     "conventional-changelog-writer",
     "changelog",

--- a/packages/conventional-changelog/package.json
+++ b/packages/conventional-changelog/package.json
@@ -13,6 +13,9 @@
     "log"
   ],
   "license": "MIT",
+  "files": [
+    "index.js"
+  ],
   "contributors": [
     {
       "name": "Brian Ford"

--- a/packages/conventional-commits-parser/package.json
+++ b/packages/conventional-commits-parser/package.json
@@ -10,6 +10,11 @@
   },
   "repository": "conventional-changelog/conventional-commits-parser",
   "license": "MIT",
+  "files": [
+    "index.js",
+    "cli.js",
+    "lib"
+  ],
   "keywords": [
     "conventional-commits-parser",
     "changelog",

--- a/packages/conventional-recommended-bump/package.json
+++ b/packages/conventional-recommended-bump/package.json
@@ -10,6 +10,11 @@
   },
   "repository": "conventional-changelog/conventional-recommended-bump",
   "license": "MIT",
+  "files": [
+    "index.js",
+    "cli.js",
+    "presets"
+  ],
   "keywords": [
     "conventional-recommended-bump",
     "recommend",

--- a/packages/standard-changelog/package.json
+++ b/packages/standard-changelog/package.json
@@ -14,6 +14,10 @@
     "log"
   ],
   "license": "MIT",
+  "files": [
+    "index.js",
+    "cli.js"
+  ],
   "dependencies": {
     "add-stream": "^1.0.0",
     "chalk": "^1.1.3",


### PR DESCRIPTION
There's some malformed JSON in the changelog-core tests that is breaking some build tooling I'm working on.

Since you're already using `package.json#files` in some places, I figured you'd want to use it everywhere.

I went through each package and checked to make sure all the necessary files were included.