### PR TITLE
feat: conventionalcommits preset, preMajor config option

### DIFF
--- a/packages/conventional-changelog-conventionalcommits/conventional-recommended-bump.js
+++ b/packages/conventional-changelog-conventionalcommits/conventional-recommended-bump.js
@@ -14,7 +14,11 @@ module.exports = function (config) {
       commits.forEach(commit => {
         if (commit.notes.length > 0) {
           breakings += commit.notes.length
-          level = 0
+          if (config.preMajor) {
+            level = 1
+          } else {
+            level = 0
+          }
         } else if (commit.type === `feat`) {
           features += 1
           if (level === 2) {

--- a/packages/conventional-changelog/index.js
+++ b/packages/conventional-changelog/index.js
@@ -8,25 +8,15 @@ function conventionalChangelog (options, context, gitRawCommitsOpts, parserOpts,
 
   if (options.preset) {
     try {
-      let presetConfig = null
-      if (typeof options.preset === 'object' && options.preset.name) {
-        // Rather than a string preset name, options.preset can be an object
-        // with a "name" key indicating the preset to load; additinoal key/value
-        // pairs are assumed to be configuration for the preset. See the documentation
-        // for a given preset for configuration available.
-        presetConfig = options.preset
-        options.config = conventionalChangelogPresetLoader(options.preset.name.toLowerCase())
-      } else {
-        options.config = conventionalChangelogPresetLoader(options.preset.toLowerCase())
-      }
-      // rather than returning a promise, presets can return a builder function
-      // which accepts a config object (allowing for customization) and returns
-      // a promise.
-      if (!options.config.then && presetConfig) {
-        options.config = options.config(presetConfig)
-      }
+      options.config = conventionalChangelogPresetLoader(options.preset)
     } catch (err) {
-      options.warn('Preset: "' + options.preset + '" does not exist')
+      if (typeof options.preset === 'object') {
+        options.warn(`Preset: "${options.preset.name}" ${err.message}`)
+      } else if (typeof options.preset === 'string') {
+        options.warn(`Preset: "${options.preset}" ${err.message}`)
+      } else {
+        options.warn(`Preset: ${err.message}`)
+      }
     }
   }
 

--- a/packages/conventional-recommended-bump/index.js
+++ b/packages/conventional-recommended-bump/index.js
@@ -29,7 +29,11 @@ function conventionalRecommendedBump (optionsArgument, parserOptsArgument, cbArg
     try {
       presetPackage = conventionalChangelogPresetLoader(options.preset)
     } catch (err) {
-      return cb(new Error(`Unable to load the "${options.preset}" preset package. Please make sure it's installed.`))
+      if (err.message === 'does not exist') {
+        return cb(new Error(`Unable to load the "${options.preset}" preset package. Please make sure it's installed.`))
+      } else {
+        return cb(err)
+      }
     }
   }
 

--- a/packages/conventional-recommended-bump/test/index.spec.js
+++ b/packages/conventional-recommended-bump/test/index.spec.js
@@ -232,7 +232,7 @@ describe(`conventional-recommended-bump API`, () => {
           preMajor: true
         }
       }, {}, (_, recommendation) => {
-        assert.strict.notEqual(recommendation.reason.indexOf('1 BREAKING'), -1)
+        assert.notStrictEqual(recommendation.reason.indexOf('1 BREAKING'), -1)
         assert.strictEqual(recommendation.releaseType, 'minor')
         done()
       })
@@ -246,7 +246,7 @@ describe(`conventional-recommended-bump API`, () => {
           name: 'conventionalcommits'
         }
       }, {}, (_, recommendation) => {
-        assert.strict.notEqual(recommendation.reason.indexOf('1 BREAKING'), -1)
+        assert.notStrictEqual(recommendation.reason.indexOf('1 BREAKING'), -1)
         assert.strictEqual(recommendation.releaseType, 'major')
         done()
       })

--- a/packages/conventional-recommended-bump/test/index.spec.js
+++ b/packages/conventional-recommended-bump/test/index.spec.js
@@ -72,20 +72,6 @@ describe(`conventional-recommended-bump API`, () => {
     })
   })
 
-  describe(`loading a preset package`, () => {
-    it(`throw an error if unable to load a preset package`, done => {
-      preparing(1)
-
-      conventionalRecommendedBump({
-        preset: `does-not-exist`
-      }, {}, err => {
-        assert.ok(err)
-        assert.strictEqual(err.message, `Unable to load the "does-not-exist" preset package. Please make sure it's installed.`)
-        done()
-      })
-    })
-  })
-
   it(`should return an error if there are no commits in the repository`, done => {
     preparing(1)
 
@@ -221,6 +207,49 @@ describe(`conventional-recommended-bump API`, () => {
           done()
         }
       }, () => {})
+    })
+  })
+
+  describe(`loading a preset package`, () => {
+    it(`throws an error if unable to load a preset package`, done => {
+      preparing(5)
+
+      conventionalRecommendedBump({
+        preset: `does-not-exist`
+      }, {}, err => {
+        assert.ok(err)
+        assert.strictEqual(err.message, `Unable to load the "does-not-exist" preset package. Please make sure it's installed.`)
+        done()
+      })
+    })
+
+    it('recommends a minor release when preMajor=true', done => {
+      preparing(5)
+
+      conventionalRecommendedBump({
+        preset: {
+          name: 'conventionalcommits',
+          preMajor: true
+        }
+      }, {}, (_, recommendation) => {
+        assert.strict.notEqual(recommendation.reason.indexOf('1 BREAKING'), -1)
+        assert.strictEqual(recommendation.releaseType, 'minor')
+        done()
+      })
+    })
+
+    it('recommends a major release when preMajor=false', done => {
+      preparing(5)
+
+      conventionalRecommendedBump({
+        preset: {
+          name: 'conventionalcommits'
+        }
+      }, {}, (_, recommendation) => {
+        assert.strict.notEqual(recommendation.reason.indexOf('1 BREAKING'), -1)
+        assert.strictEqual(recommendation.releaseType, 'major')
+        done()
+      })
     })
   })
 


### PR DESCRIPTION
## What is this?

This PR introduces the `preMajor` config option for the conventionalcommits preset.

When set to `true`, breaking changes will still be populated in `reasons` but a `minor` version bump will be recommended rather than a `major`.

----

when landing #421 I neglected to pass the new preset object to recommended bump; this PR:

1. Pulls the logic into `conventional-changelog-preset-loader` so that it's shared by both `conventional-changelog` and recommended bump.
2. introduces the `preMajor` config option ([documented here](https://github.com/conventional-changelog/conventional-changelog-config-spec/pull/4)); which is required by `standard-version`, and is used in unit-tests to ensure the preset is getting passed configuration.
