### PR TITLE
WIP: Allow repository.type to override autodetect type

### DIFF
--- a/packages/conventional-changelog-core/lib/merge-config.js
+++ b/packages/conventional-changelog-core/lib/merge-config.js
@@ -198,7 +198,9 @@ function mergeConfig(options, context, gitRawCommitsOpts, parserOpts, writerOpts
       if (context.host && (!context.issue || !context.commit || !parserOpts || !parserOpts.referenceActions)) {
         var type;
 
-        if (context.host) {
+        if (context.type) {
+          type = context.type
+        } else if (context.host) {
           var match = context.host.match(rhosts);
           if (match) {
             type = match[0];

--- a/packages/conventional-changelog-core/lib/merge-config.js
+++ b/packages/conventional-changelog-core/lib/merge-config.js
@@ -199,7 +199,7 @@ function mergeConfig(options, context, gitRawCommitsOpts, parserOpts, writerOpts
         var type;
 
         if (context.type) {
-          type = context.type
+          type = context.type;
         } else if (context.host) {
           var match = context.host.match(rhosts);
           if (match) {


### PR DESCRIPTION
Related to #257, the current setup only allows the publicly hosted versions of gitlab/github/bitbucket. Unless I'm misreading the code, I think this can be fixed as follows:

I suspect this will allow you to do this syntax for privately hosted gitlab/github/bitbucket:

```
"repository": {
  "url": "https://private.gitlab",
  "type": "gitlab"
}
```

I know I need to add tests, and need to test this locally, but wanted to get confirmation first that I'm not barking up the wrong tree. I'm not a JS dev, so I'm probably making a lot of assumptions in how this works.