### PR TITLE
fix(preset): recommended-bump ESLint preset

### DIFF
--- a/packages/conventional-changelog-eslint/conventional-recommended-bump.js
+++ b/packages/conventional-changelog-eslint/conventional-recommended-bump.js
@@ -1,16 +1,20 @@
 'use strict';
 
 module.exports = {
-  whatBump: (commits) => {
+  whatBump: commits => {
     let level = 2;
     let breakings = 0;
     let features = 0;
 
     commits.forEach(commit => {
-      if (commit.notes.length > 0) {
-        breakings += commit.notes.length;
+      if (!commit.type) {
+        return;
+      }
+
+      if (commit.type.toLowerCase() === 'breaking') {
+        breakings += 1;
         level = 0;
-      } else if (commit.type === `feat`) {
+      } else if (commit.type.toLowerCase() === 'new') {
         features += 1;
         if (level === 2) {
           level = 1;
@@ -20,19 +24,16 @@ module.exports = {
 
     return {
       level: level,
-      reason: `There are ${breakings} BREAKING CHANGES and ${features} features`
+      reason: `There are ${breakings} breaking changes and ${features} features`
     };
   },
-
   parserOpts: {
-    headerPattern: /^(\w*)(?:\((.*)\))?\: (.*)$/,
+    headerPattern: /^(\w*): (.*)$/,
     headerCorrespondence: [
-      `type`,
-      `scope`,
-      `subject`
+      'type',
+      'subject'
     ],
-    noteKeywords: `BREAKING CHANGE`,
-    revertPattern: /^revert:\s([\s\S]*?)\s*This reverts commit (\w*)\./,
-    revertCorrespondence: [`header`, `hash`]
+    revertPattern: /^[rR]evert:\s([\s\S]*?)\s*This reverts commit (\w*)\./,
+    revertCorrespondence: ['header', 'hash']
   }
 };


### PR DESCRIPTION
In a project, we recently started to use `conventional-recommended-bump` (version 2.0.6) and it was giving us wrong results with `npx conventional-recommended-bump -p eslint`. The latest version that works with `-p eslint` seems to be 1.2.1 (with built-in presets).

It seems that the Angular preset was inadvertently copied into the ESLint package with commit 60815b50bc68b50a8430c21ec0499273a4a1c402.

This corrects the `conventional-recommended-bump` ESLint preset in `conventional-changelog-eslint` to behave the same as the built-in ESLint preset that was removed with #270.

Related to #241