### PR TITLE
fix(Delimiter): Breaks debug output.

### DIFF
--- a/packages/git-raw-commits/index.js
+++ b/packages/git-raw-commits/index.js
@@ -7,7 +7,7 @@ var stream = require('stream')
 var template = require('lodash.template')
 var through = require('through2')
 
-var DELIMITER = '------------------------ >8 ------------------------'
+var DELIMITER = '____________________________________________________'
 
 function normalizeExecOpts (execOpts) {
   execOpts = execOpts || {}


### PR DESCRIPTION
Fixes #477 

Fixes issue as described

What the delimiter looks like with change:

```
git log --format=%B%n-hash-%n%H%n-gitTags-%n%d%n-committerDate-%n%ci%n-authorName-%n%an%n-authorEmail-%n%ae%n-gpgStatus-%n%G?%n-gpgSigner-%n%GS%n____________________________________________________ git-semver-tags@2.0.0..git-semver-tags@2.0.3
```

What it looked like before the change:
```
git log --format=%B%n-hash-%n%H%n-gitTags-%n%d%n-committerDate-%n%ci%n-authorName-%n%an%n-authorEmail-%n%ae%n-gpgStatus-%n%G?%n-gpgSigner-%n%GS%n------------------------ >8 ------------------------ git-semver-tags@2.0.0..git-semver-tags@2.0.3
```

The original version fails with `fatal: unrecognized argument: ------------------------`, the fixed version executes normally.

Run this `git log` command above in the `conventional-changelog` repo itself to see the change.