### PR TITLE
fix: always parse references

### DIFF
--- a/packages/conventional-commits-parser/test/cli.spec.js
+++ b/packages/conventional-commits-parser/test/cli.spec.js
@@ -79,9 +79,44 @@ describe('cli', function() {
     });
     cp.stdout
       .pipe(concat(function(chunk) {
-        expect(chunk.toString()).to.include('"scope":"category","type":"fix:subcategory","subject":"My subject"');
-        expect(chunk.toString()).to.include('"references":[{"action":"Close","owner":null,"repository":null,"issue":"10036","raw":"#10036","prefix":"#"},{"action":"fix","owner":null,"repository":null,"issue":"9338","raw":"#9338","prefix":"#"}]');
-        expect(chunk.toString()).to.include('"notes":[{"title":"BREAKING NEWS","text":"A lot of changes!"}]');
+        var data = JSON.parse(chunk.toString())[0];
+        expect(data.scope).to.equal('category');
+        expect(data.type).to.equal('fix:subcategory');
+        expect(data.subject).to.equal('My subject');
+
+        expect(data.references).to.eql([
+          {
+            action: 'Close',
+            owner: null,
+            repository: null,
+            issue: '10036',
+            raw: '#10036',
+            prefix: '#'
+          },
+          {
+            action: null,
+            issue: '13233',
+            owner: null,
+            prefix: '#',
+            raw: 'Fixed #13233',
+            repository: null
+          },
+          {
+            action: 'fix',
+            owner: null,
+            repository: null,
+            issue: '9338',
+            raw: '#9338',
+            prefix: '#'
+          }
+        ]);
+
+        expect(data.notes).to.eql([
+          {
+            title: 'BREAKING NEWS',
+            text: 'A lot of changes!'
+          }
+        ]);
 
         done();
       }));

--- a/packages/conventional-commits-parser/test/index.spec.js
+++ b/packages/conventional-commits-parser/test/index.spec.js
@@ -171,6 +171,13 @@ describe('conventionalCommitsParser', function() {
             raw: '#123',
             prefix: '#'
           }, {
+            action: null,
+            owner: null,
+            repository: null,
+            issue: '25',
+            raw: 'Closes #25',
+            prefix: '#'
+          }, {
             action: 'fix',
             owner: null,
             repository: null,
@@ -178,7 +185,8 @@ describe('conventionalCommitsParser', function() {
             raw: '#33',
             prefix: '#'
           }]);
-        } else if (i === 1) {
+        }
+        if (i === 1) {
           expect(chunk.type).to.equal('fix');
           expect(chunk.scope).to.equal('ng-list');
           expect(chunk.subject).to.equal('Another custom separator');
@@ -232,6 +240,13 @@ describe('conventionalCommitsParser', function() {
             raw: '#123',
             prefix: '#'
           }, {
+            action: null,
+            owner: null,
+            repository: null,
+            issue: '25',
+            raw: 'Closes #25',
+            prefix: '#'
+          }, {
             action: 'fix',
             owner: null,
             repository: null,
@@ -272,5 +287,45 @@ describe('sync', function() {
 
     expect(result.header).to.equal('feat(ng-list): Allow custom separator');
     expect(result.footer).to.equal('Closes #123\nCloses #25\nFixes #33');
+    expect(result.references).to.eql([
+      {
+        action: 'Closes',
+        issue: '123',
+        owner: null,
+        prefix: '#',
+        raw: '#123',
+        repository: null
+      },
+      {
+        action: 'Closes',
+        issue: '25',
+        owner: null,
+        prefix: '#',
+        raw: '#25',
+        repository: null
+      },
+      {
+        action: 'Fixes',
+        issue: '33',
+        owner: null,
+        prefix: '#',
+        raw: '#33',
+        repository: null
+      }
+    ]);
+  });
+
+  it('should parse references from header', function() {
+    var commit = 'Subject #1';
+    var result = conventionalCommitsParser.sync(commit);
+
+    expect(result.references).to.eql([{
+      action: null,
+      issue: '1',
+      owner: null,
+      prefix: '#',
+      raw: 'Subject #1',
+      repository: null
+    }]);
   });
 });

--- a/packages/conventional-commits-parser/test/parser.spec.js
+++ b/packages/conventional-commits-parser/test/parser.spec.js
@@ -588,11 +588,12 @@ describe('parser', function() {
     });
 
     it('should parse important notes that start with asterisks (for squash commits)', function() {
-      var text = 'Previously multiple template bindings on one element\n' +
-          '(ex. `<div *ngIf=\'..\' *ngFor=\'...\'>`) were allowed but most of the time\n' +
-          'were leading to undesired result. It is possible that a small number\n' +
-          'of applications will see template parse errors that shuld be fixed by\n' +
-          'nesting elements or using `<template>` tags explicitly.\n' +
+      var expectedText = 'Previously multiple template bindings on one element\n' +
+        '(ex. `<div *ngIf=\'..\' *ngFor=\'...\'>`) were allowed but most of the time\n' +
+        'were leading to undesired result. It is possible that a small number\n' +
+        'of applications will see template parse errors that shuld be fixed by\n' +
+        'nesting elements or using `<template>` tags explicitly.';
+      var text = expectedText +
           '\n' +
           'Closes #9462';
       options.noteKeywords = ['BREAKING CHANGE'];
@@ -610,9 +611,9 @@ describe('parser', function() {
       );
       var expected = {
         title: 'BREAKING CHANGE',
-        text: text
+        text: expectedText
       };
-
+      expect(msg.references.map(function(ref) {return ref.issue;})).to.include('9462');
       expect(msg.notes[0]).to.eql(expected);
     });
 


### PR DESCRIPTION
* always parse references, regardless of presence of an action
* move reference parsing to reusable function
* adapt test cases to changed behaviour
* fixes #248

## Before

* references were dropped from header, body and footer by `parser.sync`
* this happened for references that had no `action` included in `options.referenceActions`
* due to `parser.sync` defaulting to an hardcoded set of `options.referenceActions`, references without (matching) action were never parsed

```js
 const parser = require('conventional-commits-parser').sync;

parse('type: subject #1').references;
/* [ ] */
```

## After
* fall back to catch-all regex if options.referenceActions regex produces no matches
* strip reference strings from all `notes`, was inconsistent before

```js
 const parser = require('conventional-commits-parser').sync;

parse('type: subject #1').references;
/* [ { action: null,
       owner: null,
       repository: null,
       issue: '1',
       raw: 'type: subject #1',
       prefix: '#' } ] */
```