### PR TITLE
Allow use of full package names when loading presets

### DIFF
--- a/packages/conventional-changelog-preset-loader/index.js
+++ b/packages/conventional-changelog-preset-loader/index.js
@@ -24,8 +24,12 @@ function presetLoader (requireMethod) {
       name = parts.join(`/`)
     }
 
+    if (!name.startsWith('conventional-changelog-')) {
+      name = `conventional-changelog-${name}`
+    }
+
     try {
-      const config = requireMethod(`${scope}conventional-changelog-${name}`)
+      const config = requireMethod(`${scope}${name}`)
       // rather than returning a promise, presets can return a builder function
       // which accepts a config object (allowing for customization) and returns
       // a promise.

--- a/packages/conventional-changelog-preset-loader/test/test.js
+++ b/packages/conventional-changelog-preset-loader/test/test.js
@@ -32,6 +32,26 @@ describe(`presetLoader`, () => {
       .and.to.have.been.calledWith(`conventional-changelog-angular/preset/path`)
   })
 
+  it(`loads unscoped package with full package name`, () => {
+    const requireMethod = sinon.spy()
+    const load = presetLoader(requireMethod)
+
+    load(`conventional-changelog-angular`)
+
+    expect(requireMethod).to.have.been.calledOnce
+      .and.to.have.been.calledWith(`conventional-changelog-angular`)
+  })
+
+  it(`loads unscoped package with full package name containing path`, () => {
+    const requireMethod = sinon.spy()
+    const load = presetLoader(requireMethod)
+
+    load(`conventional-changelog-angular/preset/path`)
+
+    expect(requireMethod).to.have.been.calledOnce
+      .and.to.have.been.calledWith(`conventional-changelog-angular/preset/path`)
+  })
+
   it(`loads scoped package`, () => {
     const requireMethod = sinon.spy()
     const load = presetLoader(requireMethod)
@@ -47,6 +67,26 @@ describe(`presetLoader`, () => {
     const load = presetLoader(requireMethod)
 
     load(`@scope/angular/preset/path`)
+
+    expect(requireMethod).to.have.been.calledOnce
+      .and.to.have.been.calledWith(`@scope/conventional-changelog-angular/preset/path`)
+  })
+
+  it(`loads scoped package with full package name`, () => {
+    const requireMethod = sinon.spy()
+    const load = presetLoader(requireMethod)
+
+    load(`@scope/conventional-changelog-angular`)
+
+    expect(requireMethod).to.have.been.calledOnce
+      .and.to.have.been.calledWith(`@scope/conventional-changelog-angular`)
+  })
+
+  it(`loads scoped package with full package name containing path`, () => {
+    const requireMethod = sinon.spy()
+    const load = presetLoader(requireMethod)
+
+    load(`@scope/conventional-changelog-angular/preset/path`)
 
     expect(requireMethod).to.have.been.calledOnce
       .and.to.have.been.calledWith(`@scope/conventional-changelog-angular/preset/path`)


### PR DESCRIPTION
It's rather surprising and confusing esp. with scoped packages that the CLI effectively requires using an option like `--preset=@scope/preset` in order to fetch the preset defined in `@scope/conventional-changelog-preset`.

This change allows for the loader to also handle full package paths, so that with the above example `--preset=@scope/conventional-changelog-preset` would work.