### PR TITLE
fix(angular): do not skip commit types

### DIFF
--- a/packages/conventional-changelog-angular/writer-opts.js
+++ b/packages/conventional-changelog-angular/writer-opts.js
@@ -25,12 +25,10 @@ module.exports = Q.all([
 function getWriterOpts () {
   return {
     transform: (commit, context) => {
-      let discard = true
       const issues = []
 
       commit.notes.forEach(note => {
         note.title = `BREAKING CHANGES`
-        discard = false
       })
 
       if (commit.type === `feat`) {
@@ -41,8 +39,6 @@ function getWriterOpts () {
         commit.type = `Performance Improvements`
       } else if (commit.type === `revert`) {
         commit.type = `Reverts`
-      } else if (discard) {
-        return
       } else if (commit.type === `docs`) {
         commit.type = `Documentation`
       } else if (commit.type === `style`) {
@@ -55,6 +51,8 @@ function getWriterOpts () {
         commit.type = `Build System`
       } else if (commit.type === `ci`) {
         commit.type = `Continuous Integration`
+      } else {
+        return
       }
 
       if (commit.scope === `*`) {


### PR DESCRIPTION
Before most commit types were skipped and not written into the changelog. This change allows all commit types be part of the changelog.

This was discussed in the issue https://github.com/conventional-changelog/conventional-changelog/issues/317, but no changes were made.