### PR TITLE
fix: address discrepancies between cc preset and spec

### DIFF
--- a/packages/conventional-changelog-conventionalcommits/README.md
+++ b/packages/conventional-changelog-conventionalcommits/README.md
@@ -6,6 +6,9 @@ A concrete implementation of the specification described at
 [conventionalcommits.org](https://conventionalcommits.org/) for automated
 CHANGELOG generation and version management.
 
+TODO: once we flesh out the spec for configuring conventional-changelog tools,
+fill in this section of the README [see](https://github.com/conventional-changelog/conventional-changelog-config-spec/issues/1).
+
 [travis-image]: https://travis-ci.org/conventional-changelog/conventional-changelog.svg?branch=master
 [travis-url]: https://travis-ci.org/conventional-changelog/conventional-changelog
 [coveralls-image]: https://coveralls.io/repos/conventional-changelog/conventional-changelog/badge.svg

--- a/packages/conventional-changelog-conventionalcommits/test/test.js
+++ b/packages/conventional-changelog-conventionalcommits/test/test.js
@@ -24,8 +24,8 @@ betterThanBefore.setups([
 
     gitDummyCommit(['build: first build setup', 'BREAKING CHANGE: New build system.'])
     gitDummyCommit(['ci(travis): add TravisCI pipeline', 'BREAKING CHANGE: Continuously integrated.'])
-    gitDummyCommit(['feat: amazing new module', 'BREAKING CHANGE: Not backward compatible.'])
-    gitDummyCommit(['fix(compile): avoid a bug', 'BREAKING CHANGE: The Change is huge.'])
+    gitDummyCommit(['Feat: amazing new module', 'BREAKING CHANGE: Not backward compatible.'])
+    gitDummyCommit(['Fix(compile): avoid a bug', 'BREAKING CHANGE: The Change is huge.'])
     gitDummyCommit(['perf(ngOptions): make it faster', ' closes #1, #2'])
     gitDummyCommit('revert(ngOptions): bad commit')
     gitDummyCommit('fix(*): oops')
@@ -57,6 +57,12 @@ betterThanBefore.setups([
   function () {
     gitDummyCommit(['fix: use npm@5 (@username)'])
     gitDummyCommit(['build(deps): bump @dummy/package from 7.1.2 to 8.0.0', 'BREAKING CHANGE: The Change is huge.'])
+    gitDummyCommit([
+      'feat: complex new feature',
+      'this is a complex new feature with many reviewers',
+      'Reviewer: @hutson\nFixes: #99\nRefs: #100\nBREAKING CHANGE: this completely changes the API'
+    ])
+    gitDummyCommit(['FEAT(foo): incredible new flag FIXES: #33'])
   }
 ])
 
@@ -122,7 +128,7 @@ describe('conventionalcommits.org preset', function () {
         expect(chunk).to.include('**travis:** Continuously integrated.')
         expect(chunk).to.include('amazing new module')
         expect(chunk).to.include('**compile:** avoid a bug')
-        expect(chunk).to.include('feat')
+        expect(chunk).to.include('Feat')
 
         expect(chunk).to.not.include('make it faster')
         expect(chunk).to.not.include('Reverts')
@@ -163,18 +169,20 @@ describe('conventionalcommits.org preset', function () {
       }))
   })
 
-  it('should replace @username with GitHub user URL', function (done) {
+  it('should replace @user with configured userUrlFormat', function (done) {
     preparing(4)
 
     conventionalChangelogCore({
-      config: preset
+      config: require('../')({
+        userUrlFormat: 'https://foo/{{user}}'
+      })
     })
       .on('error', function (err) {
         done(err)
       })
       .pipe(through(function (chunk) {
         chunk = chunk.toString()
-        expect(chunk).to.include('[@bcoe](https://github.com/bcoe)')
+        expect(chunk).to.include('[@bcoe](https://foo/bcoe)')
         done()
       }))
   })
@@ -353,6 +361,40 @@ describe('conventionalcommits.org preset', function () {
 
         expect(chunk).to.not.include('[@dummy](https://github.com/dummy)/package')
         expect(chunk).to.include('bump @dummy/package from')
+        done()
+      }))
+  })
+
+  it('supports multiple lines of footer information', function (done) {
+    preparing(8)
+
+    conventionalChangelogCore({
+      config: preset
+    })
+      .on('error', function (err) {
+        done(err)
+      })
+      .pipe(through(function (chunk) {
+        chunk = chunk.toString()
+        expect(chunk).to.include('closes [#99]')
+        expect(chunk).to.include('[#100]')
+        expect(chunk).to.include('this completely changes the API')
+        done()
+      }))
+  })
+
+  it('does not require that types are case sensitive', function (done) {
+    preparing(8)
+
+    conventionalChangelogCore({
+      config: preset
+    })
+      .on('error', function (err) {
+        done(err)
+      })
+      .pipe(through(function (chunk) {
+        chunk = chunk.toString()
+        expect(chunk).to.include('incredible new flag')
         done()
       }))
   })

--- a/packages/conventional-changelog-conventionalcommits/test/test.js
+++ b/packages/conventional-changelog-conventionalcommits/test/test.js
@@ -12,6 +12,8 @@ var path = require('path')
 var betterThanBefore = require('better-than-before')()
 var preparing = betterThanBefore.preparing
 
+const EOL = require('os').EOL
+
 betterThanBefore.setups([
   function () {
     shell.config.resetForTesting()
@@ -60,7 +62,7 @@ betterThanBefore.setups([
     gitDummyCommit([
       'feat: complex new feature',
       'this is a complex new feature with many reviewers',
-      'Reviewer: @hutson\nFixes: #99\nRefs: #100\nBREAKING CHANGE: this completely changes the API'
+      `Reviewer: @hutson${EOL}Fixes: #99${EOL}Refs: #100${EOL}BREAKING CHANGE: this completely changes the API`
     ])
     gitDummyCommit(['FEAT(foo): incredible new flag FIXES: #33'])
   }

--- a/packages/conventional-changelog-conventionalcommits/test/test.js
+++ b/packages/conventional-changelog-conventionalcommits/test/test.js
@@ -12,8 +12,6 @@ var path = require('path')
 var betterThanBefore = require('better-than-before')()
 var preparing = betterThanBefore.preparing
 
-const EOL = require('os').EOL
-
 betterThanBefore.setups([
   function () {
     shell.config.resetForTesting()
@@ -62,7 +60,10 @@ betterThanBefore.setups([
     gitDummyCommit([
       'feat: complex new feature',
       'this is a complex new feature with many reviewers',
-      `Reviewer: @hutson${EOL}Fixes: #99${EOL}Refs: #100${EOL}BREAKING CHANGE: this completely changes the API`
+      'Reviewer: @hutson',
+      'Fixes: #99',
+      'Refs: #100',
+      'BREAKING CHANGE: this completely changes the API'
     ])
     gitDummyCommit(['FEAT(foo): incredible new flag FIXES: #33'])
   }


### PR DESCRIPTION
I've written some more tests ensuring that various aspects of the conventionalcommits.org specification are adhered to; in the process I've fixed a few things.

* types should not need to be case sensitive (I've added a test for this and fixed a bug).
* user URLs were tied to GitHub, I've made this configurable now.
* I've added a test ensuring that footers can be multiple lines (in the process I found a [bug](https://github.com/conventional-changelog/conventional-changelog/issues/428).
