### PR TITLE
fix(filter): only remove commits that reverted commits in the scope

### DIFF
--- a/packages/conventional-commits-filter/index.js
+++ b/packages/conventional-commits-filter/index.js
@@ -17,27 +17,39 @@ function conventionalCommitsFilter (commits) {
 
   var ret = [];
   var ignores = [];
+  var remove = [];
   commits.forEach(function (commit) {
     if (commit.revert) {
-      ignores.push(commit.revert);
-    } else {
-      ret.push(commit);
+      ignores.push(commit);
     }
+
+    ret.push(commit);
   });
 
+  // Filter out reverted commits
   ret = ret.filter(function (commit) {
     var ignoreThis = false;
 
     commit = commit.raw ? modifyValues(commit.raw, modifyValue) : modifyValues(commit, modifyValue);
 
-    ignores.some(function (ignore) {
-      ignore = modifyValues(ignore, modifyValue);
+    ignores.some(function (ignoreCommit) {
+      var ignore = modifyValues(ignoreCommit.revert, modifyValue);
 
       ignoreThis = isSubset(commit, ignore);
+
+      if (ignoreThis) {
+        remove.push(ignoreCommit.hash);
+      }
+
       return ignoreThis;
     });
 
     return !ignoreThis;
+  });
+
+  // Filter out the commits that reverted something otherwise keep the revert commits
+  ret = ret.filter(function (commit) {
+    return remove.indexOf(commit.hash) !== 0;
   });
 
   return ret;

--- a/packages/conventional-commits-filter/test.js
+++ b/packages/conventional-commits-filter/test.js
@@ -8,8 +8,39 @@ it('should error if `commits` is not `array`', function () {
   });
 });
 
-it('should filter reverted commits', function () {
+it('should filter reverted commits that exist in the commits array', function () {
   var commits = [{
+    type: 'revert',
+    scope: null,
+    subject: 'feat(): a very important feature',
+    header: 'revert: feat(): a very important feature\n',
+    body: 'This reverts commit 048fe156c9eddbe566f040f64ca6be1f55b16a23.\n',
+    footer: null,
+    notes: [],
+    references: [],
+    revert: {
+      header: 'feat(): amazing new module',
+      hash: '048fe156c9eddbe566f040f64ca6be1f55b16a23',
+      body: null
+    },
+    hash: '207abfa16885ef5ff88dfc6cdde694bb3fd03104\n',
+    raw: {
+      type: 'revert',
+      scope: null,
+      subject: 'feat(): a very important feature',
+      header: 'revert: feat(): a very important feature\n',
+      body: 'This reverts commit 048fe156c9eddbe566f040f64ca6be1f55b16a23.\n',
+      footer: null,
+      notes: [],
+      references: [],
+      revert: {
+        header: 'feat(): a very important feature',
+        hash: '048fe156c9eddbe566f040f64ca6be1f55b16a23',
+        body: null
+      },
+      hash: '207abfa16885ef5ff88dfc6cdde694bb3fd03104\n'
+    }
+  }, {
     type: 'revert',
     scope: null,
     subject: 'feat(): amazing new module',
@@ -113,9 +144,40 @@ it('should filter reverted commits', function () {
 
   commits = conventionalCommitsFilter(commits);
 
-  assert.equal(commits.length, 2);
+  assert.equal(commits.length, 3);
 
   assert.deepEqual(commits, [{
+    type: 'revert',
+    scope: null,
+    subject: 'feat(): a very important feature',
+    header: 'revert: feat(): a very important feature\n',
+    body: 'This reverts commit 048fe156c9eddbe566f040f64ca6be1f55b16a23.\n',
+    footer: null,
+    notes: [],
+    references: [],
+    revert: {
+      header: 'feat(): amazing new module',
+      hash: '048fe156c9eddbe566f040f64ca6be1f55b16a23',
+      body: null
+    },
+    hash: '207abfa16885ef5ff88dfc6cdde694bb3fd03104\n',
+    raw: {
+      type: 'revert',
+      scope: null,
+      subject: 'feat(): a very important feature',
+      header: 'revert: feat(): a very important feature\n',
+      body: 'This reverts commit 048fe156c9eddbe566f040f64ca6be1f55b16a23.\n',
+      footer: null,
+      notes: [],
+      references: [],
+      revert: {
+        header: 'feat(): a very important feature',
+        hash: '048fe156c9eddbe566f040f64ca6be1f55b16a23',
+        body: null
+      },
+      hash: '207abfa16885ef5ff88dfc6cdde694bb3fd03104\n'
+    }
+  }, {
     type: 'What',
     scope: null,
     subject: 'new feature',


### PR DESCRIPTION
The change makes sure we only remove reverted commits if they reverted something in the current scope. 

This is useful when we are working with a subset of all commits and want to know if the commits makes sense to list in our changelog. Without this change we would always remove commits that made a revert from the changelog, even if the commit in question was done in a previous release. Now we will only remove the revert commit from the changelog if it reverted something in the current release.

Example using the Angular convention.

```
HASH-3 revert: fix: added something
                 This reverts commit HASH-1.
HASH-2 chore: release 1.0.1
HASH-1 fix: added something
```

This would make our changelog empty, since the filter with the default configuration would remove it. We would like it to list `revert: fix: added something`.

We would like it to remove our `revert:` commit however if the revert was done in the same "scope".

```
HASH-5: fix: solved that problem
HASH-4 revert: fix: added something else
                 This reverts commit HASH-3.
HASH-3 fix: added something else
HASH-2 chore: release 1.0.1
HASH-1 fix: added something
```

Here we expect that our changelog only have `fix: solved that problem` which this change still upholds.