### PR TITLE
fix(writer): normalize release headings (#214)

### DIFF
--- a/packages/conventional-changelog-core/test/test.js
+++ b/packages/conventional-changelog-core/test/test.js
@@ -250,7 +250,7 @@ describe('conventionalChangelogCore', function() {
       .pipe(through(function(chunk) {
         chunk = chunk.toString();
 
-        expect(chunk).to.include('## 0.0.17');
+        expect(chunk).to.include('## <small>0.0.17');
         expect(chunk).to.include('Second commit');
         expect(chunk).to.include('closes [#1](https://github.com/ajoslin/conventional-changelog/issues/1)');
 
@@ -269,7 +269,7 @@ describe('conventionalChangelogCore', function() {
       .pipe(through(function(chunk) {
         chunk = chunk.toString();
 
-        expect(chunk).to.include('## 0.0.17');
+        expect(chunk).to.include('## <small>0.0.17');
         expect(chunk).to.include('Second commit');
 
         done();
@@ -330,7 +330,7 @@ describe('conventionalChangelogCore', function() {
       .pipe(through(function(chunk) {
         chunk = chunk.toString();
 
-        expect(chunk).to.include('## v0.0.17');
+        expect(chunk).to.include('## <small>v0.0.17');
         expect(chunk).to.include('Second commit');
         expect(chunk).to.include('closes [#1](https://github.com/a/b/issues/1)');
 
@@ -367,7 +367,7 @@ describe('conventionalChangelogCore', function() {
     }).pipe(through(function(chunk) {
       chunk = chunk.toString();
 
-      expect(chunk).to.include('## 0.0.17');
+      expect(chunk).to.include('## <small>0.0.17');
       expect(chunk).to.include('closes [#1](github/a/b/issues/1)');
 
       done();

--- a/packages/conventional-changelog-writer/templates/header.hbs
+++ b/packages/conventional-changelog-writer/templates/header.hbs
@@ -1,11 +1,10 @@
 <a name="{{version}}"></a>
-{{#if isPatch~}}
-  ##
-{{~else~}}
-  #
-{{~/if}} {{version}}
+## {{#if isPatch~}} <small>
+  {{~/if~}} {{version}}
   {{~#if title}} "{{title}}"
-  {{~/if}}
+  {{~/if~}}
   {{~#if date}} ({{date}})
+  {{~/if~}}
+  {{~#if isPatch~}} </small>
   {{~/if}}
 

--- a/packages/conventional-changelog-writer/test/index.spec.js
+++ b/packages/conventional-changelog-writer/test/index.spec.js
@@ -75,7 +75,7 @@ describe('conventionalChangelogWriter', function() {
       upstream
         .pipe(conventionalChangelogWriter())
         .pipe(through(function(chunk, enc, cb) {
-          expect(chunk.toString()).to.equal('<a name=""></a>\n#  (' + today + ')\n\n\n\n\n');
+          expect(chunk.toString()).to.equal('<a name=""></a>\n##  (' + today + ')\n\n\n\n\n');
 
           i++;
           cb(null);
@@ -236,7 +236,7 @@ describe('conventionalChangelogWriter', function() {
           }
         }))
         .pipe(through(function(chunk, enc, cb) {
-          expect(chunk.toString()).to.equal('<a name=\"\"></a>\n#  (' + today + ')\n\n\n\n\n');
+          expect(chunk.toString()).to.equal('<a name=\"\"></a>\n##  (' + today + ')\n\n\n\n\n');
 
           i++;
           cb(null);
@@ -321,7 +321,7 @@ describe('conventionalChangelogWriter', function() {
             chunk = chunk.toString();
 
             if (i === 0) {
-              expect(chunk).to.include('<a name=""></a>\n#  (' + today);
+              expect(chunk).to.include('<a name=""></a>\n##  (' + today);
               expect(chunk).to.include('feat(scope): ');
 
               expect(chunk).to.not.include('<a name="1.0.1"></a>');
@@ -329,7 +329,7 @@ describe('conventionalChangelogWriter', function() {
               expect(chunk).to.not.include('perf(template): ');
               expect(chunk).to.not.include('refactor(name): ');
             } else {
-              expect(chunk).to.include('<a name="1.0.1"></a>\n## 1.0.1 (2015-04-07)');
+              expect(chunk).to.include('<a name="1.0.1"></a>\n## <small>1.0.1 (2015-04-07)</small>');
               expect(chunk).to.include('fix(ng-list): ');
               expect(chunk).to.include('perf(template): ');
               expect(chunk).to.include('refactor(name): ');
@@ -395,7 +395,7 @@ describe('conventionalChangelogWriter', function() {
             chunk = chunk.toString();
 
             if (i === 0) {
-              expect(chunk).to.include('<a name=""></a>\n#  (' + today);
+              expect(chunk).to.include('<a name=""></a>\n##  (' + today);
 
               expect(chunk).to.not.include('<a name="1.0.1"></a>\n## 1.0.1 (2015-04-07)');
             } else if (i === 1) {
@@ -439,7 +439,7 @@ describe('conventionalChangelogWriter', function() {
             chunk = chunk.toString();
 
             if (i === 0) {
-              expect(chunk).to.include('<a name=""></a>\n#  (' + today);
+              expect(chunk).to.include('<a name=""></a>\n##  (' + today);
               expect(chunk).to.not.include('<a name="1.0.1"></a>\n## 1.0.1 (2015-04-07)');
             } else {
               expect(chunk).to.include('<a name="1.0.1"></a>');
@@ -464,7 +464,7 @@ describe('conventionalChangelogWriter', function() {
           .pipe(through(function(chunk, enc, cb) {
             chunk = chunk.toString();
 
-            expect(chunk).to.include('<a name=""></a>\n#  (' + today);
+            expect(chunk).to.include('<a name=""></a>\n##  (' + today);
 
             i++;
             cb(null);
@@ -486,10 +486,10 @@ describe('conventionalChangelogWriter', function() {
             chunk = chunk.toString();
 
             if (i === 0) {
-              expect(chunk).to.include('<a name="0.0.1"></a>\n## 0.0.1 (2015-01-01)');
+              expect(chunk).to.include('<a name="0.0.1"></a>\n## <small>0.0.1 (2015-01-01)</small>');
               expect(chunk).to.not.include('<a name="1.0.1"></a>');
             } else {
-              expect(chunk).to.include('<a name="1.0.1"></a>\n## 1.0.1 (2015-04-07)');
+              expect(chunk).to.include('<a name="1.0.1"></a>\n## <small>1.0.1 (2015-04-07)</small>');
               expect(chunk).to.not.include('<a name="0.0.1"></a>');
             }
 
@@ -514,9 +514,9 @@ describe('conventionalChangelogWriter', function() {
             chunk = chunk.toString();
 
             if (i === 0) {
-              expect(chunk).to.equal('<a name=""></a>\n#  (' + today + ')\n\n\n\n\n');
+              expect(chunk).to.equal('<a name=""></a>\n##  (' + today + ')\n\n\n\n\n');
             } else {
-              expect(chunk).to.equal('<a name="1.0.1"></a>\n## 1.0.1 (2015-04-07 15:00:44 +1000)\n\n\n\n\n');
+              expect(chunk).to.equal('<a name="1.0.1"></a>\n## <small>1.0.1 (2015-04-07 15:00:44 +1000)</small>\n\n\n\n\n');
             }
 
             i++;
@@ -536,11 +536,11 @@ describe('conventionalChangelogWriter', function() {
           }))
           .pipe(through.obj(function(chunk, enc, cb) {
             if (i === 0) {
-              expect(chunk.log).to.include('<a name=""></a>\n#  (' + today + ')\n\n');
+              expect(chunk.log).to.include('<a name=""></a>\n##  (' + today + ')\n\n');
               expect(chunk.log).to.include('feat(scope): broadcast $destroy event on scope destruction');
               expect(chunk.keyCommit).to.eql();
             } else {
-              expect(chunk.log).to.include('<a name="1.0.1"></a>\n## 1.0.1 (2015-04-07)\n\n');
+              expect(chunk.log).to.include('<a name="1.0.1"></a>\n## <small>1.0.1 (2015-04-07)</small>\n\n');
               expect(chunk.log).to.include('fix(ng-list): Allow custom separator');
               expect(chunk.log).to.include('perf(template): tweak');
               expect(chunk.log).to.include('refactor(name): rename this module to conventional-changelog-writer');
@@ -690,14 +690,14 @@ describe('conventionalChangelogWriter', function() {
             chunk = chunk.toString();
 
             if (i === 0) {
-              expect(chunk).to.include('<a name="1.0.1"></a>\n## 1.0.1 (2015-04-07');
+              expect(chunk).to.include('<a name="1.0.1"></a>\n## <small>1.0.1 (2015-04-07)</small>');
               expect(chunk).to.include('feat(scope): ');
 
               expect(chunk).to.not.include('<a name=""></a>');
               expect(chunk).to.not.include('perf(template): ');
               expect(chunk).to.not.include('refactor(name): ');
             } else if (i === 1) {
-              expect(chunk).to.include('<a name="2.0.1"></a>\n## 2.0.1 (2015-04-07');
+              expect(chunk).to.include('<a name="2.0.1"></a>\n## <small>2.0.1 (2015-04-07)</small>');
               expect(chunk).to.include('fix(ng-list): ');
 
               expect(chunk).to.not.include('<a name="1.0.1"></a>');
@@ -707,7 +707,7 @@ describe('conventionalChangelogWriter', function() {
               expect(chunk).to.include('perf(template): ');
               expect(chunk).to.include('refactor(name): ');
             } else if (i === 3) {
-              expect(chunk).to.include('<a name=""></a>\n#  (' + today);
+              expect(chunk).to.include('<a name=""></a>\n##  (' + today);
             }
 
             i++;
@@ -732,9 +732,9 @@ describe('conventionalChangelogWriter', function() {
             chunk = chunk.toString();
 
             if (i === 0) {
-              expect(chunk).to.equal('<a name="1.0.1"></a>\n## 1.0.1 (2015-04-07 15:00:44 +1000)\n\n\n\n\n');
+              expect(chunk).to.equal('<a name="1.0.1"></a>\n## <small>1.0.1 (2015-04-07 15:00:44 +1000)</small>\n\n\n\n\n');
             } else {
-              expect(chunk).to.equal('<a name=""></a>\n#  (' + today + ')\n\n\n\n\n');
+              expect(chunk).to.equal('<a name=""></a>\n##  (' + today + ')\n\n\n\n\n');
             }
 
             i++;
@@ -755,13 +755,13 @@ describe('conventionalChangelogWriter', function() {
           }))
           .pipe(through.obj(function(chunk, enc, cb) {
             if (i === 0) {
-              expect(chunk.log).to.include('<a name="1.0.1"></a>\n## 1.0.1 (2015-04-07)\n\n');
+              expect(chunk.log).to.include('<a name="1.0.1"></a>\n## <small>1.0.1 (2015-04-07)</small>\n\n');
               expect(chunk.log).to.include('broadcast $destroy event on scope destruction');
               expect(chunk.log).to.include('fix(ng-list):');
               expect(chunk.keyCommit.version).to.equal('1.0.1');
               expect(chunk.keyCommit.committerDate).to.equal('2015-04-07');
             } else {
-              expect(chunk.log).to.include('<a name=""></a>\n#  (' + today + ')\n\n');
+              expect(chunk.log).to.include('<a name=""></a>\n##  (' + today + ')\n\n');
               expect(chunk.log).to.include('perf(template): tweak');
               expect(chunk.log).to.include('refactor(name): rename this module to conventional-changelog-writer');
               expect(chunk.keyCommit).to.eql();
@@ -875,7 +875,7 @@ describe('conventionalChangelogWriter', function() {
     upstream
       .pipe(conventionalChangelogWriter())
       .pipe(through(function(chunk, enc, cb) {
-        expect(chunk.toString()).to.equal('<a name=""></a>\n#  (' + today + ')\n\n* bla \n\n\n\n');
+        expect(chunk.toString()).to.equal('<a name=""></a>\n##  (' + today + ')\n\n* bla \n\n\n\n');
 
         i++;
         cb(null);

--- a/packages/conventional-changelog-writer/test/partial.header.spec.js
+++ b/packages/conventional-changelog-writer/test/partial.header.spec.js
@@ -24,27 +24,27 @@ describe('partial.header', function() {
     templateContext.isPatch = true;
     var log = Handlebars.compile(template)(templateContext);
 
-    expect(log).to.equal('<a name="my version"></a>\n## my version\n');
+    expect(log).to.equal('<a name="my version"></a>\n## <small>my version</small>\n');
   });
 
   it('should generate header if `isPatch` is falsy', function() {
     templateContext.isPatch = false;
     var log = Handlebars.compile(template)(templateContext);
 
-    expect(log).to.equal('<a name="my version"></a>\n# my version\n');
+    expect(log).to.equal('<a name="my version"></a>\n## my version\n');
   });
 
   it('should generate header if `title` is truthy', function() {
     templateContext.title = 'my title';
     var log = Handlebars.compile(template)(templateContext);
 
-    expect(log).to.equal('<a name="my version"></a>\n# my version "my title"\n');
+    expect(log).to.equal('<a name="my version"></a>\n## my version "my title"\n');
   });
 
   it('should generate header if `date` is truthy', function() {
     templateContext.date = 'my date';
     var log = Handlebars.compile(template)(templateContext);
 
-    expect(log).to.equal('<a name="my version"></a>\n# my version (my date)\n');
+    expect(log).to.equal('<a name="my version"></a>\n## my version (my date)\n');
   });
 });


### PR DESCRIPTION
Updated the default header template to generate semantic HTML headings using the method suggested by @marcysutton in #214 ✨ 

**Edit:** updated commit message with the following for context:

> Logic for generating release headings has been changed to make all
> heading levels the same (`##`/`h2`) for better compatibility with
> screen readers and parsers, and to conform to HTML semantics. Patch
> release titles are now wrapped in a `<small>` tag to maintain the
> visual hierarchy of the previous style.
> 
> Resolves #214.
> 
> Related issues:
> - #214 (comment)
> - conventional-changelog/standard-version#208