### PR TITLE
fix(preset, conventionalcommits): ensure working entrypoint

### DIFF
--- a/packages/conventional-changelog-conventionalcommits/index.js
+++ b/packages/conventional-changelog-conventionalcommits/index.js
@@ -5,13 +5,7 @@ const parserOpts = require(`./parser-opts`)
 const recommendedBumpOpts = require(`./conventional-recommended-bump`)
 const writerOpts = require(`./writer-opts`)
 
-module.exports = function (config) {
-  return Q.all([
-    conventionalChangelog(config),
-    parserOpts(config),
-    recommendedBumpOpts(config),
-    writerOpts(config)
-  ]).spread((conventionalChangelog, parserOpts, recommendedBumpOpts, writerOpts) => {
+module.exports = Q.all([conventionalChangelog, parserOpts, recommendedBumpOpts, writerOpts])
+  .spread((conventionalChangelog, parserOpts, recommendedBumpOpts, writerOpts) => {
     return { conventionalChangelog, parserOpts, recommendedBumpOpts, writerOpts }
   })
-}


### PR DESCRIPTION
Before this the command would stop working midway (always on the last line on the log below).

```
[munif:/<dir>/<repo>] master(U1,1) 1 ± lerna version prerelease --yes --loglevel=silly -m "chore: msg"
lerna sill argv { _: [ 'version' ],
lerna sill argv   yes: true,
lerna sill argv   y: true,
lerna sill argv   loglevel: 'silly',
lerna sill argv   m: 'chore: msg',
lerna sill argv   message: 'chore: msg',
lerna sill argv   lernaVersion: '3.13.4',
lerna sill argv   '$0': 'node_modules/.bin/lerna',
lerna sill argv   bump: 'prerelease' }
lerna notice cli v3.13.4
lerna verb rootPath /<dir>/<repo>
lerna info versioning independent
lerna sill isAnythingCommitted 
lerna verb isAnythingCommitted 1
lerna sill currentBranch 
lerna verb currentBranch master
lerna sill hasTags 
lerna verb hasTags false
lerna info Assuming all packages changed
lerna verb updated @<scope>/<pkg1>
lerna verb updated @<scope>/<pkg2>
lerna verb updated @<scope>/<pkg3>
lerna info version Skipping unversioned private package "@<scope>/<pkg3>"
lerna verb git-describe undefined => "5b18165"
lerna sill git-describe parsed => {"refCount":"7","sha":"5b18165","isDirty":false}
lerna sill batched [ PackageGraphNode {
lerna sill batched     name: '@<scope>/<pkg1>',
lerna sill batched     externalDependencies: Map { '<dep>' => [Object] },
lerna sill batched     localDependencies: Map {},
lerna sill batched     localDependents: Map { '@<scope>/<pkg2>' => [PackageGraphNode] } } ]
lerna sill batched [ PackageGraphNode {
lerna sill batched     name: '@<scope>/<pkg2>',
lerna sill batched     externalDependencies: Map {},
lerna sill batched     localDependencies: Map {},
lerna sill batched     localDependents: Map {} } ]

Changes:
 - @<scope>/<pkg1>: 0.0.0 => 0.0.1-alpha.0
 - @<scope>/<pkg2>: 0.0.0 => 0.0.1-alpha.0

lerna info auto-confirmed 
lerna info execute Skipping git push
lerna info execute Skipping GitHub releases
lerna sill lifecycle No script for "preversion" in "<repo>", continuing
lerna sill lifecycle No script for "preversion" in "@<scope>/<pkg1>", continuing
lerna sill lifecycle No script for "version" in "@<scope>/<pkg1>", continuing
lerna sill independent for @<scope>/<pkg1> at /<dir>/<repo>/packages/<pkg1>
lerna verb getChangelogConfig using preset "conventional-changelog-conventionalcommits"
lerna sill npa { type: 'tag',
lerna sill npa   registry: true,
lerna sill npa   where: undefined,
lerna sill npa   raw: 'conventional-changelog-conventionalcommits',
lerna sill npa   name: 'conventional-changelog-conventionalcommits',
lerna sill npa   escapedName: 'conventional-changelog-conventionalcommits',
lerna sill npa   scope: undefined,
lerna sill npa   rawSpec: '',
lerna sill npa   saveSpec: null,
lerna sill npa   fetchSpec: 'latest',
lerna sill npa   gitRange: undefined,
lerna sill npa   gitCommittish: undefined,
lerna sill npa   hosted: undefined }
lerna verb getChangelogConfig Attempting to resolve preset "conventional-changelog-conventionalcommits"
lerna info getChangelogConfig Successfully resolved preset "conventional-changelog-conventionalcommits"
```

The log is for version `3.13`. I noticed the same for `3.14` & `3.15`.