### PR TITLE
feat: allow forced cwd

### DIFF
--- a/packages/git-raw-commits/README.md
+++ b/packages/git-raw-commits/README.md
@@ -22,46 +22,58 @@ gitRawCommits(options)
 
 ## API
 
-### gitRawCommits([options])
+### gitRawCommits(gitOpts, [execOpts])
 
 Returns a readable stream. Stream is split to break on each commit.
 
-#### options
+#### gitOpts
 
 Type: `object`
 
 Please check the available options at http://git-scm.com/docs/git-log.
 **NOTE:** Single dash arguments are not supported because of https://github.com/sindresorhus/dargs/blob/master/index.js#L5.
 
-*NOTE*: for `<revision range>` we can also use `<from>..<to>` pattern, and this module has the following extra options for shortcut of this patter:
+*NOTE*: for `<revision range>` we can also use `<from>..<to>` pattern, and this module has the following extra options for shortcut of this pattern:
 
-##### from
+##### gitOpts.from
 
 Type: `string` Default: `''`
 
-##### to
+##### gitOpts.to
 
 Type: `string` Default: `'HEAD'`
 
 This module also have the following additions:
 
-##### format
+##### gitOpts.format
 
 Type: `string` Default: `'%B'`
 
 Please check http://git-scm.com/docs/git-log for format options.
 
-##### debug
+##### gitOpts.debug
 
 Type: `function`
 
 A function to get debug information.
 
-##### path
+##### gitOpts.path
 
 Type: `string`
 
-Filter commits to the path provided. 
+Filter commits to the path provided.
+
+##### execOpts
+
+Options to pass to `git` `childProcess`
+
+Type: `object`
+
+##### execOpts.cwd
+
+Type: `string`
+
+Current working directory to execute git in
 
 
 ## CLI

--- a/packages/git-raw-commits/index.js
+++ b/packages/git-raw-commits/index.js
@@ -6,47 +6,60 @@ var stream = require('stream');
 var template = require('lodash.template');
 var through = require('through2');
 
-function gitRawCommits(options, opts) {
+var DELIMITER = '------------------------ >8 ------------------------';
+
+function normalizeExecOpts(execOpts) {
+  execOpts = execOpts || {};
+  execOpts.cwd = execOpts.cwd || process.cwd();
+  return execOpts;
+}
+
+function normalizeGitOpts(gitOpts) {
+  gitOpts = gitOpts || {};
+  gitOpts.format = gitOpts.format || '%B';
+  gitOpts.from = gitOpts.from || '';
+  gitOpts.to = gitOpts.to || 'HEAD';
+  return gitOpts;
+}
+
+function getGitArgs(gitOpts) {
+  var gitFormat = template('--format=<%= format %>%n' + DELIMITER)(gitOpts);
+  var gitFromTo = [gitOpts.from, gitOpts.to].filter(Boolean).join('..');
+
+  var gitArgs = ['log', gitFormat, gitFromTo];
+
+  // allow commits to focus on a single directory
+  // this is useful for monorepos.
+  if (gitOpts.path) {
+    gitArgs.push('--', gitOpts.path);
+  }
+
+  return gitArgs.concat(dargs(gitOpts, {
+    excludes: ['debug', 'from', 'to', 'format', 'path']
+  }));
+}
+
+function gitRawCommits(rawGitOpts, rawExecOpts) {
   var readable = new stream.Readable();
   readable._read = function() {};
 
-  options = options || {};
-  opts = opts || {};
-  options.format = options.format || '%B';
-  options.from = options.from || '';
-  options.to = options.to || 'HEAD';
+  var gitOpts = normalizeGitOpts(rawGitOpts);
+  var execOpts = normalizeExecOpts(rawExecOpts);
+  var args = getGitArgs(gitOpts);
 
-  var gitFormat = template('--format=<%= format %>%n' +
-    '------------------------ >8 ------------------------'
-  )(options);
-  var gitFromTo = template('<%- from ? [from, to].join("..") : to %>')(options);
-
-  var args = dargs(options, {
-    excludes: ['from', 'to', 'format', 'path']
-  });
-
-  var argsPrefix = [gitFormat, gitFromTo];
-  // allow commits to focus on a single directory
-  // this is useful for monorepos.
-  if (options.path) {
-    argsPrefix.push('--', options.path);
-  }
-
-  args = ['log'].concat(argsPrefix, args);
-
-  if (options.debug) {
-    options.debug('Your git-log command is:\ngit ' + args.join(' '));
+  if (gitOpts.debug) {
+    gitOpts.debug('Your git-log command is:\ngit ' + args.join(' '));
   }
 
   var isError = false;
 
   var child = execFile('git', args, {
-    cwd: opts.cwd || process.cwd(),
+    cwd: execOpts.cwd,
     maxBuffer: Infinity
   });
 
   child.stdout
-    .pipe(split('------------------------ >8 ------------------------\n'))
+    .pipe(split(DELIMITER + '\n'))
     .pipe(through(function(chunk, enc, cb) {
       readable.push(chunk);
       isError = false;

--- a/packages/git-raw-commits/index.js
+++ b/packages/git-raw-commits/index.js
@@ -6,11 +6,12 @@ var stream = require('stream');
 var template = require('lodash.template');
 var through = require('through2');
 
-function gitRawCommits(options) {
+function gitRawCommits(options, opts) {
   var readable = new stream.Readable();
   readable._read = function() {};
 
   options = options || {};
+  opts = opts || {};
   options.format = options.format || '%B';
   options.from = options.from || '';
   options.to = options.to || 'HEAD';
@@ -40,6 +41,7 @@ function gitRawCommits(options) {
   var isError = false;
 
   var child = execFile('git', args, {
+    cwd: opts.cwd || process.cwd(),
     maxBuffer: Infinity
   });
 


### PR DESCRIPTION
This adds an optional second `opts` argument to `git-raw-commits` intended for options-passing to `child_process.execFile` - specifically this allows to force a cwd for the `git log` process.

**Edit**:
This allows consumers like [commitlint](https://github.com/marionebl/commitlint/blob/master/%40commitlint/core/src/read.js#L37) to decouple command from execution cwd. 

In the first step this makes testing considerably easier. Before I had to change the `cwd` via `process.chdir()` to pick up commit messages from prepared fixture repositories (which forced serial, slow execution) in my tests, now I can specify it via the new option.

For users, this is exposed up to the command line interface to allow for easier scripting, e.g.:

Before
```
cd git-repository
commitlint --from=HEAD^1
cd ..
``` 

After
```
commitlint --from=HEAD^1 --cwd=git-repository
``` 