### PR TITLE
fix(filter): replace `is-subset` with `lodash.ismatch`

### DIFF
--- a/packages/conventional-commits-filter/index.js
+++ b/packages/conventional-commits-filter/index.js
@@ -1,6 +1,6 @@
 'use strict'
 
-var isSubset = require('is-subset')
+var isMatch = require('lodash.ismatch')
 var modifyValues = require('modify-values')
 
 function modifyValue (val) {
@@ -36,7 +36,7 @@ function conventionalCommitsFilter (commits) {
     ignores.some(function (ignoreCommit) {
       var ignore = modifyValues(ignoreCommit.revert, modifyValue)
 
-      ignoreThis = isSubset(commit, ignore)
+      ignoreThis = isMatch(commit, ignore)
 
       if (ignoreThis) {
         remove.push(ignoreCommit.hash)

--- a/packages/conventional-commits-filter/package.json
+++ b/packages/conventional-commits-filter/package.json
@@ -28,7 +28,7 @@
     "commits"
   ],
   "dependencies": {
-    "is-subset": "^0.1.1",
+    "lodash.ismatch": "^4.4.0",
     "modify-values": "^1.0.0"
   },
   "scripts": {


### PR DESCRIPTION
This replace [is-subset](https://github.com/studio-b12/is-subset) with [lodash.isMatch](https://lodash.com/docs/4.17.10#isMatch).

`is-subset` doesn't seems to be maintained anymore (last commit from October 2015) and it currently has a bug that prevent to use [pkg](https://github.com/zeit/pkg): https://github.com/studio-b12/is-subset/pull/9.

As a result any module that depends on `conventional-commits-filter` cannot be bundled with [pkg](https://github.com/zeit/pkg). 