### PR TITLE
fix(preset): ESLint recommended-bump is always "patch"

### DIFF
--- a/packages/conventional-changelog-eslint/conventional-recommended-bump.js
+++ b/packages/conventional-changelog-eslint/conventional-recommended-bump.js
@@ -11,14 +11,12 @@ module.exports = {
     let features = 0
 
     commits.forEach(commit => {
-      if (!commit.type) {
-        return
-      }
+      if (!commit.tag) return
 
-      if (commit.type.toLowerCase() === 'breaking') {
+      if (commit.tag.toLowerCase() === 'breaking') {
         breakings += 1
         level = 0
-      } else if (commit.type.toLowerCase() === 'new') {
+      } else if (commit.tag.toLowerCase() === 'new') {
         features += 1
         if (level === 2) {
           level = 1


### PR DESCRIPTION
Recommended version bump detection with ESLint preset is broken since
`conventional-changelog-eslint` version 3.0.0:

`npx conventional-recommended-bump -p eslint` always returns "patch".

This is because the preset's `parserOpts` (re-used with v3.0.0)
"headerCorrespondence" is set to `['tag', 'message']` rather than
`['type', 'subject']`, which was used before in the [ESLint preset
"conventional-recommended-bump" specific `parserOpts`][1].

This adapts the ESLint preset's `whatBump` implementation to check "tag"
instead of "type", which fixes the issue.

[1]: https://github.com/conventional-changelog/conventional-changelog/blob/ce1fd981f88ce201e996dfa833e4682de3aafcdd/packages/conventional-changelog-eslint/conventional-recommended-bump.js#L32-L35