### PR TITLE
fix(cli): pass `--tag-prefix` option to core

### DIFF
--- a/packages/conventional-changelog-cli/cli.js
+++ b/packages/conventional-changelog-cli/cli.js
@@ -47,6 +47,7 @@ var cli = meow(`
 
       -c, --context             A filepath of a json that is used to define template variables
       -l, --lerna-package       Generate a changelog for a specific lerna package (:pkg-name@1.0.0)
+      -t, --tag-prefix          Tag prefix to consider when reading the tags
       --commit-path             Generate a changelog scoped to a specific directory
 `, {
   flags: {
@@ -82,6 +83,9 @@ var cli = meow(`
     },
     'lerna-package': {
       alias: `l`
+    },
+    'tag-prefix': {
+      alias: `t`
     }
   }
 })
@@ -113,7 +117,8 @@ var options = _.omit({
   append: append,
   releaseCount: releaseCount,
   outputUnreleased: flags.outputUnreleased,
-  lernaPackage: flags.lernaPackage
+  lernaPackage: flags.lernaPackage,
+  tagPrefix: flags.tagPrefix
 }, _.isUndefined)
 
 if (flags.verbose) {


### PR DESCRIPTION
closes #337 

I did not found any contribution guide to this repo. Are there any intorduction on how to test this on my local machine? I just copied the parts from `lerna-package` as they should work the same way.