### PR TITLE
fix(preset:angular): Scoped NPM packages are not seen as GitHub username anymore

### DIFF
--- a/packages/conventional-changelog-angular/test/test.js
+++ b/packages/conventional-changelog-angular/test/test.js
@@ -56,6 +56,7 @@ betterThanBefore.setups([
   },
   function () {
     gitDummyCommit(['fix: use npm@5 (@username)'])
+    gitDummyCommit(['build(deps): bump @dummy/package from 7.1.2 to 8.0.0', 'BREAKING CHANGE: The Change is huge.'])
   }
 ])
 
@@ -320,6 +321,8 @@ describe('angular preset', function () {
         expect(chunk).to.not.include('(https://github.com/5')
         expect(chunk).to.include('(https://github.com/username')
 
+        expect(chunk).to.not.include('[@dummy](https://github.com/dummy)/package')
+        expect(chunk).to.include('bump @dummy/package from')
         done()
       }))
   })

--- a/packages/conventional-changelog-angular/writer-opts.js
+++ b/packages/conventional-changelog-angular/writer-opts.js
@@ -79,7 +79,13 @@ function getWriterOpts () {
         }
         if (context.host) {
           // User URLs.
-          commit.subject = commit.subject.replace(/\B@([a-z0-9](?:-?[a-z0-9]){0,38})/g, `[@$1](${context.host}/$1)`)
+          commit.subject = commit.subject.replace(/\B@([a-z0-9](?:-?[a-z0-9/]){0,38})/g, (_, username) => {
+            if (username.includes('/')) {
+              return `@${username}`
+            }
+
+            return `[@${username}](${context.host}/${username})`
+          })
         }
       }
 


### PR DESCRIPTION
GitHub username detection of Angular preset detects scoped NPM packages as GitHub username, package `@dummy/package` will be replaced by `[@dummy](https://github.com/dummy)/package` in the changelog.

![selection_999 155](https://user-images.githubusercontent.com/2103975/48252656-97599500-e405-11e8-9c28-4499bd96dac4.png)

With this patch, scoped NPM packages won't be detected as GitHub username:
![selection_999 157](https://user-images.githubusercontent.com/2103975/48253288-3632c100-e407-11e8-8bb6-5b5a77aae88c.png)

