### PR TITLE
chore(package): set Node requirement to oldest supported LTS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: node_js
 
 node_js:
-  - 4
   - 6
   - 8
 

--- a/README.md
+++ b/README.md
@@ -35,3 +35,17 @@ found in [packages/conventional-changelog](https://github.com/conventional-chang
 - [conventional-commits-detector](https://github.com/conventional-changelog/conventional-commits-detector) - Detect what commit message convention your repository is using
 - [commitizen](https://github.com/commitizen/cz-cli) - Simple commit conventions for internet citizens.
 - [commitlint](https://github.com/marionebl/commitlint) - Lint commit messages
+
+## Node Support Policy
+
+We only support [Long-Term Support](https://github.com/nodejs/Release) versions of Node.
+
+We specifically limit our support to LTS versions of Node, not because this package won't work on other versions, but because we have a limited amount of time, and supporting LTS offers the greatest return on that investment.
+
+It's possible this package will work correctly on newer versions of Node. It may even be possible to use this package on older versions of Node, though that's more unlikely as we'll make every effort to take advantage of features available in the oldest LTS version we support.
+
+As each Node LTS version reaches its end-of-life we will remove that version from the `node` `engines` property of our package's `package.json` file. Removing a Node version is considered a breaking change and will entail the publishing of a new major version of this package. We will not accept any requests to support an end-of-life version of Node. Any merge requests or issues supporting an end-of-life version of Node will be closed.
+
+We will accept code that allows this package to run on newer, non-LTS, versions of Node. Furthermore, we will attempt to ensure our own changes work on the latest version of Node. To help in that commitment, our continuous integration setup runs against all LTS versions of Node in addition the most recent Node release; called _current_.
+
+JavaScript package managers should allow you to install this package with any version of Node, with, at most, a warning if your version of Node does not fall within the range specified by our `node` `engines` property. If you encounter issues installing this package, please report the issue to your package manager.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,22 +6,22 @@ environment:
 matrix:
   fast_finish: true
 
-build: off
-
 cache:
   - node_modules/
   - '%APPDATA%\npm-cache'
 
-init:
+install:
+  - ps: Install-Product node $env:nodejs_version
+  - npm install
+
+build: off
+
+before_test:
   - git config --global user.name 'CI'
   - git config --global user.email 'dummy@example.org'
   - npm install --global npm@latest
   - node --version
   - npm --version
-
-install:
-  - ps: Install-Product node $env:nodejs_version
-  - npm install
 
 test_script:
   - npm run test-windows

--- a/package.json
+++ b/package.json
@@ -8,8 +8,7 @@
   "bugs": "https://github.com/conventional-changelog/conventional-changelog/issues",
   "description": "Generate a changelog from git metadata",
   "engines": {
-    "node": ">=4.2.0",
-    "npm": ">=2.1.9"
+    "node": ">=6.9.0"
   },
   "files": [],
   "homepage": "https://github.com/conventional-changelog/conventional-changelog#readme",

--- a/packages/conventional-changelog-angular/package.json
+++ b/packages/conventional-changelog-angular/package.json
@@ -26,6 +26,9 @@
     "templates"
   ],
   "author": "Steve Mao",
+  "engines": {
+    "node": ">=6.9.0"
+  },
   "license": "ISC",
   "bugs": {
     "url": "https://github.com/conventional-changelog/conventional-changelog/issues"

--- a/packages/conventional-changelog-atom/package.json
+++ b/packages/conventional-changelog-atom/package.json
@@ -18,6 +18,9 @@
     "preset"
   ],
   "author": "Steve Mao",
+  "engines": {
+    "node": ">=6.9.0"
+  },
   "license": "ISC",
   "files": [
     "conventional-changelog.js",

--- a/packages/conventional-changelog-cli/package.json
+++ b/packages/conventional-changelog-cli/package.json
@@ -29,6 +29,9 @@
     "changelog",
     "log"
   ],
+  "engines": {
+    "node": ">=6.9.0"
+  },
   "devDependencies": {
     "concat-stream": "^1.6.0",
     "q": "^1.5.1",

--- a/packages/conventional-changelog-codemirror/package.json
+++ b/packages/conventional-changelog-codemirror/package.json
@@ -18,6 +18,9 @@
     "preset"
   ],
   "author": "Steve Mao",
+  "engines": {
+    "node": ">=6.9.0"
+  },
   "license": "ISC",
   "files": [
     "conventional-changelog.js",

--- a/packages/conventional-changelog-core/package.json
+++ b/packages/conventional-changelog-core/package.json
@@ -12,6 +12,9 @@
     "changelog",
     "log"
   ],
+  "engines": {
+    "node": ">=6.9.0"
+  },
   "license": "MIT",
   "files": [
     "index.js",

--- a/packages/conventional-changelog-ember/package.json
+++ b/packages/conventional-changelog-ember/package.json
@@ -18,6 +18,9 @@
     "preset"
   ],
   "author": "Steve Mao",
+  "engines": {
+    "node": ">=6.9.0"
+  },
   "license": "ISC",
   "files": [
     "conventional-changelog.js",

--- a/packages/conventional-changelog-eslint/package.json
+++ b/packages/conventional-changelog-eslint/package.json
@@ -18,6 +18,9 @@
     "preset"
   ],
   "author": "Steve Mao",
+  "engines": {
+    "node": ">=6.9.0"
+  },
   "license": "ISC",
   "files": [
     "conventional-changelog.js",

--- a/packages/conventional-changelog-express/package.json
+++ b/packages/conventional-changelog-express/package.json
@@ -18,6 +18,9 @@
     "preset"
   ],
   "author": "Steve Mao",
+  "engines": {
+    "node": ">=6.9.0"
+  },
   "license": "ISC",
   "files": [
     "conventional-changelog.js",

--- a/packages/conventional-changelog-jquery/package.json
+++ b/packages/conventional-changelog-jquery/package.json
@@ -18,6 +18,9 @@
     "preset"
   ],
   "author": "Steve Mao",
+  "engines": {
+    "node": ">=6.9.0"
+  },
   "license": "ISC",
   "files": [
     "conventional-changelog.js",

--- a/packages/conventional-changelog-jshint/package.json
+++ b/packages/conventional-changelog-jshint/package.json
@@ -18,6 +18,9 @@
     "preset"
   ],
   "author": "Steve Mao",
+  "engines": {
+    "node": ">=6.9.0"
+  },
   "license": "ISC",
   "files": [
     "conventional-changelog.js",

--- a/packages/conventional-changelog-preset-loader/package.json
+++ b/packages/conventional-changelog-preset-loader/package.json
@@ -12,6 +12,9 @@
     "loader"
   ],
   "license": "MIT",
+  "engines": {
+    "node": ">=6.9.0"
+  },
   "files": [
     "index.js"
   ],

--- a/packages/conventional-changelog-writer/package.json
+++ b/packages/conventional-changelog-writer/package.json
@@ -16,6 +16,9 @@
     "url": "https://github.com/conventional-changelog/conventional-changelog.git"
   },
   "license": "MIT",
+  "engines": {
+    "node": ">=6.9.0"
+  },
   "files": [
     "index.js",
     "cli.js",

--- a/packages/conventional-changelog/package.json
+++ b/packages/conventional-changelog/package.json
@@ -12,6 +12,9 @@
     "changelog",
     "log"
   ],
+  "engines": {
+    "node": ">=6.9.0"
+  },
   "license": "MIT",
   "files": [
     "index.js"

--- a/packages/conventional-commits-filter/package.json
+++ b/packages/conventional-commits-filter/package.json
@@ -15,6 +15,9 @@
     "email": "maochenyan@gmail.com",
     "url": "https://github.com/stevemao"
   },
+  "engines": {
+    "node": ">=6.9.0"
+  },
   "files": [
     "index.js"
   ],

--- a/packages/conventional-commits-parser/package.json
+++ b/packages/conventional-commits-parser/package.json
@@ -16,6 +16,9 @@
     "url": "https://github.com/conventional-changelog/conventional-changelog.git"
   },
   "license": "MIT",
+  "engines": {
+    "node": ">=6.9.0"
+  },
   "files": [
     "index.js",
     "cli.js",

--- a/packages/conventional-recommended-bump/package.json
+++ b/packages/conventional-recommended-bump/package.json
@@ -16,6 +16,9 @@
     "url": "https://github.com/conventional-changelog/conventional-changelog.git"
   },
   "license": "MIT",
+  "engines": {
+    "node": ">=6.9.0"
+  },
   "files": [
     "index.js",
     "cli.js",

--- a/packages/git-raw-commits/package.json
+++ b/packages/git-raw-commits/package.json
@@ -16,6 +16,9 @@
     "url": "https://github.com/conventional-changelog/conventional-changelog.git"
   },
   "license": "MIT",
+  "engines": {
+    "node": ">=6.9.0"
+  },
   "files": [
     "index.js",
     "cli.js"

--- a/packages/git-semver-tags/package.json
+++ b/packages/git-semver-tags/package.json
@@ -16,6 +16,9 @@
     "url": "https://github.com/conventional-changelog/conventional-changelog.git"
   },
   "license": "MIT",
+  "engines": {
+    "node": ">=6.9.0"
+  },
   "files": [
     "index.js",
     "cli.js"

--- a/packages/gulp-conventional-changelog/package.json
+++ b/packages/gulp-conventional-changelog/package.json
@@ -17,7 +17,7 @@
     "url": "https://github.com/stevemao"
   },
   "engines": {
-    "node": ">=0.10.0"
+    "node": ">=6.9.0"
   },
   "scripts": {
     "lint": "eslint --fix .",

--- a/packages/standard-changelog/package.json
+++ b/packages/standard-changelog/package.json
@@ -18,6 +18,9 @@
     "log"
   ],
   "license": "MIT",
+  "engines": {
+    "node": ">=6.9.0"
+  },
   "files": [
     "index.js",
     "cli.js"


### PR DESCRIPTION
BREAKING CHANGE:

Set the package's minimum required Node version to be the oldest LTS
currently supported by the Node Release working group. At this time,
that is Node 6 (which is in its Maintenance LTS phase).