### PR TITLE
Update npm home link

### DIFF
--- a/packages/conventional-recommended-bump/package.json
+++ b/packages/conventional-recommended-bump/package.json
@@ -2,7 +2,7 @@
   "name": "conventional-recommended-bump",
   "version": "1.0.1",
   "description": "Get a recommended version bump based on conventional commits",
-  "homepage": "https://github.com/conventional-changelog/conventional-recommended-bump",
+  "homepage": "https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-recommended-bump",
   "author": {
     "name": "Steve Mao",
     "email": "maochenyan@gmail.com",


### PR DESCRIPTION
When using `npm home conventional-recommended-bump` the old repository was opened. Now changed to point to the new location.