### PR TITLE
docs: point former conventional-changelog-lint links to commitlint

### DIFF
--- a/packages/conventional-changelog-cli/README.md
+++ b/packages/conventional-changelog-cli/README.md
@@ -117,7 +117,7 @@ message="chore(release): %s :tada:"
 - [conventional-commits-detector](https://github.com/conventional-changelog/conventional-commits-detector) - Detect what commit message convention your repository is using
 - [commitizen](https://github.com/commitizen/cz-cli) - Simple commit conventions for internet citizens.
 - [angular-precommit](https://github.com/ajoslin/angular-precommit) - Pre commit with angular conventions
-- [conventional-changelog-lint](https://github.com/marionebl/conventional-changelog-lint) - Lint commit messages against your conventional-changelog preset
+- [commitlint](https://github.com/marionebl/commitlint) - Lint commit messages
 
 
 ## License

--- a/packages/conventional-changelog/README.md
+++ b/packages/conventional-changelog/README.md
@@ -63,7 +63,7 @@ It's recommended to use a preset so you don't have to define everything yourself
 - [conventional-commits-detector](https://github.com/conventional-changelog/conventional-commits-detector) - Detect what commit message convention your repository is using
 - [commitizen](https://github.com/commitizen/cz-cli) - Simple commit conventions for internet citizens.
 - [angular-precommit](https://github.com/ajoslin/angular-precommit) - Pre commit with angular conventions
-- [conventional-changelog-lint](https://github.com/marionebl/conventional-changelog-lint) - Lint commit messages against your conventional-changelog preset
+- [commitlint](https://github.com/marionebl/commitlint) - Lint commit messages
 
 
 ## License


### PR DESCRIPTION
* follow up to #141