### PR TITLE
fix(lerna tags): Support multi-digit version tags

### DIFF
--- a/packages/git-semver-tags/index.js
+++ b/packages/git-semver-tags/index.js
@@ -8,7 +8,7 @@ function lernaTag(tag, pkg) {
   if (pkg && !(new RegExp('^' + pkg + '@')).test(tag)) {
     return false;
   } else {
-    return /^.+@[0-9]+\.[0-9]\.[0-9](-.+)?$/.test(tag);
+    return /^.+@[0-9]+\.[0-9]+\.[0-9]+(-.+)?$/.test(tag);
   }
 }
 

--- a/packages/git-semver-tags/test.js
+++ b/packages/git-semver-tags/test.js
@@ -128,6 +128,21 @@ it('should work with lerna style tags', function(done) {
   }, {lernaTags: true});
 });
 
+it('should work with lerna style tags with multiple digits', function(done) {
+  writeFileSync('test5', '');
+  shell.exec('git add --all && git commit -m"fifth commit"');
+  shell.exec('git tag foobar-project@0.0.10');
+  shell.exec('git add --all && git commit -m"sixth commit"');
+  shell.exec('git tag foobar-project@0.10.0');
+  shell.exec('git add --all && git commit -m"seventh commit"');
+  shell.exec('git tag foobar-project@10.0.0');
+
+  gitSemverTags(function(err, tags) {
+    equal(tags, ['foobar-project@10.0.0', 'foobar-project@0.10.0', 'foobar-project@0.0.10', 'foo-project@5.0.0', 'foo-project@4.0.0', 'blarg-project@1.0.0']);
+    done();
+  }, {lernaTags: true});
+});
+
 it('should allow lerna style tags to be filtered by package', function(done) {
   writeFileSync('test5', '');
   shell.exec('git add --all && git commit -m"seventh commit"');


### PR DESCRIPTION
We recently released `stryker@0.10.0` using Lerna. Ever since this module thinks that `stryker@0.9.3` is the last tag we have. This is because the minor and patch version are only allowed to be one digit. This PR fixes this issue by allowing multiple digits.