### PR TITLE
feat(gitExecOpts): Provide facility to define options.

### DIFF
--- a/packages/conventional-changelog-core/index.js
+++ b/packages/conventional-changelog-core/index.js
@@ -6,7 +6,7 @@ const conventionalChangelogWriter = require('conventional-changelog-writer')
 const stream = require('stream')
 const through = require('through2')
 const mergeConfig = require('./lib/merge-config')
-function conventionalChangelog (options, context, gitRawCommitsOpts, parserOpts, writerOpts) {
+function conventionalChangelog (options, context, gitRawCommitsOpts, parserOpts, writerOpts, gitRawExecOpts) {
   writerOpts = writerOpts || {}
 
   var readable = new stream.Readable({
@@ -14,15 +14,16 @@ function conventionalChangelog (options, context, gitRawCommitsOpts, parserOpts,
   })
   readable._read = function () {}
 
-  mergeConfig(options, context, gitRawCommitsOpts, parserOpts, writerOpts)
+  mergeConfig(options, context, gitRawCommitsOpts, parserOpts, writerOpts, gitRawExecOpts)
     .then(function (data) {
       options = data.options
       context = data.context
       gitRawCommitsOpts = data.gitRawCommitsOpts
       parserOpts = data.parserOpts
       writerOpts = data.writerOpts
+      gitRawExecOpts = data.gitRawExecOpts;
 
-      gitRawCommits(gitRawCommitsOpts)
+      gitRawCommits(gitRawCommitsOpts, gitRawExecOpts)
         .on('error', function (err) {
           err.message = 'Error in git-raw-commits: ' + err.message
           setImmediate(readable.emit.bind(readable), 'error', err)

--- a/packages/conventional-changelog-core/index.js
+++ b/packages/conventional-changelog-core/index.js
@@ -21,7 +21,7 @@ function conventionalChangelog (options, context, gitRawCommitsOpts, parserOpts,
       gitRawCommitsOpts = data.gitRawCommitsOpts
       parserOpts = data.parserOpts
       writerOpts = data.writerOpts
-      gitRawExecOpts = data.gitRawExecOpts;
+      gitRawExecOpts = data.gitRawExecOpts
 
       gitRawCommits(gitRawCommitsOpts, gitRawExecOpts)
         .on('error', function (err) {

--- a/packages/conventional-changelog-core/lib/merge-config.js
+++ b/packages/conventional-changelog-core/lib/merge-config.js
@@ -320,7 +320,7 @@ function mergeConfig (options, context, gitRawCommitsOpts, parserOpts, writerOpt
         gitRawCommitsOpts: gitRawCommitsOpts,
         parserOpts: parserOpts,
         writerOpts: writerOpts,
-        gitRawExecOpts: gitRawExecOpts,
+        gitRawExecOpts: gitRawExecOpts
       }
     })
 }

--- a/packages/conventional-changelog-core/lib/merge-config.js
+++ b/packages/conventional-changelog-core/lib/merge-config.js
@@ -52,13 +52,14 @@ function guessNextTag (previousTag, version) {
   return version
 }
 
-function mergeConfig (options, context, gitRawCommitsOpts, parserOpts, writerOpts) {
+function mergeConfig (options, context, gitRawCommitsOpts, parserOpts, writerOpts, gitRawExecOpts) {
   var configPromise
   var pkgPromise
   var gitRemoteOriginUrlPromise
 
   context = context || {}
   gitRawCommitsOpts = gitRawCommitsOpts || {}
+  gitRawExecOpts = gitRawExecOpts || {}
 
   options = _.merge({
     pkg: {
@@ -318,7 +319,8 @@ function mergeConfig (options, context, gitRawCommitsOpts, parserOpts, writerOpt
         context: context,
         gitRawCommitsOpts: gitRawCommitsOpts,
         parserOpts: parserOpts,
-        writerOpts: writerOpts
+        writerOpts: writerOpts,
+        gitRawExecOpts: gitRawExecOpts,
       }
     })
 }


### PR DESCRIPTION
Fixes #479 

This allows a new param to be provided to core that are passed to git-raw-commit as exec option, notable, now being able to change the cwd from a calling function.

If no value provided, it'll work normally as `cwd` is defaulted to the `process.cwd()` value when falsy.