### PR TITLE
feat(parser): parse merge message and conventional commit on same line

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 **/node_modules/
 **/tmp/
 /lerna-debug.log
+.idea

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "test-windows": "lerna exec --concurrency 1 -- npm run test-windows",
     "release": "lerna publish --conventional-commits"
   },
-  "version": "1.0.0",
+  "version": "1.0.1",
   "devDependencies": {
     "better-than-before": "^1.0.0",
     "chai": "^4.2.0",

--- a/packages/conventional-commits-parser/lib/parser.js
+++ b/packages/conventional-commits-parser/lib/parser.js
@@ -159,7 +159,7 @@ function parser (raw, options, regex) {
       mergeParts[partName] = partValue
     })
   } else {
-    header = merge
+    header = inputLine
     merge = null
 
     _.forEach(mergeCorrespondence, function (partName) {

--- a/packages/conventional-commits-parser/lib/parser.js
+++ b/packages/conventional-commits-parser/lib/parser.js
@@ -36,7 +36,7 @@ function getReferences (input, regex) {
   var referenceSentences
   var referenceMatch
 
-  var inputMatch = input ? input.match(regex.reference) : null
+  var inputMatch = input ? input.match(regex.references) : null
   var reApplicable = inputMatch
     ? regex.references
     : CATCH_ALL

--- a/packages/conventional-commits-parser/lib/parser.js
+++ b/packages/conventional-commits-parser/lib/parser.js
@@ -36,7 +36,8 @@ function getReferences (input, regex) {
   var referenceSentences
   var referenceMatch
 
-  var reApplicable = input.match(regex.references) !== null
+  var inputMatch = input ? input.match(regex.reference) : null
+  var reApplicable = inputMatch
     ? regex.references
     : CATCH_ALL
 
@@ -138,17 +139,17 @@ function parser (raw, options, regex) {
   }
 
   // msg parts
-  merge = lines.shift()
+  var inputLine = lines.shift()
   var mergeParts = {}
   var headerParts = {}
   body = ''
   footer = ''
 
-  mergeMatch = merge.match(options.mergePattern)
+  mergeMatch = inputLine.match(options.mergePattern)
   if (mergeMatch && options.mergePattern) {
     merge = mergeMatch[0]
 
-    header = lines.shift()
+    header = inputLine.replace(merge, '').trim()
     while (!header.trim()) {
       header = lines.shift()
     }
@@ -166,7 +167,7 @@ function parser (raw, options, regex) {
     })
   }
 
-  headerMatch = header.match(options.headerPattern)
+  headerMatch = header ? header.match(options.headerPattern) : null
   if (headerMatch) {
     _.forEach(headerCorrespondence, function (partName, index) {
       var partValue = headerMatch[index + 1] || null

--- a/packages/conventional-commits-parser/test/parser.spec.js
+++ b/packages/conventional-commits-parser/test/parser.spec.js
@@ -357,14 +357,14 @@ describe('parser', function () {
     var mergeOptions = {
       headerPattern: /^(\w*)(?:\(([\w$.\-* ]*)\))?: (.*)$/,
       headerCorrespondence: ['type', 'scope', 'subject'],
-      mergePattern: /^Merge branch '(\w+)'$/,
+      mergePattern: /^Merge branch '(\w+)'/,
       mergeCorrespondence: ['source', 'issueId']
     }
 
     var mergeRegex = regex(mergeOptions)
 
     var mergeMsg = parser(
-      'Merge branch \'feature\'\nHEADER',
+      'Merge branch \'feature\' feat(scope): this is a message',
       mergeOptions,
       mergeRegex
     )


### PR DESCRIPTION
Can now parse both a merge message and a conventional commit that appear on the same line