### PR TITLE
feat(preset): Angular style changelog preset for VSTS

### DIFF
--- a/packages/conventional-changelog-angular-vsts/LICENSE.md
+++ b/packages/conventional-changelog-angular-vsts/LICENSE.md
@@ -1,0 +1,15 @@
+### ISC License
+
+Copyright © [conventional-changelog team](https://github.com/conventional-changelog)
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND
+FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+PERFORMANCE OF THIS SOFTWARE. 

--- a/packages/conventional-changelog-angular-vsts/README.md
+++ b/packages/conventional-changelog-angular-vsts/README.md
@@ -1,0 +1,103 @@
+# [![NPM version][npm-image]][npm-url] [![Build Status][travis-image]][travis-url] [![Dependency Status][daviddm-image]][daviddm-url] [![Coverage Status][coveralls-image]][coveralls-url]
+
+> [conventional-changelog](https://github.com/ajoslin/conventional-changelog) [angular](https://github.com/angular/angular) preset
+
+**Issues with the convention itself should be reported on the Angular issue tracker.**
+
+## Angular Convention
+
+Angular's [commit message guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit).
+
+### Examples
+
+Appears under "Features" header, pencil subheader:
+
+```
+feat(pencil): add 'graphiteWidth' option
+```
+
+Appears under "Bug Fixes" header, graphite subheader, with a link to issue #28:
+
+```
+fix(graphite): stop graphite breaking when width < 0.1
+
+Closes #28
+```
+
+Appears under "Performance Improvements" header, and under "Breaking Changes" with the breaking change explanation:
+
+```
+perf(pencil): remove graphiteWidth option
+
+BREAKING CHANGE: The graphiteWidth option has been removed. The default graphite width of 10mm is always used for performance reason.
+```
+
+The following commit and commit `667ecc1` do not appear in the changelog if they are under the same release. If not, the revert commit appears under the "Reverts" header.
+
+```
+revert: feat(pencil): add 'graphiteWidth' option
+
+This reverts commit 667ecc1654a317a13331b17617d973392f415f02.
+```
+
+### Commit Message Format
+
+A commit message consists of a **header**, **body** and **footer**.  The header has a **type**, **scope** and **subject**:
+
+```
+<type>(<scope>): <subject>
+<BLANK LINE>
+<body>
+<BLANK LINE>
+<footer>
+```
+
+The **header** is mandatory and the **scope** of the header is optional.
+
+### Revert
+
+If the commit reverts a previous commit, it should begin with `revert: `, followed by the header of the reverted commit. In the body it should say: `This reverts commit <hash>.`, where the hash is the SHA of the commit being reverted.
+
+### Type
+
+If the prefix is `feat`, `fix` or `perf`, it will appear in the changelog. However if there is any [BREAKING CHANGE](#footer), the commit will always appear in the changelog.
+
+Other prefixes are up to your discretion. Suggested prefixes are `build`, `ci`, `docs` ,`style`, `refactor`, and `test` for non-changelog related tasks.
+
+Details regarding these types can be found in the official [Angular Contributing Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#type)
+
+### Scope
+
+The scope could be anything specifying place of the commit change. For example `$location`,
+`$browser`, `$compile`, `$rootScope`, `ngHref`, `ngClick`, `ngView`, etc...
+
+### Subject
+
+The subject contains succinct description of the change:
+
+* use the imperative, present tense: "change" not "changed" nor "changes"
+* don't capitalize first letter
+* no dot (.) at the end
+
+### Body
+
+Just as in the **subject**, use the imperative, present tense: "change" not "changed" nor "changes".
+The body should include the motivation for the change and contrast this with previous behavior.
+
+### Footer
+
+The footer should contain any information about **Breaking Changes** and is also the place to
+reference GitHub issues that this commit **Closes**.
+
+**Breaking Changes** should start with the word `BREAKING CHANGE:` with a space or two newlines. The rest of the commit message is then used for this.
+
+A detailed explanation can be found in this [document][commit-message-format].
+
+[npm-image]: https://badge.fury.io/js/conventional-changelog-angular.svg
+[npm-url]: https://npmjs.org/package/conventional-changelog-angular
+[travis-image]: https://travis-ci.org/conventional-changelog/conventional-changelog-angular.svg?branch=master
+[travis-url]: https://travis-ci.org/conventional-changelog/conventional-changelog-angular
+[daviddm-image]: https://david-dm.org/conventional-changelog/conventional-changelog-angular.svg?theme=shields.io
+[daviddm-url]: https://david-dm.org/conventional-changelog/conventional-changelog-angular
+[coveralls-image]: https://coveralls.io/repos/conventional-changelog/conventional-changelog-angular/badge.svg
+[coveralls-url]: https://coveralls.io/r/conventional-changelog/conventional-changelog-angular

--- a/packages/conventional-changelog-angular-vsts/conventional-changelog.js
+++ b/packages/conventional-changelog-angular-vsts/conventional-changelog.js
@@ -1,0 +1,10 @@
+'use strict'
+
+const Q = require(`q`)
+const parserOpts = require(`./parser-opts`)
+const writerOpts = require(`./writer-opts`)
+
+module.exports = Q.all([parserOpts, writerOpts])
+  .spread((parserOpts, writerOpts) => {
+    return {parserOpts, writerOpts}
+  })

--- a/packages/conventional-changelog-angular-vsts/conventional-recommended-bump.js
+++ b/packages/conventional-changelog-angular-vsts/conventional-recommended-bump.js
@@ -1,0 +1,40 @@
+'use strict'
+
+module.exports = {
+  whatBump: (commits) => {
+    let level = 2
+    let breakings = 0
+    let features = 0
+
+    commits.forEach(commit => {
+      if (commit.notes.length > 0) {
+        breakings += commit.notes.length
+        level = 0
+      } else if (commit.type === `feat`) {
+        features += 1
+        if (level === 2) {
+          level = 1
+        }
+      }
+    })
+
+    return {
+      level: level,
+      reason: breakings === 1
+        ? `There are ${breakings} BREAKING CHANGE and ${features} features`
+        : `There are ${breakings} BREAKING CHANGES and ${features} features`
+    }
+  },
+
+  parserOpts: {
+    headerPattern: /^(\w*)(?:\((.*)\))?: (.*)$/,
+    headerCorrespondence: [
+      `type`,
+      `scope`,
+      `subject`
+    ],
+    noteKeywords: `BREAKING CHANGE`,
+    revertPattern: /^revert:\s([\s\S]*?)\s*This reverts commit (\w*)\./,
+    revertCorrespondence: [`header`, `hash`]
+  }
+}

--- a/packages/conventional-changelog-angular-vsts/index.js
+++ b/packages/conventional-changelog-angular-vsts/index.js
@@ -1,0 +1,11 @@
+'use strict'
+const Q = require(`q`)
+const conventionalChangelog = require(`./conventional-changelog`)
+const parserOpts = require(`./parser-opts`)
+const recommendedBumpOpts = require(`./conventional-recommended-bump`)
+const writerOpts = require(`./writer-opts`)
+
+module.exports = Q.all([conventionalChangelog, parserOpts, recommendedBumpOpts, writerOpts])
+  .spread((conventionalChangelog, parserOpts, recommendedBumpOpts, writerOpts) => {
+    return {conventionalChangelog, parserOpts, recommendedBumpOpts, writerOpts}
+  })

--- a/packages/conventional-changelog-angular-vsts/package.json
+++ b/packages/conventional-changelog-angular-vsts/package.json
@@ -1,0 +1,48 @@
+{
+  "name": "conventional-changelog-angular-vsts",
+  "version": "4.0.0",
+  "description": "conventional-changelog angular preset for vsts",
+  "main": "index.js",
+  "scripts": {
+    "lint": "eslint --fix .",
+    "test": "mocha --timeout 30000 && npm run-script lint",
+    "test-windows": "mocha --timeout 30000"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/conventional-changelog/conventional-changelog.git"
+  },
+  "keywords": [
+    "conventional-changelog",
+    "angular",
+    "preset"
+  ],
+  "files": [
+    "conventional-changelog.js",
+    "conventional-recommended-bump.js",
+    "index.js",
+    "parser-opts.js",
+    "writer-opts.js",
+    "templates"
+  ],
+  "author": "Steve Mao",
+  "engines": {
+    "node": ">=6.9.0"
+  },
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/conventional-changelog/conventional-changelog/issues"
+  },
+  "homepage": "https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-angular#readme",
+  "devDependencies": {
+    "better-than-before": "^1.0.0",
+    "conventional-changelog-core": "^3.0.0",
+    "git-dummy-commit": "^1.2.0",
+    "shelljs": "^0.8.0",
+    "through2": "^2.0.0"
+  },
+  "dependencies": {
+    "compare-func": "^1.3.1",
+    "q": "^1.5.1"
+  }
+}

--- a/packages/conventional-changelog-angular-vsts/parser-opts.js
+++ b/packages/conventional-changelog-angular-vsts/parser-opts.js
@@ -1,0 +1,13 @@
+'use strict'
+
+module.exports = {
+  headerPattern: /^(\w*)(?:\((.*)\))?: (.*)$/,
+  headerCorrespondence: [
+    `type`,
+    `scope`,
+    `subject`
+  ],
+  noteKeywords: [`BREAKING CHANGE`],
+  revertPattern: /^revert:\s([\s\S]*?)\s*This reverts commit (\w*)\./,
+  revertCorrespondence: [`header`, `hash`]
+}

--- a/packages/conventional-changelog-angular-vsts/templates/commit.hbs
+++ b/packages/conventional-changelog-angular-vsts/templates/commit.hbs
@@ -1,0 +1,59 @@
+*{{#if scope}} **{{scope}}:**
+{{~/if}} {{#if subject}}
+  {{~subject}}
+{{~else}}
+  {{~header}}
+{{~/if}}
+
+{{~!-- commit link --}} {{#if @root.linkReferences~}}
+  ([{{hash}}](
+  {{~#if @root.repository}}
+    {{~#if @root.host}}
+      {{~@root.host}}/
+    {{~/if}}
+    {{~#if @root.owner}}
+      {{~@root.owner}}/
+    {{~/if}}
+    {{~@root.repository}}
+  {{~else}}
+    {{~@root.repoUrl}}
+  {{~/if}}/
+  {{~@root.commit}}/{{hash}}))
+{{~else}}
+  {{~hash}}
+{{~/if}}
+
+{{~!-- commit references --}}
+{{~#if references~}}
+  , closes
+  {{~#each references}} {{#if @root.linkReferences~}}
+    [
+    {{~#if this.owner}}
+      {{~this.owner}}/
+    {{~/if}}
+    {{~this.repository}}#{{this.issue}}](
+    {{~#if @root.repository}}
+      {{~#if @root.host}}
+        {{~@root.host}}/
+      {{~/if}}
+      {{~#if this.repository}}
+        {{~#if this.owner}}
+          {{~this.owner}}
+        {{~/if}}
+      {{~else}}
+        {{~#if @root.owner}}
+          {{~@root.owner}}
+        {{~/if}}
+        {{~/if}}
+    {{~else}}
+      {{~@root.repoUrl}}
+    {{~/if}}/
+    {{~@root.issue}}/{{this.issue}})
+  {{~else}}
+    {{~#if this.owner}}
+      {{~this.owner}}/
+    {{~/if}}
+    {{~this.repository}}#{{this.issue}}
+  {{~/if}}{{/each}}
+{{~/if}}
+

--- a/packages/conventional-changelog-angular-vsts/templates/footer.hbs
+++ b/packages/conventional-changelog-angular-vsts/templates/footer.hbs
@@ -1,0 +1,11 @@
+{{#if noteGroups}}
+{{#each noteGroups}}
+
+### {{title}}
+
+{{#each notes}}
+* {{#if commit.scope}}**{{commit.scope}}:** {{/if}}{{text}}
+{{/each}}
+{{/each}}
+
+{{/if}}

--- a/packages/conventional-changelog-angular-vsts/templates/header.hbs
+++ b/packages/conventional-changelog-angular-vsts/templates/header.hbs
@@ -1,0 +1,25 @@
+{{#if isPatch~}}
+  ##
+{{~else~}}
+  #
+{{~/if}} {{#if @root.linkCompare~}}
+  [{{version}}](
+  {{~#if @root.repository~}}
+    {{~#if @root.host}}
+      {{~@root.host}}/
+    {{~/if}}
+    {{~#if @root.owner}}
+      {{~@root.owner}}/
+    {{~/if}}
+    {{~@root.repository}}
+  {{~else}}
+    {{~@root.repoUrl}}
+  {{~/if~}}
+  /branches?_a=commits&baseVersion=GT{{previiousTag}}&targetVersion=GT{{currentTag}}
+{{~else}}
+  {{~version}}
+{{~/if}}
+{{~#if title}} "{{title}}"
+{{~/if}}
+{{~#if date}} ({{date}})
+{{/if}}

--- a/packages/conventional-changelog-angular-vsts/templates/template.hbs
+++ b/packages/conventional-changelog-angular-vsts/templates/template.hbs
@@ -1,0 +1,16 @@
+{{> header}}
+
+{{#each commitGroups}}
+
+{{#if title}}
+### {{title}}
+
+{{/if}}
+{{#each commits}}
+{{> commit root=@root}}
+{{/each}}
+
+{{/each}}
+{{> footer}}
+
+

--- a/packages/conventional-changelog-angular-vsts/test/fixtures/_custom-host.json
+++ b/packages/conventional-changelog-angular-vsts/test/fixtures/_custom-host.json
@@ -1,0 +1,4 @@
+{
+  "version": "v3.0.0",
+  "repository": "https://custom.visualstudio.com/conventional-changelog/custom"
+}

--- a/packages/conventional-changelog-angular-vsts/test/fixtures/_known-host.json
+++ b/packages/conventional-changelog-angular-vsts/test/fixtures/_known-host.json
@@ -1,0 +1,4 @@
+{
+  "version": "v2.0.0",
+  "repository": "https://visualstudio.com/conventional-changelog/example"
+}

--- a/packages/conventional-changelog-angular-vsts/test/fixtures/_unknown-host.json
+++ b/packages/conventional-changelog-angular-vsts/test/fixtures/_unknown-host.json
@@ -1,0 +1,4 @@
+{
+  "repository": "unknown",
+  "version": "v2.0.0"
+}

--- a/packages/conventional-changelog-angular-vsts/test/test.js
+++ b/packages/conventional-changelog-angular-vsts/test/test.js
@@ -1,0 +1,291 @@
+'use strict'
+var conventionalChangelogCore = require('conventional-changelog-core')
+var preset = require('../')
+var expect = require('chai').expect
+var mocha = require('mocha')
+var describe = mocha.describe
+var it = mocha.it
+var gitDummyCommit = require('git-dummy-commit')
+var shell = require('shelljs')
+var through = require('through2')
+var path = require('path')
+var betterThanBefore = require('better-than-before')()
+var preparing = betterThanBefore.preparing
+var writeFileSync = require('fs').writeFileSync
+
+betterThanBefore.setups([
+  function () {
+    shell.config.silent = true
+    shell.rm('-rf', 'tmp')
+    shell.mkdir('tmp')
+    shell.cd('tmp')
+    shell.mkdir('git-templates')
+    shell.exec('git init --template=./git-templates')
+    writeFileSync('package.json', '{ "name": "conventional-changelog-core", "repository": { "type": "git", "url": "https://visualstudio.com/conventional-changelog/conventional-changelog.git" } }')
+
+    gitDummyCommit(['build: first build setup', 'BREAKING CHANGE: New build system.'])
+    gitDummyCommit(['ci(travis): add TravisCI pipeline', 'BREAKING CHANGE: Continuously integrated.'])
+    gitDummyCommit(['feat: amazing new module', 'BREAKING CHANGE: Not backward compatible.'])
+    gitDummyCommit(['fix(compile): avoid a bug', 'BREAKING CHANGE: The Change is huge.'])
+    gitDummyCommit(['perf(ngOptions): make it faster', ' closes #1, #2'])
+    gitDummyCommit('revert(ngOptions): bad commit')
+    gitDummyCommit('fix(*): oops')
+  },
+  function () {
+    gitDummyCommit(['feat(awesome): addresses the issue brought up in #133'])
+  },
+  function () {
+    gitDummyCommit(['feat(awesome): fix #88'])
+  },
+  function () {
+    gitDummyCommit(['feat(awesome): issue brought up by @bcoe! on Friday'])
+  },
+  function () {
+    gitDummyCommit(['build(npm): edit build script', 'BREAKING CHANGE: The Change is huge.'])
+    gitDummyCommit(['ci(travis): setup travis', 'BREAKING CHANGE: The Change is huge.'])
+    gitDummyCommit(['docs(readme): make it clear', 'BREAKING CHANGE: The Change is huge.'])
+    gitDummyCommit(['style(whitespace): make it easier to read', 'BREAKING CHANGE: The Change is huge.'])
+    gitDummyCommit(['refactor(code): change a lot of code', 'BREAKING CHANGE: The Change is huge.'])
+    gitDummyCommit(['test(*): more tests', 'BREAKING CHANGE: The Change is huge.'])
+  },
+  function () {
+    shell.exec('git tag v1.0.0')
+    gitDummyCommit('feat: some more features')
+  },
+  function () {
+    gitDummyCommit(['feat(*): implementing #5 by @dlmr', ' closes #10'])
+  },
+  function () {
+    gitDummyCommit(['fix: use npm@5 (@username)'])
+  }
+])
+
+describe('angular preset for vsts', function () {
+  it('should work if there is no semver tag', function (done) {
+    preparing(1)
+
+    conventionalChangelogCore({
+      config: preset
+    })
+      .on('error', function (err) {
+        done(err)
+      })
+      .pipe(through(function (chunk) {
+        chunk = chunk.toString()
+
+        expect(chunk).to.include('first build setup')
+        expect(chunk).to.include('**travis:** add TravisCI pipeline')
+        expect(chunk).to.include('**travis:** Continuously integrated.')
+        expect(chunk).to.include('amazing new module')
+        expect(chunk).to.include('**compile:** avoid a bug')
+        expect(chunk).to.include('make it faster')
+        expect(chunk).to.include(', closes [#1](https://visualstudio.com/conventional-changelog/_workitems/edit/1) [#2](https://visualstudio.com/conventional-changelog/_workitems/edit/2)')
+        expect(chunk).to.include('New build system.')
+        expect(chunk).to.include('Not backward compatible.')
+        expect(chunk).to.include('**compile:** The Change is huge.')
+        expect(chunk).to.include('Build System')
+        expect(chunk).to.include('Continuous Integration')
+        expect(chunk).to.include('Features')
+        expect(chunk).to.include('Bug Fixes')
+        expect(chunk).to.include('Performance Improvements')
+        expect(chunk).to.include('Reverts')
+        expect(chunk).to.include('bad commit')
+        expect(chunk).to.include('BREAKING CHANGE')
+
+        expect(chunk).to.not.include('ci')
+        expect(chunk).to.not.include('feat')
+        expect(chunk).to.not.include('fix')
+        expect(chunk).to.not.include('perf')
+        expect(chunk).to.not.include('revert')
+        expect(chunk).to.not.include('***:**')
+        expect(chunk).to.not.include(': Not backward compatible.')
+
+        done()
+      }))
+  })
+
+  it('should replace #[0-9]+ with GitHub issue URL', function (done) {
+    preparing(2)
+
+    conventionalChangelogCore({
+      config: preset
+    })
+      .on('error', function (err) {
+        done(err)
+      })
+      .pipe(through(function (chunk) {
+        chunk = chunk.toString()
+        expect(chunk).to.include('[#133](https://visualstudio.com/conventional-changelog/_workitems/edit/133)')
+        done()
+      }))
+  })
+
+  it('should remove the issues that already appear in the subject', function (done) {
+    preparing(3)
+
+    conventionalChangelogCore({
+      config: preset
+    })
+      .on('error', function (err) {
+        done(err)
+      })
+      .pipe(through(function (chunk) {
+        chunk = chunk.toString()
+        expect(chunk).to.include('[#88](https://visualstudio.com/conventional-changelog/_workitems/edit/88)')
+        expect(chunk).to.not.include('closes [#88](https://visualstudio.com/conventional-changelog/_workitems/edit/88)')
+        done()
+      }))
+  })
+
+  it('should not discard commit if there is BREAKING CHANGE', function (done) {
+    preparing(5)
+
+    conventionalChangelogCore({
+      config: preset
+    })
+      .on('error', function (err) {
+        done(err)
+      })
+      .pipe(through(function (chunk) {
+        chunk = chunk.toString()
+
+        expect(chunk).to.include('Continuous Integration')
+        expect(chunk).to.include('Build System')
+        expect(chunk).to.include('Documentation')
+        expect(chunk).to.include('Styles')
+        expect(chunk).to.include('Code Refactoring')
+        expect(chunk).to.include('Tests')
+
+        done()
+      }))
+  })
+
+  it('should work if there is a semver tag', function (done) {
+    preparing(6)
+    var i = 0
+
+    conventionalChangelogCore({
+      config: preset,
+      outputUnreleased: true
+    })
+      .on('error', function (err) {
+        done(err)
+      })
+      .pipe(through(function (chunk, enc, cb) {
+        chunk = chunk.toString()
+
+        expect(chunk).to.include('some more features')
+        expect(chunk).to.not.include('BREAKING')
+
+        i++
+        cb()
+      }, function () {
+        expect(i).to.equal(1)
+        done()
+      }))
+  })
+
+  it('should work with unknown host', function (done) {
+    preparing(6)
+    var i = 0
+
+    conventionalChangelogCore({
+      config: preset,
+      pkg: {
+        path: path.join(__dirname, 'fixtures/_unknown-host.json')
+      }
+    })
+      .on('error', function (err) {
+        done(err)
+      })
+      .pipe(through(function (chunk, enc, cb) {
+        chunk = chunk.toString()
+
+        expect(chunk).to.include('(http://unknown/branches')
+        expect(chunk).to.include('](http://unknown/commits/')
+
+        i++
+        cb()
+      }, function () {
+        expect(i).to.equal(1)
+        done()
+      }))
+  })
+
+  it('should work specifying where to find a package.json using conventional-changelog-core', function (done) {
+    preparing(7)
+    var i = 0
+
+    conventionalChangelogCore({
+      config: preset,
+      pkg: {
+        path: path.join(__dirname, 'fixtures/_known-host.json')
+      }
+    })
+      .on('error', function (err) {
+        done(err)
+      })
+      .pipe(through(function (chunk, enc, cb) {
+        chunk = chunk.toString()
+
+        expect(chunk).to.include('(https://visualstudio.com/conventional-changelog/example/branches')
+        expect(chunk).to.include('](https://visualstudio.com/conventional-changelog/example/commit/')
+        expect(chunk).to.include('](https://visualstudio.com/conventional-changelog/_workitems/edit/')
+
+        i++
+        cb()
+      }, function () {
+        expect(i).to.equal(1)
+        done()
+      }))
+  })
+
+  it('should fallback to the closest package.json when not providing a location for a package.json', function (done) {
+    preparing(7)
+    var i = 0
+
+    conventionalChangelogCore({
+      config: preset
+    })
+      .on('error', function (err) {
+        done(err)
+      })
+      .pipe(through(function (chunk, enc, cb) {
+        chunk = chunk.toString()
+
+        expect(chunk).to.include('(https://visualstudio.com/conventional-changelog/conventional-changelog/branches')
+        expect(chunk).to.include('](https://visualstudio.com/conventional-changelog/conventional-changelog/commit/')
+        expect(chunk).to.include('](https://visualstudio.com/conventional-changelog/_workitems/edit/')
+
+        i++
+        cb()
+      }, function () {
+        expect(i).to.equal(1)
+        done()
+      }))
+  })
+
+  it('should support non custom visualstudio host repository locations', function (done) {
+    preparing(7)
+
+    conventionalChangelogCore({
+      config: preset,
+      pkg: {
+        path: path.join(__dirname, 'fixtures/_custom-host.json')
+      }
+    })
+      .on('error', function (err) {
+        done(err)
+      })
+      .pipe(through(function (chunk) {
+        chunk = chunk.toString()
+
+        expect(chunk).to.include('(https://custom.visualstudio.com/conventional-changelog/custom/branches')
+        expect(chunk).to.include('](https://custom.visualstudio.com/conventional-changelog/custom/commit/')
+        expect(chunk).to.include('5](https://custom.visualstudio.com/conventional-changelog/_workitems/edit/5')
+        expect(chunk).to.include(' closes [#10](https://custom.visualstudio.com/conventional-changelog/_workitems/edit/10)')
+
+        done()
+      }))
+  })
+})

--- a/packages/conventional-changelog-angular-vsts/writer-opts.js
+++ b/packages/conventional-changelog-angular-vsts/writer-opts.js
@@ -1,0 +1,95 @@
+'use strict'
+
+const compareFunc = require(`compare-func`)
+const Q = require(`q`)
+const readFile = Q.denodeify(require(`fs`).readFile)
+const resolve = require(`path`).resolve
+
+module.exports = Q.all([
+  readFile(resolve(__dirname, `./templates/template.hbs`), `utf-8`),
+  readFile(resolve(__dirname, `./templates/header.hbs`), `utf-8`),
+  readFile(resolve(__dirname, `./templates/commit.hbs`), `utf-8`),
+  readFile(resolve(__dirname, `./templates/footer.hbs`), `utf-8`)
+])
+  .spread((template, header, commit, footer) => {
+    const writerOpts = getWriterOpts()
+
+    writerOpts.mainTemplate = template
+    writerOpts.headerPartial = header
+    writerOpts.commitPartial = commit
+    writerOpts.footerPartial = footer
+
+    return writerOpts
+  })
+
+function getWriterOpts () {
+  return {
+    transform: (commit, context) => {
+      let discard = true
+      const issues = []
+
+      commit.notes.forEach(note => {
+        note.title = `BREAKING CHANGES`
+        discard = false
+      })
+
+      if (commit.type === `feat`) {
+        commit.type = `Features`
+      } else if (commit.type === `fix`) {
+        commit.type = `Bug Fixes`
+      } else if (commit.type === `perf`) {
+        commit.type = `Performance Improvements`
+      } else if (commit.type === `revert`) {
+        commit.type = `Reverts`
+      } else if (discard) {
+        return
+      } else if (commit.type === `docs`) {
+        commit.type = `Documentation`
+      } else if (commit.type === `style`) {
+        commit.type = `Styles`
+      } else if (commit.type === `refactor`) {
+        commit.type = `Code Refactoring`
+      } else if (commit.type === `test`) {
+        commit.type = `Tests`
+      } else if (commit.type === `build`) {
+        commit.type = `Build System`
+      } else if (commit.type === `ci`) {
+        commit.type = `Continuous Integration`
+      }
+
+      if (commit.scope === `*`) {
+        commit.scope = ``
+      }
+
+      if (typeof commit.subject === `string`) {
+        let url = context.repository
+          ? `${context.host}/${context.owner}`
+          : context.repoUrl
+        if (url) {
+          url = `${url}/${context.issue}/`
+          // Issue URLs.
+          commit.subject = commit.subject.replace(/#([0-9]+)/g, (_, issue) => {
+            issues.push(issue)
+            return `[#${issue}](${url}${issue})`
+          })
+        }
+      }
+
+      // remove references that already appear in the subject
+      commit.references = commit.references.filter(reference => {
+        if (issues.indexOf(reference.issue) === -1) {
+          return true
+        }
+
+        return false
+      })
+
+      return commit
+    },
+    groupBy: `type`,
+    commitGroupsSort: `title`,
+    commitsSort: [`scope`, `subject`],
+    noteGroupsSort: `title`,
+    notesSort: compareFunc
+  }
+}

--- a/packages/conventional-changelog-core/hosts/visualstudio.json
+++ b/packages/conventional-changelog-core/hosts/visualstudio.json
@@ -1,0 +1,18 @@
+{
+ "issue": "_workitems/edit",
+ "commit": "commit",
+ "referenceActions": [
+   "close",
+   "closes",
+   "closed",
+   "fix",
+   "fixes",
+   "fixed",
+   "resolve",
+   "resolves",
+   "resolved"
+ ],
+ "issuePrefixes": [
+   "#"
+ ]
+}

--- a/packages/conventional-changelog-core/lib/merge-config.js
+++ b/packages/conventional-changelog-core/lib/merge-config.js
@@ -17,7 +17,7 @@ var readPkgUp = require('read-pkg-up')
 var url = require('url')
 var _ = require('lodash')
 
-var rhosts = /github|bitbucket|gitlab/i
+var rhosts = /github|bitbucket|gitlab|visualstudio/i
 var rtag = /tag:\s*[v=]?(.+?)[,)]/gi
 
 function semverTagsPromise (options) {

--- a/packages/conventional-changelog-core/test/test.js
+++ b/packages/conventional-changelog-core/test/test.js
@@ -500,6 +500,23 @@ describe('conventionalChangelogCore', function () {
     }))
   })
 
+  it('should read visualstudio\'s host configs', function (done) {
+    preparing(5)
+
+    conventionalChangelogCore({}, {
+      host: 'visualstudio',
+      owner: 'b',
+      repository: 'a'
+    }, {}, {}).pipe(through(function (chunk) {
+      chunk = chunk.toString()
+
+      expect(chunk).to.include('](visualstudio/b/a/commit/')
+      expect(chunk).to.include('closes [#1](visualstudio/b/a/_workitems/edit/1)')
+
+      done()
+    }))
+  })
+
   it('should transform the commit', function (done) {
     preparing(5)
 


### PR DESCRIPTION
Initial version (fork preset and modify to work)

differences from the default Angular preset:
- issue links take the format of `host/owner/_workitems/edit/{{issue}}` (issues don't live at the repo level)
- compare links take the format of `/branches?_a=commits&baseVersion=GT{{previiousTag}}&targetVersion=GT{{currentTag}}`
- @user mention support removed (no equivalent profile links on vsts that I can find)
