### PR TITLE
docs: add vscode extension link to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ found in [packages/conventional-changelog](https://github.com/conventional-chang
 - [conventional-commits-detector](https://github.com/conventional-changelog/conventional-commits-detector) - Detect what commit message convention your repository is using
 - [commitizen](https://github.com/commitizen/cz-cli) - Simple commit conventions for internet citizens.
 - [commitlint](https://github.com/marionebl/commitlint) - Lint commit messages
+- [vscode-changelog-generator](https://github.com/axetroy/vscode-changelog-generator) - vscode extension
 
 ## Node Support Policy
 


### PR DESCRIPTION
It's a part of conventional-changelog ecosystem