### PR TITLE
fix: Downgrade node 10.x dependency to 6.9.0 dependency

### DIFF
--- a/packages/conventional-changelog-conventionalcommits/package.json
+++ b/packages/conventional-changelog-conventionalcommits/package.json
@@ -25,7 +25,7 @@
   ],
   "author": "Ben Coe",
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=6.9.0"
   },
   "license": "ISC",
   "bugs": {


### PR DESCRIPTION
Fixes #436.

Tested with 6.9.0, and it works.