### PR TITLE
fix(angular): smarter username detection

### DIFF
--- a/packages/conventional-changelog-angular/index.js
+++ b/packages/conventional-changelog-angular/index.js
@@ -70,7 +70,7 @@ var writerOpts = {
       }
       if (context.host) {
         // User URLs.
-        commit.subject = commit.subject.replace(/@([a-zA-Z0-9_]+)/g, '[@$1](' + context.host + '/$1)');
+        commit.subject = commit.subject.replace(/\B@([a-z0-9](?:-?[a-z0-9]){0,38})/g, '[@$1](' + context.host + '/$1)');
       }
     }
 

--- a/packages/conventional-changelog-angular/test/test.js
+++ b/packages/conventional-changelog-angular/test/test.js
@@ -50,6 +50,9 @@ betterThanBefore.setups([
   },
   function() {
     gitDummyCommit(['feat(*): implementing #5 by @dlmr', ' closes #10']);
+  },
+  function() {
+    gitDummyCommit(['fix: use npm@5 (@username)']);
   }
 ]);
 
@@ -305,6 +308,25 @@ describe('angular preset', function() {
         expect(chunk).to.include('](https://github.internal.example.com/conventional-changelog/internal/commit/');
         expect(chunk).to.include('5](https://github.internal.example.com/conventional-changelog/internal/issues/5');
         expect(chunk).to.include(' closes [#10](https://github.internal.example.com/conventional-changelog/internal/issues/10)')
+
+        done();
+      }));
+  });
+
+  it('should only replace with link to user if it is an username', function (done) {
+    preparing(9);
+
+    conventionalChangelogCore({
+      config: preset
+    })
+      .on('error', function(err) {
+        done(err);
+      })
+      .pipe(through(function(chunk) {
+        chunk = chunk.toString();
+
+        expect(chunk).to.not.include('(https://github.com/5');
+        expect(chunk).to.include('(https://github.com/username');
 
         done();
       }));


### PR DESCRIPTION
Solves issues where incorrect links would be inserted when describing the version of something, like `npm@5`. Now a space is required before a username to be replaced with a link to the profile. 

Closes #218 

---

_This PR has been based on the changes done in #217 and will be rebased on master after it has been merged._