### PR TITLE
refactor: remove anchor from header templates

### DIFF
--- a/packages/conventional-changelog-angular/templates/header.hbs
+++ b/packages/conventional-changelog-angular/templates/header.hbs
@@ -1,4 +1,3 @@
-<a name="{{version}}"></a>
 {{#if isPatch~}}
   ##
 {{~else~}}

--- a/packages/conventional-changelog-atom/templates/header.hbs
+++ b/packages/conventional-changelog-atom/templates/header.hbs
@@ -1,2 +1,1 @@
-<a name="{{version}}"></a>
 {{#if isPatch}}##{{else}}#{{/if}} {{#if @root.linkCompare}}[{{version}}]({{@root.host}}/{{#if @root.owner}}{{@root.owner}}/{{/if}}{{@root.repository}}/compare/{{previousTag}}...{{currentTag}}){{else}}{{version}}{{/if}}{{#if title}} "{{title}}"{{/if}}{{#if date}} ({{date}}){{/if}}

--- a/packages/conventional-changelog-codemirror/templates/header.hbs
+++ b/packages/conventional-changelog-codemirror/templates/header.hbs
@@ -1,2 +1,1 @@
-<a name="{{version}}"></a>
 {{#if isPatch}}##{{else}}#{{/if}} {{#if @root.linkCompare}}[{{version}}]({{@root.host}}/{{#if @root.owner}}{{@root.owner}}/{{/if}}{{@root.repository}}/compare/{{previousTag}}...{{currentTag}}){{else}}{{version}}{{/if}}{{#if title}} "{{title}}"{{/if}}{{#if date}} ({{date}}){{/if}}

--- a/packages/conventional-changelog-ember/templates/header.hbs
+++ b/packages/conventional-changelog-ember/templates/header.hbs
@@ -1,2 +1,1 @@
-<a name="{{version}}"></a>
 {{#if isPatch}}##{{else}}#{{/if}} {{#if @root.linkCompare}}[{{version}}]({{@root.host}}/{{#if @root.owner}}{{@root.owner}}/{{/if}}{{@root.repository}}/compare/{{previousTag}}...{{currentTag}}){{else}}{{version}}{{/if}}{{#if title}} "{{title}}"{{/if}}{{#if date}} ({{date}}){{/if}}

--- a/packages/conventional-changelog-eslint/templates/header.hbs
+++ b/packages/conventional-changelog-eslint/templates/header.hbs
@@ -1,2 +1,1 @@
-<a name="{{version}}"></a>
 {{#if isPatch}}##{{else}}#{{/if}} {{#if @root.linkCompare}}[{{version}}]({{@root.host}}/{{#if @root.owner}}{{@root.owner}}/{{/if}}{{@root.repository}}/compare/{{previousTag}}...{{currentTag}}){{else}}{{version}}{{/if}}{{#if title}} "{{title}}"{{/if}}{{#if date}} ({{date}}){{/if}}

--- a/packages/conventional-changelog-jquery/templates/header.hbs
+++ b/packages/conventional-changelog-jquery/templates/header.hbs
@@ -1,4 +1,3 @@
-<a name="{{version}}"></a>
 {{#if isPatch~}}
   ##
 {{~else~}}

--- a/packages/conventional-changelog-jshint/templates/header.hbs
+++ b/packages/conventional-changelog-jshint/templates/header.hbs
@@ -1,2 +1,1 @@
-<a name="{{version}}"></a>
 {{#if isPatch}}##{{else}}#{{/if}} {{#if @root.linkCompare}}[{{version}}]({{@root.host}}/{{#if @root.owner}}{{@root.owner}}/{{/if}}{{@root.repository}}/compare/{{previousTag}}...{{currentTag}}){{else}}{{version}}{{/if}}{{#if title}} "{{title}}"{{/if}}{{#if date}} ({{date}}){{/if}}

--- a/packages/conventional-changelog-writer/README.md
+++ b/packages/conventional-changelog-writer/README.md
@@ -48,7 +48,6 @@ Each chunk should be a commit. Json object is also **valid**. Parts of the objec
 The downstream might look something like this:
 
 ```js
-<a name="0.0.1"></a>
 ## 0.0.1 "this is a title" (2015-05-29)
 
 
@@ -341,7 +340,6 @@ $ conventional-changelog-writer commits.ldjson -o options.js
 The output might look something like this
 
 ```md
-<a name="1.0.0"></a>
 # 1.0.0 (2015-04-09)
 
 

--- a/packages/conventional-changelog-writer/templates/header.hbs
+++ b/packages/conventional-changelog-writer/templates/header.hbs
@@ -1,4 +1,3 @@
-<a name="{{version}}"></a>
 ## {{#if isPatch~}} <small>
   {{~/if~}} {{version}}
   {{~#if title}} "{{title}}"

--- a/packages/conventional-changelog-writer/test/index.spec.js
+++ b/packages/conventional-changelog-writer/test/index.spec.js
@@ -78,7 +78,7 @@ describe('conventionalChangelogWriter', function () {
       upstream
         .pipe(conventionalChangelogWriter())
         .pipe(through(function (chunk, enc, cb) {
-          expect(chunk.toString()).to.equal('<a name=""></a>\n##  (' + today + ')\n\n\n\n\n')
+          expect(chunk.toString()).to.equal('##  (' + today + ')\n\n\n\n\n')
 
           i++
           cb(null)
@@ -239,7 +239,7 @@ describe('conventionalChangelogWriter', function () {
           }
         }))
         .pipe(through(function (chunk, enc, cb) {
-          expect(chunk.toString()).to.equal('<a name=""></a>\n##  (' + today + ')\n\n\n\n\n')
+          expect(chunk.toString()).to.equal('##  (' + today + ')\n\n\n\n\n')
 
           i++
           cb(null)
@@ -324,20 +324,18 @@ describe('conventionalChangelogWriter', function () {
             chunk = chunk.toString()
 
             if (i === 0) {
-              expect(chunk).to.include('<a name=""></a>\n##  (' + today)
+              expect(chunk).to.include('##  (' + today)
               expect(chunk).to.include('feat(scope): ')
 
-              expect(chunk).to.not.include('<a name="1.0.1"></a>')
               expect(chunk).to.not.include('fix(ng-list): ')
               expect(chunk).to.not.include('perf(template): ')
               expect(chunk).to.not.include('refactor(name): ')
             } else {
-              expect(chunk).to.include('<a name="1.0.1"></a>\n## <small>1.0.1 (2015-04-07)</small>')
+              expect(chunk).to.include('## <small>1.0.1 (2015-04-07)</small>')
               expect(chunk).to.include('fix(ng-list): ')
               expect(chunk).to.include('perf(template): ')
               expect(chunk).to.include('refactor(name): ')
 
-              expect(chunk).to.not.include('<a name=""></a>')
               expect(chunk).to.not.include('feat(scope): ')
             }
 
@@ -398,18 +396,16 @@ describe('conventionalChangelogWriter', function () {
             chunk = chunk.toString()
 
             if (i === 0) {
-              expect(chunk).to.include('<a name=""></a>\n##  (' + today)
+              expect(chunk).to.include('##  (' + today)
 
-              expect(chunk).to.not.include('<a name="1.0.1"></a>\n## 1.0.1 (2015-04-07)')
+              expect(chunk).to.not.include('## 1.0.1 (2015-04-07)')
             } else if (i === 1) {
-              expect(chunk).to.include('<a name="1.0.1"></a>')
               expect(chunk).to.include('feat(scope): broadcast $destroy event on scope destruction')
+              expect(chunk).to.not.include('<a name=""></a>')
             } else if (i === 2) {
-              expect(chunk).to.include('<a name="2.0.1"></a>')
               expect(chunk).to.include('fix(ng-list): Allow custom separator')
               expect(chunk).to.include('perf(template): tweak')
             } else if (i === 3) {
-              expect(chunk).to.include('<a name="4.0.1"></a>')
               expect(chunk).to.include('refactor(name): rename this module to conventional-changelog-writer')
 
               expect(chunk).to.not.include('perf(template): tweak')
@@ -440,11 +436,8 @@ describe('conventionalChangelogWriter', function () {
             chunk = chunk.toString()
 
             if (i === 0) {
-              expect(chunk).to.include('<a name=""></a>\n##  (' + today)
-              expect(chunk).to.not.include('<a name="1.0.1"></a>\n## 1.0.1 (2015-04-07)')
-            } else {
-              expect(chunk).to.include('<a name="1.0.1"></a>')
-              expect(chunk).to.not.include('<a name=""></a>')
+              expect(chunk).to.include('##  (' + today)
+              expect(chunk).to.not.include('## 1.0.1 (2015-04-07)')
             }
 
             i++
@@ -465,7 +458,7 @@ describe('conventionalChangelogWriter', function () {
           .pipe(through(function (chunk, enc, cb) {
             chunk = chunk.toString()
 
-            expect(chunk).to.include('<a name=""></a>\n##  (' + today)
+            expect(chunk).to.include('##  (' + today)
 
             i++
             cb(null)
@@ -487,11 +480,9 @@ describe('conventionalChangelogWriter', function () {
             chunk = chunk.toString()
 
             if (i === 0) {
-              expect(chunk).to.include('<a name="0.0.1"></a>\n## <small>0.0.1 (2015-01-01)</small>')
-              expect(chunk).to.not.include('<a name="1.0.1"></a>')
+              expect(chunk).to.include('## <small>0.0.1 (2015-01-01)</small>')
             } else {
-              expect(chunk).to.include('<a name="1.0.1"></a>\n## <small>1.0.1 (2015-04-07)</small>')
-              expect(chunk).to.not.include('<a name="0.0.1"></a>')
+              expect(chunk).to.include('## <small>1.0.1 (2015-04-07)</small>')
             }
 
             i++
@@ -515,9 +506,9 @@ describe('conventionalChangelogWriter', function () {
             chunk = chunk.toString()
 
             if (i === 0) {
-              expect(chunk).to.equal('<a name=""></a>\n##  (' + today + ')\n\n\n\n\n')
+              expect(chunk).to.equal('##  (' + today + ')\n\n\n\n\n')
             } else {
-              expect(chunk).to.equal('<a name="1.0.1"></a>\n## <small>1.0.1 (2015-04-07 15:00:44 +1000)</small>\n\n\n\n\n')
+              expect(chunk).to.equal('## <small>1.0.1 (2015-04-07 15:00:44 +1000)</small>\n\n\n\n\n')
             }
 
             i++
@@ -537,11 +528,11 @@ describe('conventionalChangelogWriter', function () {
           }))
           .pipe(through.obj(function (chunk, enc, cb) {
             if (i === 0) {
-              expect(chunk.log).to.include('<a name=""></a>\n##  (' + today + ')\n\n')
+              expect(chunk.log).to.include('##  (' + today + ')\n\n')
               expect(chunk.log).to.include('feat(scope): broadcast $destroy event on scope destruction')
               expect(chunk.keyCommit).to.eql()
             } else {
-              expect(chunk.log).to.include('<a name="1.0.1"></a>\n## <small>1.0.1 (2015-04-07)</small>\n\n')
+              expect(chunk.log).to.include('## <small>1.0.1 (2015-04-07)</small>\n\n')
               expect(chunk.log).to.include('fix(ng-list): Allow custom separator')
               expect(chunk.log).to.include('perf(template): tweak')
               expect(chunk.log).to.include('refactor(name): rename this module to conventional-changelog-writer')
@@ -691,24 +682,22 @@ describe('conventionalChangelogWriter', function () {
             chunk = chunk.toString()
 
             if (i === 0) {
-              expect(chunk).to.include('<a name="1.0.1"></a>\n## <small>1.0.1 (2015-04-07)</small>')
+              expect(chunk).to.include('## <small>1.0.1 (2015-04-07)</small>')
               expect(chunk).to.include('feat(scope): ')
 
-              expect(chunk).to.not.include('<a name=""></a>')
               expect(chunk).to.not.include('perf(template): ')
               expect(chunk).to.not.include('refactor(name): ')
             } else if (i === 1) {
-              expect(chunk).to.include('<a name="2.0.1"></a>\n## <small>2.0.1 (2015-04-07)</small>')
+              expect(chunk).to.include('## <small>2.0.1 (2015-04-07)</small>')
               expect(chunk).to.include('fix(ng-list): ')
 
-              expect(chunk).to.not.include('<a name="1.0.1"></a>')
               expect(chunk).to.not.include('feat(scope): ')
             } else if (i === 2) {
-              expect(chunk).to.include('<a name="4.0.1"></a>\n#')
+              expect(chunk).to.include('#')
               expect(chunk).to.include('perf(template): ')
               expect(chunk).to.include('refactor(name): ')
             } else if (i === 3) {
-              expect(chunk).to.include('<a name=""></a>\n##  (' + today)
+              expect(chunk).to.include('##  (' + today)
             }
 
             i++
@@ -733,9 +722,9 @@ describe('conventionalChangelogWriter', function () {
             chunk = chunk.toString()
 
             if (i === 0) {
-              expect(chunk).to.equal('<a name="1.0.1"></a>\n## <small>1.0.1 (2015-04-07 15:00:44 +1000)</small>\n\n\n\n\n')
+              expect(chunk).to.equal('## <small>1.0.1 (2015-04-07 15:00:44 +1000)</small>\n\n\n\n\n')
             } else {
-              expect(chunk).to.equal('<a name=""></a>\n##  (' + today + ')\n\n\n\n\n')
+              expect(chunk).to.equal('##  (' + today + ')\n\n\n\n\n')
             }
 
             i++
@@ -756,13 +745,13 @@ describe('conventionalChangelogWriter', function () {
           }))
           .pipe(through.obj(function (chunk, enc, cb) {
             if (i === 0) {
-              expect(chunk.log).to.include('<a name="1.0.1"></a>\n## <small>1.0.1 (2015-04-07)</small>\n\n')
+              expect(chunk.log).to.include('## <small>1.0.1 (2015-04-07)</small>\n\n')
               expect(chunk.log).to.include('broadcast $destroy event on scope destruction')
               expect(chunk.log).to.include('fix(ng-list):')
               expect(chunk.keyCommit.version).to.equal('1.0.1')
               expect(chunk.keyCommit.committerDate).to.equal('2015-04-07')
             } else {
-              expect(chunk.log).to.include('<a name=""></a>\n##  (' + today + ')\n\n')
+              expect(chunk.log).to.include('##  (' + today + ')\n\n')
               expect(chunk.log).to.include('perf(template): tweak')
               expect(chunk.log).to.include('refactor(name): rename this module to conventional-changelog-writer')
               expect(chunk.keyCommit).to.eql()
@@ -876,7 +865,7 @@ describe('conventionalChangelogWriter', function () {
     upstream
       .pipe(conventionalChangelogWriter())
       .pipe(through(function (chunk, enc, cb) {
-        expect(chunk.toString()).to.equal('<a name=""></a>\n##  (' + today + ')\n\n* bla \n\n\n\n')
+        expect(chunk.toString()).to.equal('##  (' + today + ')\n\n* bla \n\n\n\n')
 
         i++
         cb(null)

--- a/packages/conventional-changelog-writer/test/partial.header.spec.js
+++ b/packages/conventional-changelog-writer/test/partial.header.spec.js
@@ -30,27 +30,27 @@ describe('partial.header', function () {
     templateContext.isPatch = true
     var log = Handlebars.compile(template)(templateContext)
 
-    expect(log).to.equal('<a name="my version"></a>\n## <small>my version</small>\n')
+    expect(log).to.equal('## <small>my version</small>\n')
   })
 
   it('should generate header if `isPatch` is falsy', function () {
     templateContext.isPatch = false
     var log = Handlebars.compile(template)(templateContext)
 
-    expect(log).to.equal('<a name="my version"></a>\n## my version\n')
+    expect(log).to.equal('## my version\n')
   })
 
   it('should generate header if `title` is truthy', function () {
     templateContext.title = 'my title'
     var log = Handlebars.compile(template)(templateContext)
 
-    expect(log).to.equal('<a name="my version"></a>\n## my version "my title"\n')
+    expect(log).to.equal('## my version "my title"\n')
   })
 
   it('should generate header if `date` is truthy', function () {
     templateContext.date = 'my date'
     var log = Handlebars.compile(template)(templateContext)
 
-    expect(log).to.equal('<a name="my version"></a>\n## my version (my date)\n')
+    expect(log).to.equal('## my version (my date)\n')
   })
 })


### PR DESCRIPTION
Closes #186.

BREAKING CHANGE:

Anchor tags are removed from the changelog header templates. The
rendered Markdown will no longer contain anchor tags proceeding the
version number header that constitutes the changelog header. This means
that consumers of rendered markdown will not be able to use a URL that
has been constructed to contain a version number anchor tag reference,
since the anchor tag won't exist in the rendered markdown.

It's stronly recomended consumers use the full URL path to the release
page for a given version, as that URL is a permalink to that verison,
contains all relavent release information, and does not, otherwise, rely
on the anchor tag being excessible from the current page view.

As an example, for version `2.0.0` of a GitHub project, the following
URL should be used:
- https://github.com/conventional-changelog/releaser-tools/releases/tag/v2.0.0