### PR TITLE
fix(preset, conventionalcommits): Ensure proper substitutions for the conventionalcommit preset by using commit context for values where possible.

### DIFF
--- a/packages/conventional-changelog-conventionalcommits/test/test.js
+++ b/packages/conventional-changelog-conventionalcommits/test/test.js
@@ -1,6 +1,7 @@
 'use strict'
 var conventionalChangelogCore = require('conventional-changelog-core')
-var preset = require('../')()
+var getPreset = require('../')
+var preset = getPreset()
 var expect = require('chai').expect
 var mocha = require('mocha')
 var describe = mocha.describe
@@ -156,7 +157,7 @@ describe('conventionalcommits.org preset', function () {
       }))
   })
 
-  it('should properly format cross-repository issues', function (done) {
+  it('should properly format external repository issues', function (done) {
     preparing(1)
     conventionalChangelogCore({
       config: preset
@@ -168,6 +169,24 @@ describe('conventionalcommits.org preset', function () {
         chunk = chunk.toString()
         expect(chunk).to.include('[#1](https://github.com/conventional-changelog/conventional-changelog/issues/1)')
         expect(chunk).to.include('[conventional-changelog/standard-version#358](https://github.com/conventional-changelog/standard-version/issues/358)')
+        done()
+      }))
+  })
+
+  it('should properly format external repository issues given an `issueUrlFormat`', function (done) {
+    preparing(1)
+    conventionalChangelogCore({
+      config: getPreset({
+        issueUrlFormat: 'issues://{{repository}}/issues/{{id}}'
+      })
+    })
+      .on('error', function (err) {
+        done(err)
+      })
+      .pipe(through(function (chunk) {
+        chunk = chunk.toString()
+        expect(chunk).to.include('[#1](issues://conventional-changelog/issues/1)')
+        expect(chunk).to.include('[conventional-changelog/standard-version#358](issues://standard-version/issues/358)')
         done()
       }))
   })

--- a/packages/conventional-changelog-conventionalcommits/test/test.js
+++ b/packages/conventional-changelog-conventionalcommits/test/test.js
@@ -27,6 +27,7 @@ betterThanBefore.setups([
     gitDummyCommit(['Feat: amazing new module', 'BREAKING CHANGE: Not backward compatible.'])
     gitDummyCommit(['Fix(compile): avoid a bug', 'BREAKING CHANGE: The Change is huge.'])
     gitDummyCommit(['perf(ngOptions): make it faster', ' closes #1, #2'])
+    gitDummyCommit(['fix(changelog): proper issue links', ' see #1, conventional-changelog/standard-version#358'])
     gitDummyCommit('revert(ngOptions): bad commit')
     gitDummyCommit('fix(*): oops')
   },
@@ -151,6 +152,22 @@ describe('conventionalcommits.org preset', function () {
 
         expect(chunk).to.not.include('make it faster')
         expect(chunk).to.not.include('Reverts')
+        done()
+      }))
+  })
+
+  it('should properly format cross-repository issues', function (done) {
+    preparing(1)
+    conventionalChangelogCore({
+      config: preset
+    })
+      .on('error', function (err) {
+        done(err)
+      })
+      .pipe(through(function (chunk) {
+        chunk = chunk.toString()
+        expect(chunk).to.include('[#1](https://github.com/conventional-changelog/conventional-changelog/issues/1)')
+        expect(chunk).to.include('[conventional-changelog/standard-version#358](https://github.com/conventional-changelog/standard-version/issues/358)')
         done()
       }))
   })

--- a/packages/conventional-changelog-conventionalcommits/writer-opts.js
+++ b/packages/conventional-changelog-conventionalcommits/writer-opts.js
@@ -10,7 +10,7 @@ const resolve = require(`path`).resolve
  * Handlebar partials for various property substitutions based on commit context.
  */
 const owner = '{{#if this.owner}}{{~this.owner}}{{else}}{{~@root.owner}}{{/if}}'
-const host = '{{#if this.host}}{{~this.host}}{{else}}{{~@root.host}}{{/if}}'
+const host = '{{~@root.host}}'
 const repository = '{{#if this.repository}}{{~this.repository}}{{else}}{{~@root.repository}}{{/if}}'
 
 module.exports = function (config) {

--- a/packages/conventional-changelog-conventionalcommits/writer-opts.js
+++ b/packages/conventional-changelog-conventionalcommits/writer-opts.js
@@ -6,22 +6,29 @@ const Q = require(`q`)
 const readFile = Q.denodeify(require(`fs`).readFile)
 const resolve = require(`path`).resolve
 
+/**
+ * Handlebar partials for various property substitutions based on commit context.
+ */
+const owner = '{{#if this.owner}}{{~this.owner}}{{else}}{{~@root.owner}}{{/if}}'
+const host = '{{#if this.host}}{{~this.host}}{{else}}{{~@root.host}}{{/if}}'
+const repository = '{{#if this.repository}}{{~this.repository}}{{else}}{{~@root.repository}}{{/if}}'
+
 module.exports = function (config) {
   config = defaultConfig(config)
   const commitUrlFormat = expandTemplate(config.commitUrlFormat, {
-    host: '{{~@root.host}}',
-    owner: '{{~@root.owner}}',
-    repository: '{{~@root.repository}}'
+    host,
+    owner,
+    repository
   })
   const compareUrlFormat = expandTemplate(config.compareUrlFormat, {
-    host: '{{~@root.host}}',
-    owner: '{{~@root.owner}}',
-    repository: '{{~@root.repository}}'
+    host,
+    owner,
+    repository
   })
   const issueUrlFormat = expandTemplate(config.issueUrlFormat, {
-    host: '{{~@root.host}}',
-    owner: '{{~@root.owner}}',
-    repository: '{{~@root.repository}}',
+    host,
+    owner,
+    repository,
     id: '{{this.issue}}'
   })
 


### PR DESCRIPTION
- adds conditionals around commit context for host, owner and repository.

closes #462