### PR TITLE
fix(presets): support scoped packages as presets

### DIFF
--- a/packages/conventional-changelog/README.md
+++ b/packages/conventional-changelog/README.md
@@ -48,6 +48,8 @@ Type: `string` Possible values: `'angular', 'atom', 'codemirror', 'ember', 'esli
 
 It's recommended to use a preset so you don't have to define everything yourself. Presets are names of built-in `config`.
 
+A scoped preset package such as `@scope/conventional-changelog-custom-preset` can be used by passing `@scope/custom-preset` to this option.
+
 **NOTE:** `options.config` will be overwritten by the values of preset. You should use either `preset` or `config`, but not both.
 
 

--- a/packages/conventional-changelog/index.js
+++ b/packages/conventional-changelog/index.js
@@ -15,7 +15,6 @@ function conventionalChangelog(options, context, gitRawCommitsOpts, parserOpts, 
         name = parts.join('');
       }
       
-      console.log('scope', scope, 'name', name);
       options.config = require(scope + 'conventional-changelog-' + name);
     } catch (err) {
       options.warn('Preset: "' + options.preset + '" does not exist');

--- a/packages/conventional-changelog/index.js
+++ b/packages/conventional-changelog/index.js
@@ -14,7 +14,7 @@ function conventionalChangelog(options, context, gitRawCommitsOpts, parserOpts, 
         scope = parts.shift() + '/';
         name = parts.join('');
       }
-      
+
       options.config = require(scope + 'conventional-changelog-' + name);
     } catch (err) {
       options.warn('Preset: "' + options.preset + '" does not exist');

--- a/packages/conventional-changelog/index.js
+++ b/packages/conventional-changelog/index.js
@@ -6,7 +6,17 @@ function conventionalChangelog(options, context, gitRawCommitsOpts, parserOpts, 
 
   if (options.preset) {
     try {
-      options.config = require('conventional-changelog-' + options.preset.toLowerCase());
+      var scope = '';
+      var name = options.preset.toLowerCase();
+
+      if (name[0] === '@') {
+        var parts = name.split('/');
+        scope = parts.shift() + '/';
+        name = parts.join('');
+      }
+      
+      console.log('scope', scope, 'name', name);
+      options.config = require(scope + 'conventional-changelog-' + name);
     } catch (err) {
       options.warn('Preset: "' + options.preset + '" does not exist');
     }


### PR DESCRIPTION
Previously, a scoped packages such as `@my-org/conventional-changelog-myorg` was not able to be used when specifying a preset. This change checks if the preset is scoped, and re-appends the scope when constructing the preset package name.