### PR TITLE
fix: `tagPrefix` was not passed properly in conventional-changelog-core

### DIFF
--- a/packages/conventional-changelog-core/README.md
+++ b/packages/conventional-changelog-core/README.md
@@ -115,6 +115,11 @@ Specify a package in lerna-style monorepo that the CHANGELOG should be generated
 Lerna tags releases in the format `foo-package@1.0.0` and assumes that packages
 are stored in the directory structure `./packages/foo-package`.
 
+##### tagPrefix
+
+Specify a prefix for the git tag that will be taken into account during the comparison.
+For instance if your version tag is prefixed by `version/` instead of `v` you would specify `--tagPrefix=version/`
+
 #### context
 
 See the [conventional-changelog-writer](https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-writer) docs. There are some defaults or changes:

--- a/packages/conventional-changelog-core/lib/merge-config.js
+++ b/packages/conventional-changelog-core/lib/merge-config.js
@@ -28,7 +28,7 @@ function semverTagsPromise (options) {
       } else {
         resolve(result)
       }
-    }, {lernaTags: !!options.lernaPackage, package: options.lernaPackage})
+    }, {lernaTags: !!options.lernaPackage, package: options.lernaPackage, tagPrefix: options.tagPrefix})
   })
 }
 


### PR DESCRIPTION
Following my previous PR, I'm now looking at how to consume this properly in `standard-version` and I noticed that I forgot to pass the parameter in one place...

This PR fixes that ! The original PR can be found here https://github.com/conventional-changelog/conventional-changelog/pull/259

During the `merge-config` part of conventional-changelog-core a call is made to `gitSemverTags` to retrieve the list of tags so that the changelog can compare the previous one with the change made so far.
This call was not passing the `tagPrefix` parameter so was failing to retrieve the correct tag list !

@hbetts @bcoe please review