### PR TITLE
refactor: replace deprecated gulp-util

### DIFF
--- a/packages/gulp-conventional-changelog/index.js
+++ b/packages/gulp-conventional-changelog/index.js
@@ -3,7 +3,8 @@ var addStream = require('add-stream');
 var assign = require('object-assign');
 var concat = require('concat-stream');
 var conventionalChangelog = require('conventional-changelog');
-var gutil = require('gulp-util');
+var PluginError = require('plugin-error');
+var fancyLog = require('fancy-log');
 var through = require('through2');
 
 module.exports = function(opts, context, gitRawCommitsOpts, parserOpts, writerOpts) {
@@ -13,7 +14,7 @@ module.exports = function(opts, context, gitRawCommitsOpts, parserOpts, writerOp
   }, opts);
 
   if (opts.verbose) {
-    opts.debug = gutil.log;
+    opts.debug = fancyLog;
   }
 
   return through.obj(function(file, enc, cb) {
@@ -24,7 +25,7 @@ module.exports = function(opts, context, gitRawCommitsOpts, parserOpts, writerOp
 
     var stream = conventionalChangelog(opts, context, gitRawCommitsOpts, parserOpts, writerOpts)
       .on('error', function(err) {
-        cb(new gutil.PluginError('gulp-conventional-changelog', err));
+        cb(new PluginError('gulp-conventional-changelog', err));
       });
 
     if (file.isStream()) {

--- a/packages/gulp-conventional-changelog/package.json
+++ b/packages/gulp-conventional-changelog/package.json
@@ -31,8 +31,9 @@
     "add-stream": "^1.0.0",
     "concat-stream": "^1.5.0",
     "conventional-changelog": "^1.1.10",
-    "gulp-util": "^3.0.6",
+    "fancy-log": "^1.3.2",
     "object-assign": "^4.0.1",
+    "plugin-error": "^1.0.1",
     "through2": "^2.0.0"
   },
   "devDependencies": {
@@ -41,6 +42,7 @@
     "jscs": "^2.0.0",
     "jshint": "^2.8.0",
     "mocha": "*",
-    "shelljs": "^0.6.0"
+    "shelljs": "^0.6.0",
+    "vinyl": "^2.1.0"
   }
 }

--- a/packages/gulp-conventional-changelog/readme.md
+++ b/packages/gulp-conventional-changelog/readme.md
@@ -109,7 +109,7 @@ There are some changes:
 
 #### warn
 
-If the cli contains flag `--verbose` it is `gutil.log`.
+If the cli contains flag `--verbose` it is `fancyLog`.
 
 
 ## License

--- a/packages/gulp-conventional-changelog/test.js
+++ b/packages/gulp-conventional-changelog/test.js
@@ -2,7 +2,7 @@
 var concat = require('concat-stream');
 var conventionalChangelog = require('./');
 var expect = require('chai').expect;
-var gutil = require('gulp-util');
+var Vinyl = require('vinyl');
 var join = require('path').join;
 var shell = require('shelljs');
 var through = require('through2');
@@ -29,7 +29,7 @@ describe('error', function() {
       cb(file);
     });
 
-    stream.write(new gutil.File({
+    stream.write(new Vinyl({
       cwd: __dirname,
       base: join(__dirname, 'fixtures'),
       path: join(__dirname, 'fixtures/CHANGELOG.md'),
@@ -65,7 +65,7 @@ describe('stream', function() {
         }));
     });
 
-    stream.write(new gutil.File({
+    stream.write(new Vinyl({
       cwd: __dirname,
       base: join(__dirname, 'fixtures'),
       path: join(__dirname, 'fixtures/CHANGELOG.md'),
@@ -93,7 +93,7 @@ describe('stream', function() {
         }));
     });
 
-    stream.write(new gutil.File({
+    stream.write(new Vinyl({
       cwd: __dirname,
       base: join(__dirname, 'fixtures'),
       path: join(__dirname, 'fixtures/CHANGELOG.md'),
@@ -119,7 +119,7 @@ describe('stream', function() {
         }));
     });
 
-    stream.write(new gutil.File({
+    stream.write(new Vinyl({
       cwd: __dirname,
       base: join(__dirname, 'fixtures'),
       path: join(__dirname, 'fixtures/CHANGELOG.md'),
@@ -142,7 +142,7 @@ describe('buffer', function() {
 
     stream.on('end', cb);
 
-    stream.write(new gutil.File({
+    stream.write(new Vinyl({
       cwd: __dirname,
       base: join(__dirname, 'fixtures'),
       path: join(__dirname, 'fixtures/CHANGELOG.md'),
@@ -164,7 +164,7 @@ describe('buffer', function() {
 
     stream.on('end', cb);
 
-    stream.write(new gutil.File({
+    stream.write(new Vinyl({
       cwd: __dirname,
       base: join(__dirname, 'fixtures'),
       path: join(__dirname, 'fixtures/CHANGELOG.md'),
@@ -186,7 +186,7 @@ describe('buffer', function() {
 
     stream.on('end', cb);
 
-    stream.write(new gutil.File({
+    stream.write(new Vinyl({
       cwd: __dirname,
       base: join(__dirname, 'fixtures'),
       path: join(__dirname, 'fixtures/CHANGELOG.md'),
@@ -210,7 +210,7 @@ describe('buffer', function() {
 
     stream.on('end', cb);
 
-    stream.write(new gutil.File({
+    stream.write(new Vinyl({
       cwd: __dirname,
       base: join(__dirname, 'fixtures'),
       path: join(__dirname, 'fixtures/CHANGELOG.md'),
@@ -237,7 +237,7 @@ describe('null', function() {
       done();
     }));
 
-    stream.write(new gutil.File({
+    stream.write(new Vinyl({
       path: 'null.md',
       contents: null
     }));
@@ -256,7 +256,7 @@ it('should verbose', function(cb) {
     cb();
   });
 
-  stream.write(new gutil.File({
+  stream.write(new Vinyl({
     cwd: __dirname,
     base: join(__dirname, 'fixtures'),
     path: join(__dirname, 'fixtures/CHANGELOG.md'),


### PR DESCRIPTION
[`gulp-util`](https://www.npmjs.com/package/gulp-util) has been deprecated recently. Continuing to use this dependency may prevent the use of your library with the recently released version 4 of Gulp, it is important to replace `gulp-util`.

See:
- https://medium.com/gulpjs/gulp-util-ca3b1f9f9ac5
- https://github.com/gulpjs/gulp-util/issues/143