### PR TITLE
fix(deps, cli): bumps (minor + patch) lodash in conventional-changelog-cli

### DIFF
--- a/packages/conventional-changelog-cli/package.json
+++ b/packages/conventional-changelog-cli/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "add-stream": "^1.0.0",
     "conventional-changelog": "file:../conventional-changelog",
-    "lodash": "^4.2.1",
+    "lodash": "^4.14.14",
     "meow": "^4.0.0",
     "tempfile": "^1.1.1"
   },


### PR DESCRIPTION
- Resolves a security warning in lodash (CVE-2019-10744)

closes #486 