### PR TITLE
feat: regex headerPattern for eslint

### DIFF
--- a/packages/conventional-changelog-eslint/parser-opts.js
+++ b/packages/conventional-changelog-eslint/parser-opts.js
@@ -1,7 +1,7 @@
 'use strict';
 
 module.exports = {
-  headerPattern: /^(\w*)\: (.*?)(?:\((.*)\))?$/,
+  headerPattern: /^(\w*):\s*(.*)$/,
   headerCorrespondence: [
     `tag`,
     `message`

--- a/packages/conventional-changelog-eslint/test/test.js
+++ b/packages/conventional-changelog-eslint/test/test.js
@@ -24,6 +24,8 @@ describe('eslint preset', function() {
     writeFileSync('test4', '');
     shell.exec('git add --all && git commit -m"Docs: Fix unmatched paren in rule description"');
     writeFileSync('test5', '');
+    shell.exec('git add --all && git commit -m"Fix:        Commit with trailing spaces in the beginning"');
+    writeFileSync('test6', '');
     shell.exec('git add --all && git commit -m"Merge pull request #3033 from gcochard/patch-3 "');
   });
 
@@ -40,6 +42,7 @@ describe('eslint preset', function() {
         expect(chunk).to.include('the `no-class-assign` rule');
         expect(chunk).to.include('### Fix');
         expect(chunk).to.include('indent rule should recognize single line statements with ASI');
+        expect(chunk).to.include('* Commit with trailing spaces in the beginning');
         expect(chunk).to.include('### Docs');
 
         expect(chunk).to.not.include('3033');


### PR DESCRIPTION
The previous regex got a lot of overhead. The new one is easier to read and faster to parse.

But here I changed the regex a bit. First it also matched whitespaces in the beginning of the message, now it doesnt. If the same behavior is wished, I can change the regex to:

```js
 /^(\w*): (.*)$/
```
Which does the same as the original one, but with less overhead