### PR TITLE
fix(cli): fix issue to pass conventional-changelog standard options cli.js

### DIFF
--- a/packages/conventional-changelog-cli/cli.js
+++ b/packages/conventional-changelog-cli/cli.js
@@ -141,6 +141,7 @@ try {
   if (flags.config) {
     config = require(resolve(process.cwd(), flags.config))
     options.config = config
+    options = _.merge(options, config.options)
   } else {
     config = {}
   }


### PR DESCRIPTION
fix(cli.js): fix issue where standard conventional-changelog options are not passed into the options object using --config flag