### PR TITLE
fix(eslint): display short tag in release notes (closes #313)

### DIFF
--- a/packages/conventional-changelog-eslint/templates/commit.hbs
+++ b/packages/conventional-changelog-eslint/templates/commit.hbs
@@ -1,5 +1,5 @@
 * {{#if message}}{{message}}{{else}}{{header}}{{/if}}
 
-{{~!-- commit hash --}} {{#if @root.linkReferences}}([{{hash}}]({{#if @root.host}}{{@root.host}}/{{/if}}{{#if @root.owner}}{{@root.owner}}/{{/if}}{{@root.repository}}/{{@root.commit}}/{{hash}})){{else}}{{hash~}}{{/if}}
+{{~!-- commit hash --}} {{#if @root.linkReferences}}([{{shortHash}}]({{#if @root.host}}{{@root.host}}/{{/if}}{{#if @root.owner}}{{@root.owner}}/{{/if}}{{@root.repository}}/{{@root.commit}}/{{hash}})){{else}}{{hash~}}{{/if}}
 
 {{~!-- commit references --}}{{#if references}}, closes{{~#each references}} {{#if @root.linkReferences}}[{{#if this.owner}}{{this.owner}}/{{/if}}{{this.repository}}#{{this.issue}}]({{#if @root.host}}{{@root.host}}/{{/if}}{{#if this.repository}}{{#if this.owner}}{{this.owner}}/{{/if}}{{this.repository}}{{else}}{{#if @root.owner}}{{@root.owner}}/{{/if}}{{@root.repository}}{{/if}}/{{@root.issue}}/{{this.issue}}){{else}}{{#if this.owner}}{{this.owner}}/{{/if}}{{this.repository}}#{{this.issue}}{{/if}}{{/each}}{{/if}}

--- a/packages/conventional-changelog-eslint/writer-opts.js
+++ b/packages/conventional-changelog-eslint/writer-opts.js
@@ -26,6 +26,8 @@ function getWriterOpts () {
         return
       }
 
+      commit.shortHash = commit.hash.substring(0, 7)
+
       return commit
     },
     groupBy: `tag`,


### PR DESCRIPTION
Fixes current problem where ESLIint generates release notes using the full hash like shown below.

![image](https://user-images.githubusercontent.com/230500/63832285-c0d1b600-c970-11e9-8a92-6d574668dba6.png)
