### PR TITLE
feat: send options to whatBump

### DIFF
--- a/packages/conventional-recommended-bump/index.js
+++ b/packages/conventional-recommended-bump/index.js
@@ -73,7 +73,7 @@ function conventionalRecommendedBump (optionsArgument, parserOptsArgument, cbArg
             warn(`No commits since last release`)
           }
 
-          let result = whatBump(commits)
+          let result = whatBump(commits, options)
 
           if (result && result.level != null) {
             result.releaseType = VERSIONS[result.level]

--- a/packages/conventional-recommended-bump/test/index.spec.js
+++ b/packages/conventional-recommended-bump/test/index.spec.js
@@ -154,6 +154,19 @@ describe(`conventional-recommended-bump API`, () => {
       })
     })
 
+    it(`should send options to 'whatBump'`, done => {
+      preparing(2)
+
+      conventionalRecommendedBump({
+        lernaPackage: 'test',
+        whatBump: (commits, options) => { return options.lernaPackage }
+      }, (err, recommendation) => {
+        if (err) done(err)
+        assert.deepStrictEqual(recommendation, 'test')
+        done()
+      })
+    })
+
     it(`should return 'releaseType' as undefined if 'level' is not valid`, done => {
       preparing(2)
 


### PR DESCRIPTION
In custom scenarios it is useful to get some context of the current options of the `conventionalRecommendedBump` call.
    
For example, when using a custom changelog preset together with Lerna, and the preset uses a custom `whatBump` method that requires to know the current Lerna package that it is being run for.
    
See: https://github.com/lerna/lerna/blob/a6733a2b864cf9d082d080bbd3bfedb04e59b0ab/core/conventional-commits/lib/recommend-version.js#L13-L21
