### PR TITLE
fix: truncate after scissors line

### DIFF
--- a/packages/conventional-commits-parser/lib/parser.js
+++ b/packages/conventional-commits-parser/lib/parser.js
@@ -21,6 +21,16 @@ function getCommentFilter(char) {
   };
 }
 
+function truncateToScissor(lines) {
+  var scissorIndex = lines.indexOf(SCISSOR);
+
+  if (scissorIndex === -1) {
+    return lines;
+  }
+
+  return lines.slice(0, scissorIndex);
+}
+
 function getReferences(input, regex) {
   var references = [];
   var referenceSentences;
@@ -88,12 +98,7 @@ function parser(raw, options, regex) {
     passTrough;
 
   var rawLines = trimOffNewlines(raw).split(/\r?\n/);
-  var scissorIndex = rawLines.indexOf(SCISSOR);
-  var truncatedLines = scissorIndex > -1 ?
-    rawLines.slice(0, scissorIndex) :
-    rawLines;
-
-  var lines = truncatedLines.filter(commentFilter);
+  var lines = truncateToScissor(rawLines).filter(commentFilter);
 
   var continueNote = false;
   var isBody = true;

--- a/packages/conventional-commits-parser/lib/parser.js
+++ b/packages/conventional-commits-parser/lib/parser.js
@@ -3,6 +3,7 @@ var trimOffNewlines = require('trim-off-newlines');
 var _ = require('lodash');
 
 var CATCH_ALL = /()(.+)/gi;
+var SCISSOR = '# ------------------------ >8 ------------------------';
 
 function append(src, line) {
   if (src) {
@@ -86,7 +87,13 @@ function parser(raw, options, regex) {
     getCommentFilter(options.commentChar) :
     passTrough;
 
-  var lines = trimOffNewlines(raw).split(/\r?\n/).filter(commentFilter);
+  var rawLines = trimOffNewlines(raw).split(/\r?\n/);
+  var scissorIndex = rawLines.indexOf(SCISSOR);
+  var truncatedLines = scissorIndex > -1 ?
+    rawLines.slice(0, scissorIndex) :
+    rawLines;
+
+  var lines = truncatedLines.filter(commentFilter);
 
   var continueNote = false;
   var isBody = true;

--- a/packages/conventional-commits-parser/test/parser.spec.js
+++ b/packages/conventional-commits-parser/test/parser.spec.js
@@ -287,13 +287,36 @@ describe('parser', function() {
 
   it('should truncate from scissors line', function() {
     var msg = parser(
-      'this is some subject before a scissors-line\n' +
+      'this is some header before a scissors-line\n' +
       '# ------------------------ >8 ------------------------\n' +
       'this is a line that should be truncated\n',
       options,
       reg
     );
     expect(msg.body).to.equal(null);
+  });
+
+  it('should keep header before scissor line', function() {
+    var msg = parser(
+      'this is some header before a scissors-line\n' +
+      '# ------------------------ >8 ------------------------\n' +
+      'this is a line that should be truncated\n',
+      options,
+      reg
+    );
+    expect(msg.header).to.equal('this is some header before a scissors-line');
+  });
+
+  it('should keep body before scissor line', function() {
+    var msg = parser(
+      'this is some subject before a scissors-line\n' +
+      'this is some body before a scissors-line\n' +
+      '# ------------------------ >8 ------------------------\n' +
+      'this is a line that should be truncated\n',
+      options,
+      reg
+    );
+    expect(msg.body).to.equal('this is some body before a scissors-line');
   });
 
   describe('mentions', function() {

--- a/packages/conventional-commits-parser/test/parser.spec.js
+++ b/packages/conventional-commits-parser/test/parser.spec.js
@@ -285,6 +285,17 @@ describe('parser', function() {
     });
   });
 
+  it.only('should truncate from scissors line', function() {
+    var msg = parser(
+      'this is some subject before a scissors-line\n' +
+      '# ------------------------ >8 ------------------------\n' +
+      'this is a line that should be truncated\n',
+      options,
+      reg
+    );
+    expect(msg.body).to.equal(null);
+  });
+
   describe('mentions', function() {
     it('should mention someone in the commit', function() {
       var options = {

--- a/packages/conventional-commits-parser/test/parser.spec.js
+++ b/packages/conventional-commits-parser/test/parser.spec.js
@@ -285,7 +285,7 @@ describe('parser', function() {
     });
   });
 
-  it.only('should truncate from scissors line', function() {
+  it('should truncate from scissors line', function() {
     var msg = parser(
       'this is some subject before a scissors-line\n' +
       '# ------------------------ >8 ------------------------\n' +


### PR DESCRIPTION
This resolves an issue where commit authored via `git commit -v` and fed into `conventional-commits-parser` via `.git/COMMIT_EDITMSG` directly where not truncated as intended from the beginning of the scissors line

## Before

https://runkit.com/marionebl/conventional-commits-parser-scissors
```js 
const parser = require('conventional-commits-parser');
const message = `A message
# ------------------------ >8 ------------------------
diff --git a/package.json b/package.json
index d88860d05..dd6c7818f 100644
--- a/somehting.json
+++ b/somehting.json`;

parser.sync(message, {commentChar: '#'}) // => {body: 'diff --git a/package.json b/packag…mehting.json\n+++ b/somehting.json'}
```

## After

```
const parser = require('conventional-commits-parser');
const message = `A message
# ------------------------ >8 ------------------------
diff --git a/package.json b/package.json
index d88860d05..dd6c7818f 100644
--- a/somehting.json
+++ b/somehting.json`;

parser.sync(message, {commentChar: '#'}) // => {body: null}
```