### PR TITLE
feat(angular): use the context for getting the package.json and the url

### DIFF
--- a/packages/conventional-changelog-angular/index.js
+++ b/packages/conventional-changelog-angular/index.js
@@ -1,7 +1,6 @@
 'use strict';
 var compareFunc = require('compare-func');
 var gufg = require('github-url-from-git');
-var readPkgUp = require('read-pkg-up');
 var Q = require('q');
 var readFile = Q.denodeify(require('fs').readFile);
 var resolve = require('path').resolve;
@@ -18,8 +17,8 @@ var parserOpts = {
   revertCorrespondence: ['header', 'hash']
 };
 
-function issueUrl() {
-  var pkg = readPkgUp.sync().pkg;
+function issueUrl(context) {
+  var pkg = context.packageData;
 
   if (pkg && pkg.repository && pkg.repository.url && ~pkg.repository.url.indexOf('github.com')) {
     var gitUrl = gufg(pkg.repository.url);
@@ -31,7 +30,7 @@ function issueUrl() {
 }
 
 var writerOpts = {
-  transform: function(commit) {
+  transform: function(commit, context) {
     var discard = true;
     var issues = [];
 
@@ -71,7 +70,7 @@ var writerOpts = {
     }
 
     if (typeof commit.subject === 'string') {
-      var url = issueUrl();
+      var url = issueUrl(context);
       if (url) {
         // GitHub issue URLs.
         commit.subject = commit.subject.replace(/#([0-9]+)/g, function(_, issue) {

--- a/packages/conventional-changelog-angular/package.json
+++ b/packages/conventional-changelog-angular/package.json
@@ -42,7 +42,6 @@
   "dependencies": {
     "compare-func": "^1.3.1",
     "github-url-from-git": "^1.4.0",
-    "q": "^1.4.1",
-    "read-pkg-up": "^2.0.0"
+    "q": "^1.4.1"
   }
 }

--- a/packages/conventional-changelog-angular/test/fixtures/_known-host.json
+++ b/packages/conventional-changelog-angular/test/fixtures/_known-host.json
@@ -1,0 +1,5 @@
+{
+  "repository": "unknown",
+  "version": "v2.0.0",
+  "repository": "https://github.com/conventional-changelog/example"
+}

--- a/packages/conventional-changelog-angular/test/test.js
+++ b/packages/conventional-changelog-angular/test/test.js
@@ -46,7 +46,7 @@ betterThanBefore.setups([
   },
   function() {
     shell.exec('git tag v1.0.0');
-    gitDummyCommit('feat: some more features');
+    gitDummyCommit('feat: some more features, implementing #3');
   }
 ]);
 
@@ -220,6 +220,60 @@ describe('angular preset', function() {
 
         expect(chunk).to.include('(http://unknown/compare');
         expect(chunk).to.include('](http://unknown/commits/');
+
+        i++;
+        cb();
+      }, function() {
+        expect(i).to.equal(1);
+        done();
+      }));
+  });
+
+  it('should work specifying where to find a package.json using conventional-changelog-core', function(done) {
+    preparing(7);
+    var i = 0;
+
+    conventionalChangelogCore({
+      config: preset,
+      pkg: {
+        path: __dirname + '/fixtures/_known-host.json'
+      }
+    })
+      .on('error', function(err) {
+        done(err);
+      })
+      .pipe(through(function(chunk, enc, cb) {
+        chunk = chunk.toString();
+
+        expect(chunk).to.include('(https://github.com/conventional-changelog/example/compare');
+        expect(chunk).to.include('](https://github.com/conventional-changelog/example/commit/');
+        expect(chunk).to.include('](https://github.com/conventional-changelog/example/issues/');
+
+        i++;
+        cb();
+      }, function() {
+        expect(i).to.equal(1);
+        done();
+      }));
+  });
+
+  it('should fallback to the closest package.json when not providing a location for a package.json', function(done) {
+    preparing(7);
+    var i = 0;
+
+    conventionalChangelogCore({
+      config: preset,
+    })
+      .on('error', function(err) {
+        done(err);
+      })
+      .pipe(through(function(chunk, enc, cb) {
+        chunk = chunk.toString();
+
+        expect(chunk).to.include('(https://github.com/conventional-changelog/conventional-changelog-angular/compare');
+        expect(chunk).to.include('](https://github.com/conventional-changelog/conventional-changelog-angular/commit/');
+        expect(chunk).to.include('](https://github.com/conventional-changelog/conventional-changelog-angular/issues/');
+
 
         i++;
         cb();


### PR DESCRIPTION
This will make result in more flexibility since we now use the logic in `conventional-changelog-core` which will fallback to use `read-pkg-up`.

https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-core#pkg

Related PR #206 