### PR TITLE
feat: allow to specify a tagPrefix in conventional-recommended-bump

### DIFF
--- a/packages/conventional-recommended-bump/README.md
+++ b/packages/conventional-recommended-bump/README.md
@@ -77,6 +77,15 @@ An array of parsed commits. The commits are from last semver tag to `HEAD` and i
 
 If it returns with `level` `0` it will be a `major` bump. If `1`, `minor` bump. If `2`, `patch`.
 
+##### tagPrefix
+
+Type: `string`
+
+Specify a prefix for the git tag that will be taken into account during the comparison.
+
+For instance if your version tag is prefixed by `version/` instead of `v` you would specify `--tagPrefix=version/`
+
+
 #### parserOpts
 
 See the [conventional-commits-parser](https://github.com/conventional-changelog/conventional-commits-parser) docs.
@@ -96,12 +105,6 @@ Object includes what's returned by `whatBump` and
 Type: `string` Possible values: `'major'`, `'minor'` and `'patch'`
 
 The value of what it should release as.
-
-##### tagPrefix
-
-Type: `string`
-
-Specify a prefix for the git tag that will be taken into account during the comparison.
 
 ## Related
 

--- a/packages/conventional-recommended-bump/README.md
+++ b/packages/conventional-recommended-bump/README.md
@@ -97,6 +97,11 @@ Type: `string` Possible values: `'major'`, `'minor'` and `'patch'`
 
 The value of what it should release as.
 
+##### tagPrefix
+
+Type: `string`
+
+Specify a prefix for the git tag that will be taken into account during the comparison.
 
 ## Related
 

--- a/packages/conventional-recommended-bump/cli.js
+++ b/packages/conventional-recommended-bump/cli.js
@@ -23,6 +23,7 @@ var cli = meow({
     '  -f, --field-pattern            Regex to match other fields',
     '  -v, --verbose                  Verbose output',
     '  -l, --lerna-package            Recommend a bump for a specific lerna package (:pkg-name@1.0.0)',
+    '  -t, --tag-prefix               Tag prefix to consider when reading the tags',
     '  --commit-path                  Recommend a bump scoped to a specific directory'
   ]
 }, {
@@ -36,13 +37,15 @@ var cli = meow({
     n: 'noteKeywords',
     f: 'fieldPattern',
     v: 'verbose',
-    l: 'lernaPackage'
+    l: 'lernaPackage',
+    t: 'tagPrefix'
   }
 });
 
 var options = {
   path: cli.flags.commitPath,
-  lernaPackage: cli.flags.lernaPackage
+  lernaPackage: cli.flags.lernaPackage,
+  tagPrefix: cli.flags.tagPrefix
 };
 var flags = cli.flags;
 var preset = flags.preset;

--- a/packages/conventional-recommended-bump/index.js
+++ b/packages/conventional-recommended-bump/index.js
@@ -83,7 +83,7 @@ function conventionalRecommendedBump(options, parserOpts, cb) {
 
         cb(null, result);
       }));
-  }, {lernaTags: !!options.lernaPackage, package: options.lernaPackage});
+  }, {lernaTags: !!options.lernaPackage, package: options.lernaPackage, tagPrefix: options.tagPrefix});
 }
 
 module.exports = conventionalRecommendedBump;

--- a/packages/conventional-recommended-bump/test/test.js
+++ b/packages/conventional-recommended-bump/test/test.js
@@ -47,6 +47,13 @@ betterThanBefore.setups([
     fs.writeFileSync('test/packages/foo/foo2.txt', 'change');
     shell.exec('git add --all && git commit -m"fix: I made a slight change to foo2.txt"');
   },
+  function() { // 8
+    fs.writeFileSync('test3', '');
+    shell.exec('git add --all && git commit -m"feat: should not be taken into account\nBREAKING CHANGE: I break the API"');
+    shell.exec('git tag ms/1.0.0');
+    fs.writeFileSync('test4', '');
+    shell.exec('git add --all && git commit -m"feat: this should have been working"');
+  },
 ]);
 
 betterThanBefore.tearsWithJoy(function() {
@@ -198,6 +205,20 @@ describe('conventional-recommended-bump', function() {
         path: 'test/packages/foo'
       }, function(err, recommendation) {
         equal(recommendation.releaseType, 'patch');
+        done();
+      });
+    });
+  });
+
+  describe('repo with tag prefix', function() {
+    it('should recommends a minor release if appropriate', function(done) {
+      preparing(8);
+
+      conventionalRecommendedBump({
+        tagPrefix: 'ms/',
+        preset: 'angular'
+      }, function(err, recommendation) {
+        equal(recommendation.releaseType, 'minor');
         done();
       });
     });

--- a/packages/git-semver-tags/README.md
+++ b/packages/git-semver-tags/README.md
@@ -36,6 +36,7 @@ v1.0.0
   git history, rather than `v1.0.0` format.
 * `opts.package`: what package should lerna style tags be listed for, e.g.,
   `foo-package`.
+* `opts.tagPrefix`: specify a prefix for the git tag to be ignored from the semver checks
 
 ## License
 

--- a/packages/git-semver-tags/cli.js
+++ b/packages/git-semver-tags/cli.js
@@ -10,7 +10,7 @@ var args = meow({
     'Options',
     ' --lerna parse lerna style git tags',
     ' --package when listing lerna style tags, filter by a package',
-    ' --tagPrefix prefix to remove from the tag during their processing'
+    ' --tagPrefix prefix to remove from the tags during their processing'
   ]
 });
 

--- a/packages/git-semver-tags/cli.js
+++ b/packages/git-semver-tags/cli.js
@@ -9,7 +9,8 @@ var args = meow({
     '  git-semver-tags',
     'Options',
     ' --lerna parse lerna style git tags',
-    ' --package when listing lerna style tags, filter by a package'
+    ' --package when listing lerna style tags, filter by a package',
+    ' --tagPrefix prefix to remove from the tag during their processing'
   ]
 });
 
@@ -22,5 +23,6 @@ gitSemverTags(function(err, tags) {
   console.log(tags.join('\n'));
 }, {
   lernaTags: args.flags.lerna,
-  package: args.flags.package
+  package: args.flags.package,
+  tagPrefix: args.flags.tagPrefix
 });

--- a/packages/git-semver-tags/index.js
+++ b/packages/git-semver-tags/index.js
@@ -29,7 +29,10 @@ module.exports = function(callback, opts) {
     }
 
     var tags = [];
-
+    var tagPrefixRegexp;
+    if (opts.tagPrefix) {
+      tagPrefixRegexp = new RegExp('^' + opts.tagPrefix);
+    }
     data.split('\n').forEach(function(decorations) {
       var match;
       while (match = regex.exec(decorations)) {
@@ -39,8 +42,8 @@ module.exports = function(callback, opts) {
             tags.push(tag);
           }
         } else if (opts.tagPrefix) {
-          if ((new RegExp('^' + opts.tagPrefix)).test(tag)) {
-            if (semverValid(tag.replace(new RegExp('^' + opts.tagPrefix), ''))) {
+          if (tagPrefixRegexp.test(tag)) {
+            if (semverValid(tag.replace(tagPrefixRegexp, ''))) {
               tags.push(tag);
             }
           }

--- a/packages/git-semver-tags/index.js
+++ b/packages/git-semver-tags/index.js
@@ -31,7 +31,7 @@ module.exports = function(callback, opts) {
     var tags = [];
     var tagPrefixRegexp;
     if (opts.tagPrefix) {
-      tagPrefixRegexp = new RegExp('^' + opts.tagPrefix);
+      tagPrefixRegexp = new RegExp('^' + opts.tagPrefix + '(.*)');
     }
     data.split('\n').forEach(function(decorations) {
       var match;
@@ -42,10 +42,9 @@ module.exports = function(callback, opts) {
             tags.push(tag);
           }
         } else if (opts.tagPrefix) {
-          if (tagPrefixRegexp.test(tag)) {
-            if (semverValid(tag.replace(tagPrefixRegexp, ''))) {
-              tags.push(tag);
-            }
+          var matches = tag.match(tagPrefixRegexp);
+          if (matches && semverValid(matches[1])) {
+            tags.push(tag);
           }
         } else if (semverValid(tag)) {
           tags.push(tag);

--- a/packages/git-semver-tags/index.js
+++ b/packages/git-semver-tags/index.js
@@ -38,6 +38,12 @@ module.exports = function(callback, opts) {
           if (lernaTag(tag, opts.package)) {
             tags.push(tag);
           }
+        } else if (opts.tagPrefix) {
+          if ((new RegExp('^' + opts.tagPrefix)).test(tag)) {
+            if (semverValid(tag.replace(new RegExp('^' + opts.tagPrefix), ''))) {
+              tags.push(tag);
+            }
+          }
         } else if (semverValid(tag)) {
           tags.push(tag);
         }

--- a/packages/git-semver-tags/test.js
+++ b/packages/git-semver-tags/test.js
@@ -167,6 +167,8 @@ it('should work with tag prefix option', function(done) {
   shell.exec('git tag ms/6.0.0');
   shell.exec('git add --all && git commit -m"tenth commit"');
   shell.exec('git tag ms/7.0.0');
+  shell.exec('git add --all && git commit -m"eleventh commit"');
+  shell.exec('git tag notms/7.0.0');
 
   gitSemverTags(function(err, tags) {
     equal(tags, ['ms/7.0.0', 'ms/6.0.0']);

--- a/packages/git-semver-tags/test.js
+++ b/packages/git-semver-tags/test.js
@@ -160,3 +160,16 @@ it('should not allow package filter without lernaTags=true', function(done) {
     done();
   }, {package: 'bar-project'});
 });
+
+it('should work with tag prefix option', function(done) {
+  writeFileSync('test6', '');
+  shell.exec('git add --all && git commit -m"eigth commit"');
+  shell.exec('git tag ms/6.0.0');
+  shell.exec('git add --all && git commit -m"tenth commit"');
+  shell.exec('git tag ms/7.0.0');
+
+  gitSemverTags(function(err, tags) {
+    equal(tags, ['ms/7.0.0', 'ms/6.0.0']);
+    done();
+  }, {tagPrefix: 'ms/'});
+});


### PR DESCRIPTION
This PR adds the possibility to specify a `tagPrefix` in `conventional-recommended-bump`.

Currently is you use a `tagPrefix` in https://github.com/conventional-changelog/standard-version and that tagPrefix is not semver compatible, standard version will not work as intended as it cannot find the releases.

By specifying the tagPrefix in `conventional-recommended-bump` and in turn in `git-semver-tags` we can get a proper version bump recommendation.

If this is accepted `standard-version` will have to be updated to pass the extra parameter to `conventional-recommended-bump`

Thanks in advance for your review