### PR TITLE
[git-semver-tags]: BREAKING: switch params, make it normal node-style signature

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2007,7 +2007,6 @@
         "conventional-changelog-preset-loader": "file:packages/conventional-changelog-preset-loader",
         "conventional-commits-filter": "file:packages/conventional-commits-filter",
         "conventional-commits-parser": "file:packages/conventional-commits-parser",
-        "git-raw-commits": "file:packages/git-raw-commits",
         "git-semver-tags": "file:packages/git-semver-tags",
         "meow": "^4.0.0",
         "q": "^1.5.1"

--- a/packages/conventional-changelog-core/lib/merge-config.js
+++ b/packages/conventional-changelog-core/lib/merge-config.js
@@ -22,13 +22,13 @@ var rtag = /tag:\s*[v=]?(.+?)[,)]/gi
 
 function semverTagsPromise (options) {
   return Q.Promise(function (resolve, reject) {
-    gitSemverTags(function (err, result) {
+    gitSemverTags({ lernaTags: !!options.lernaPackage, package: options.lernaPackage, tagPrefix: options.tagPrefix }, function (err, result) {
       if (err) {
         reject(err)
       } else {
         resolve(result)
       }
-    }, { lernaTags: !!options.lernaPackage, package: options.lernaPackage, tagPrefix: options.tagPrefix })
+    })
   })
 }
 

--- a/packages/conventional-recommended-bump/index.js
+++ b/packages/conventional-recommended-bump/index.js
@@ -55,7 +55,11 @@ function conventionalRecommendedBump (optionsArgument, parserOptsArgument, cbArg
 
     const warn = typeof parserOpts.warn === `function` ? parserOpts.warn : noop
 
-    gitSemverTags((err, tags) => {
+    gitSemverTags({
+      lernaTags: !!options.lernaPackage,
+      package: options.lernaPackage,
+      tagPrefix: options.tagPrefix
+    }, (err, tags) => {
       if (err) {
         return cb(err)
       }
@@ -83,11 +87,6 @@ function conventionalRecommendedBump (optionsArgument, parserOptsArgument, cbArg
 
           cb(null, result)
         }))
-    },
-    {
-      lernaTags: !!options.lernaPackage,
-      package: options.lernaPackage,
-      tagPrefix: options.tagPrefix
     })
   }).catch(err => cb(err))
 }

--- a/packages/git-semver-tags/README.md
+++ b/packages/git-semver-tags/README.md
@@ -14,7 +14,9 @@ $ npm install --save git-semver-tags
 ## Usage
 
 ```js
-var gitSemverTags = require('git-semver-tags', [options]);
+var gitSemverTags = require('git-semver-tags');
+
+// gitSemverTags([options,] callback)
 
 gitSemverTags(function(err, tags) {
   console.log(tags);

--- a/packages/git-semver-tags/cli.js
+++ b/packages/git-semver-tags/cli.js
@@ -12,15 +12,15 @@ var args = meow(`
     --tagPrefix prefix to remove from the tags during their processing`
 )
 
-gitSemverTags(function (err, tags) {
+gitSemverTags({
+  lernaTags: args.flags.lerna,
+  package: args.flags.package,
+  tagPrefix: args.flags.tagPrefix
+}, function (err, tags) {
   if (err) {
     console.error(err.toString())
     process.exit(1)
   }
 
   console.log(tags.join('\n'))
-}, {
-  lernaTags: args.flags.lerna,
-  package: args.flags.package,
-  tagPrefix: args.flags.tagPrefix
 })

--- a/packages/git-semver-tags/cli.js
+++ b/packages/git-semver-tags/cli.js
@@ -7,9 +7,10 @@ var args = meow(`
   Usage
     git-semver-tags
   Options
-    --lerna parse lerna style git tags
-    --package when listing lerna style tags, filter by a package
-    --tagPrefix prefix to remove from the tags during their processing`
+    --cwd                  path to git repository to be searched
+    --lerna                parse lerna style git tags
+    --package <name>       when listing lerna style tags, filter by a package
+    --tagPrefix <prefix>   prefix to remove from the tags during their processing`
 )
 
 gitSemverTags({

--- a/packages/git-semver-tags/index.js
+++ b/packages/git-semver-tags/index.js
@@ -1,5 +1,6 @@
 'use strict'
 
+var proc = require('process')
 var exec = require('child_process').exec
 var semverValid = require('semver').valid
 var regex = /tag:\s*(.+?)[,)]/gi
@@ -13,22 +14,19 @@ function lernaTag (tag, pkg) {
   }
 }
 
-module.exports = function (opts, callback) {
+module.exports = function gitSemverTags (opts, callback) {
   if (typeof opts === 'function') {
     callback = opts
     opts = {}
   }
-  opts = opts || {}
+  var options = Object.assign({ maxBuffer: Infinity, cwd: proc.cwd() }, opts)
 
-  if (opts.package && !opts.lernaTags) {
-    callback(Error('opts.package should only be used when running in lerna mode'))
+  if (options.package && !options.lernaTags) {
+    callback(new Error('opts.package should only be used when running in lerna mode'))
     return
   }
 
-  exec(cmd, {
-    maxBuffer: Infinity
-    cwd: opts.cwd
-  }, function (err, data) {
+  exec(cmd, options, function (err, data) {
     if (err) {
       callback(err)
       return
@@ -36,18 +34,18 @@ module.exports = function (opts, callback) {
 
     var tags = []
     var tagPrefixRegexp
-    if (opts.tagPrefix) {
-      tagPrefixRegexp = new RegExp('^' + opts.tagPrefix + '(.*)')
+    if (options.tagPrefix) {
+      tagPrefixRegexp = new RegExp('^' + options.tagPrefix + '(.*)')
     }
     data.split('\n').forEach(function (decorations) {
       var match
       while ((match = regex.exec(decorations))) {
         var tag = match[1]
-        if (opts.lernaTags) {
-          if (lernaTag(tag, opts.package)) {
+        if (options.lernaTags) {
+          if (lernaTag(tag, options.package)) {
             tags.push(tag)
           }
-        } else if (opts.tagPrefix) {
+        } else if (options.tagPrefix) {
           var matches = tag.match(tagPrefixRegexp)
           if (matches && semverValid(matches[1])) {
             tags.push(tag)

--- a/packages/git-semver-tags/index.js
+++ b/packages/git-semver-tags/index.js
@@ -13,7 +13,11 @@ function lernaTag (tag, pkg) {
   }
 }
 
-module.exports = function (callback, opts) {
+module.exports = function (opts, callback) {
+  if (typeof opts === 'function') {
+    callback = opts
+    opts = {}
+  }
   opts = opts || {}
 
   if (opts.package && !opts.lernaTags) {
@@ -23,6 +27,7 @@ module.exports = function (callback, opts) {
 
   exec(cmd, {
     maxBuffer: Infinity
+    cwd: opts.cwd
   }, function (err, data) {
     if (err) {
       callback(err)

--- a/packages/git-semver-tags/test.js
+++ b/packages/git-semver-tags/test.js
@@ -1,4 +1,6 @@
 'use strict'
+
+var path = require('path')
 var assert = require('assert')
 var gitSemverTags = require('./')
 var mocha = require('mocha')
@@ -137,11 +139,11 @@ describe('git-semver-tags', function () {
     shell.exec('git add --all && git commit -m"seventh commit"')
     shell.exec('git tag foo-project@5.0.0')
 
-    gitSemverTags(function (err, tags) {
+    gitSemverTags({ lernaTags: true }, function (err, tags) {
       if (err) done(err)
       assert.deepStrictEqual(tags, ['foo-project@5.0.0', 'foo-project@4.0.0', 'blarg-project@1.0.0'])
       done()
-    }, { lernaTags: true })
+    })
   })
 
   it('should work with lerna style tags with multiple digits', function (done) {
@@ -153,11 +155,11 @@ describe('git-semver-tags', function () {
     shell.exec('git add --all && git commit -m"seventh commit"')
     shell.exec('git tag foobar-project@10.0.0')
 
-    gitSemverTags(function (err, tags) {
+    gitSemverTags({ lernaTags: true }, function (err, tags) {
       if (err) done(err)
       assert.deepStrictEqual(tags, ['foobar-project@10.0.0', 'foobar-project@0.10.0', 'foobar-project@0.0.10', 'foo-project@5.0.0', 'foo-project@4.0.0', 'blarg-project@1.0.0'])
       done()
-    }, { lernaTags: true })
+    })
   })
 
   it('should allow lerna style tags to be filtered by package', function (done) {
@@ -165,18 +167,18 @@ describe('git-semver-tags', function () {
     shell.exec('git add --all && git commit -m"seventh commit"')
     shell.exec('git tag bar-project@5.0.0')
 
-    gitSemverTags(function (err, tags) {
+    gitSemverTags({ lernaTags: true, package: 'bar-project' }, function (err, tags) {
       if (err) done(err)
       assert.deepStrictEqual(tags, ['bar-project@5.0.0'])
       done()
-    }, { lernaTags: true, package: 'bar-project' })
+    })
   })
 
   it('should not allow package filter without lernaTags=true', function (done) {
-    gitSemverTags(function (err) {
+    gitSemverTags({ package: 'bar-project' }, function (err) {
       assert.deepStrictEqual(err.message, 'opts.package should only be used when running in lerna mode')
       done()
-    }, { package: 'bar-project' })
+    })
   })
 
   it('should work with tag prefix option', function (done) {
@@ -188,11 +190,11 @@ describe('git-semver-tags', function () {
     shell.exec('git add --all && git commit -m"eleventh commit"')
     shell.exec('git tag notms/7.0.0')
 
-    gitSemverTags(function (err, tags) {
+    gitSemverTags({ tagPrefix: 'ms/' }, function (err, tags) {
       if (err) done(err)
       assert.deepStrictEqual(tags, ['ms/7.0.0', 'ms/6.0.0'])
       done()
-    }, { tagPrefix: 'ms/' })
+    })
   })
 })
 
@@ -211,7 +213,10 @@ describe('git semver tags on different cwd', function () {
     shell.exec('git add --all && git commit -m "First commit"')
     shell.exec('git tag v1.1.0')
 
-    gitSemverTags(function (err, tags) {
+    shell.cd('cd ' + path.join(__dirname, 'tmp'))
+
+    var cwd = path.join(__dirname, 'tmp', 'foobar')
+    gitSemverTags({ cwd: cwd }, function (err, tags) {
       if (err) done(err)
       assert.deepStrictEqual(tags, ['v1.1.0'])
       done()

--- a/packages/git-semver-tags/test.js
+++ b/packages/git-semver-tags/test.js
@@ -195,3 +195,26 @@ describe('git-semver-tags', function () {
     }, { tagPrefix: 'ms/' })
   })
 })
+
+describe('git semver tags on different cwd', function () {
+  it('getting semver tag on cwd', (done) => {
+    shell.config.resetForTesting()
+    shell.cd(__dirname)
+    shell.rm('-rf', 'tmp')
+    shell.mkdir('tmp')
+    shell.cd('tmp')
+    shell.mkdir('foobar')
+    shell.cd('foobar')
+    shell.exec('git init')
+
+    writeFileSync('test2', '')
+    shell.exec('git add --all && git commit -m "First commit"')
+    shell.exec('git tag v1.1.0')
+
+    gitSemverTags(function (err, tags) {
+      if (err) done(err)
+      assert.deepStrictEqual(tags, ['v1.1.0'])
+      done()
+    })
+  })
+})


### PR DESCRIPTION
e.g. `(opts, callback)`

Also, allow passing `opts.cwd` ... because it currently fails if you want to listen on another directory

Also. I would go with `Object.assign`, but was not sure for the require node version in CI.