### PR TITLE
feat: .changelogrc

### DIFF
--- a/packages/conventional-changelog-core/test/fixtures/changelogrc/.changelogrc
+++ b/packages/conventional-changelog-core/test/fixtures/changelogrc/.changelogrc
@@ -1,0 +1,3 @@
+{
+    "extend": ["preset:conventionalcommits"]
+}

--- a/packages/conventional-changelog-core/test/fixtures/changelogrc/.changelogrc-extend
+++ b/packages/conventional-changelog-core/test/fixtures/changelogrc/.changelogrc-extend
@@ -1,0 +1,6 @@
+{
+    "writerOpts": {
+        "host": "https://hosted-scm.biz"
+    },
+    "extend": ["preset:conventionalcommits", "../invalid/local/path/.changelogrc"]
+}


### PR DESCRIPTION
- Adds two example fixtures for `.changelogrc`

---

This is a WIP PR. I mostly wanted to make sure I was on the same page as the update suggested in #421. 

Work can either be continued here or closed out. 


