### PR TITLE
preset-loader dependencies -> devDependencies

### DIFF
--- a/packages/conventional-changelog-preset-loader/package.json
+++ b/packages/conventional-changelog-preset-loader/package.json
@@ -15,7 +15,7 @@
   "files": [
     "index.js"
   ],
-  "dependencies": {
+  "devDependencies": {
     "chai": "^4.1.2",
     "jscs": "^3.0.7",
     "jshint": "^2.9.5",


### PR DESCRIPTION
I tried installing conventional-changelog-preset-loader today and suddenly I had transitive runtime dependencies on chai, jshint, etc. cc @hbetts 