### PR TITLE
feat: sort sections of CHANGELOG based on priority

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   },
   "scripts": {
     "lint": "eslint . --cache --cache-location ./node_modules/.cache/ --ignore-path .gitignore",
+    "fix": "eslint . --fix --cache --cache-location ./node_modules/.cache/ --ignore-path .gitignore",
     "pretest": "npm run lint",
     "test": "nyc mocha --timeout 30000 packages/*/test{,/*}.js",
     "test-windows": "lerna exec --concurrency 1 -- npm run test-windows",

--- a/packages/conventional-changelog-conventionalcommits/test/test.js
+++ b/packages/conventional-changelog-conventionalcommits/test/test.js
@@ -119,7 +119,7 @@ describe('conventionalcommits.org preset', function () {
           chunk.indexOf('Features') < chunk.indexOf('Bug Fixes') &&
           chunk.indexOf('Bug Fixes') < chunk.indexOf('Performance Improvements') &&
           chunk.indexOf('Performance Improvements') < chunk.indexOf('Reverts')
-        ).to.be.true;
+        ).to.equal(true)
 
         done()
       }))

--- a/packages/conventional-changelog-conventionalcommits/test/test.js
+++ b/packages/conventional-changelog-conventionalcommits/test/test.js
@@ -113,6 +113,14 @@ describe('conventionalcommits.org preset', function () {
         expect(chunk).to.not.include('***:**')
         expect(chunk).to.not.include(': Not backward compatible.')
 
+        // CHANGELOG should group sections in order of importance:
+        expect(
+          chunk.indexOf('BREAKING CHANGE') < chunk.indexOf('Features') &&
+          chunk.indexOf('Features') < chunk.indexOf('Bug Fixes') &&
+          chunk.indexOf('Bug Fixes') < chunk.indexOf('Performance Improvements') &&
+          chunk.indexOf('Performance Improvements') < chunk.indexOf('Reverts')
+        ).to.be.true;
+
         done()
       }))
   })

--- a/packages/conventional-changelog-conventionalcommits/writer-opts.js
+++ b/packages/conventional-changelog-conventionalcommits/writer-opts.js
@@ -141,13 +141,13 @@ function getWriterOpts (config) {
     // the groupings of commit messages, e.g., Features vs., Bug Fixes, are
     // sorted based on their probable importance:
     commitGroupsSort: (a, b) => {
-      const commitGroupOrder = ['Reverts', 'Performance Improvements', 'Bug Fixes', 'Features'];
-      const gRankA = commitGroupOrder.indexOf(a.title);
-      const gRankB = commitGroupOrder.indexOf(b.title);
+      const commitGroupOrder = ['Reverts', 'Performance Improvements', 'Bug Fixes', 'Features']
+      const gRankA = commitGroupOrder.indexOf(a.title)
+      const gRankB = commitGroupOrder.indexOf(b.title)
       if (gRankA >= gRankB) {
-        return -1;
+        return -1
       } else {
-        return 1;
+        return 1
       }
     },
     commitsSort: [`scope`, `subject`],

--- a/packages/conventional-changelog-conventionalcommits/writer-opts.js
+++ b/packages/conventional-changelog-conventionalcommits/writer-opts.js
@@ -138,7 +138,18 @@ function getWriterOpts (config) {
       return commit
     },
     groupBy: `type`,
-    commitGroupsSort: `title`,
+    // the groupings of commit messages, e.g., Features vs., Bug Fixes, are
+    // sorted based on their probable importance:
+    commitGroupsSort: (a, b) => {
+      const commitGroupOrder = ['Reverts', 'Performance Improvements', 'Bug Fixes', 'Features'];
+      const gRankA = commitGroupOrder.indexOf(a.title);
+      const gRankB = commitGroupOrder.indexOf(b.title);
+      if (gRankA >= gRankB) {
+        return -1;
+      } else {
+        return 1;
+      }
+    },
     commitsSort: [`scope`, `subject`],
     noteGroupsSort: `title`,
     notesSort: compareFunc


### PR DESCRIPTION
@tommywo @jbottigliero small tweak to improve readability of CHANGELOG, features will now be displayed above fixes.