### PR TITLE
fix(cli): set options.config to loaded custom config for processing

### DIFF
--- a/packages/conventional-changelog-cli/cli.js
+++ b/packages/conventional-changelog-cli/cli.js
@@ -112,6 +112,7 @@ try {
 
   if (flags.config) {
     config = require(resolve(process.cwd(), flags.config));
+    options.config = config;
   } else {
     config = {};
   }

--- a/packages/conventional-changelog-cli/package.json
+++ b/packages/conventional-changelog-cli/package.json
@@ -29,6 +29,7 @@
     "jscs": "^2.7.0",
     "jshint": "^2.8.0",
     "mocha": "*",
+    "q": "^1.5.1",
     "shelljs": "^0.6.0"
   },
   "dependencies": {

--- a/packages/conventional-changelog-cli/test/fixtures/promise-config.js
+++ b/packages/conventional-changelog-cli/test/fixtures/promise-config.js
@@ -1,0 +1,8 @@
+'use strict';
+var Q = require('q');
+
+module.exports = Q.resolve({
+  writerOpts: {
+    mainTemplate: '{{commitGroups.[0].commits.[0].type}}{{testContext}}template'
+  }
+});

--- a/packages/conventional-changelog-cli/test/test.js
+++ b/packages/conventional-changelog-cli/test/test.js
@@ -312,6 +312,18 @@ describe('cli', function () {
       }));
   });
 
+  it('--config should work with a return promise', function (done) {
+    var cp = spawn(cliPath, ['--config', '../test/fixtures/promise-config.js'], {
+      stdio: [process.stdin, null, null]
+    });
+
+    cp.stdout
+      .pipe(concat(function (chunk) {
+        expect(chunk.toString()).to.equal('template');
+        done();
+      }));
+  });
+
   it('--config should work with relative path', function (done) {
     var cp = spawn(cliPath, ['--config', '../test/fixtures/config.js'], {
       stdio: [process.stdin, null, null]


### PR DESCRIPTION
Closes #227 

Setting this up allows the core to properly load the configuration (handling promises or however the config is delivered). Otherwise nothing is loaded and a default config is used instead.