### PR TITLE
feat(angular): use the context for getting the repository and host urls

### DIFF
--- a/packages/conventional-changelog-angular/package.json
+++ b/packages/conventional-changelog-angular/package.json
@@ -41,8 +41,6 @@
   },
   "dependencies": {
     "compare-func": "^1.3.1",
-    "github-url-from-git": "^1.4.0",
-    "q": "^1.4.1",
-    "read-pkg-up": "^2.0.0"
+    "q": "^1.4.1"
   }
 }

--- a/packages/conventional-changelog-angular/test/fixtures/_ghe-host.json
+++ b/packages/conventional-changelog-angular/test/fixtures/_ghe-host.json
@@ -1,0 +1,5 @@
+{
+  "repository": "ghe",
+  "version": "v3.0.0",
+  "repository": "https://github.internal.example.com/conventional-changelog/internal"
+}

--- a/packages/conventional-changelog-angular/test/fixtures/_known-host.json
+++ b/packages/conventional-changelog-angular/test/fixtures/_known-host.json
@@ -1,0 +1,5 @@
+{
+  "repository": "known",
+  "version": "v2.0.0",
+  "repository": "https://github.com/conventional-changelog/example"
+}


### PR DESCRIPTION
This will result in more flexibility since we now use the logic already existing in `conventional-changelog-core` and at the same time make the code simpler. The logic now matches the one already present in [the templates for inserting a link to the commit](https://github.com/conventional-changelog/conventional-changelog/blob/master/packages/conventional-changelog-angular/templates/commit.hbs#L9-L21).

This PR supersedes and replaces #216
