### PR TITLE
fix(preset-loader): fix handling conventionalcommits preset without config object

### DIFF
--- a/packages/conventional-changelog-cli/test/test.js
+++ b/packages/conventional-changelog-cli/test/test.js
@@ -367,6 +367,19 @@ describe('cli', function () {
         done()
       }))
   })
+  it('--preset "conventionalcommits" should work', function (done) {
+    writeFileSync('angular', '')
+    shell.exec('git add --all && git commit -m"fix: fix it!"')
+    var cp = spawn(cliPath, ['--preset', 'conventionalcommits'], {
+      stdio: [process.stdin, null, null]
+    })
+
+    cp.stdout
+      .pipe(concat(function (chunk) {
+        expect(chunk.toString()).to.include('Bug Fixes')
+        done()
+      }))
+  })
 
   it('--config should work with --preset', function (done) {
     var cp = spawn(cliPath, ['--preset', 'angular', '--config', path.join(__dirname, 'fixtures/config.js')], {

--- a/packages/conventional-changelog-preset-loader/index.js
+++ b/packages/conventional-changelog-preset-loader/index.js
@@ -33,8 +33,9 @@ function presetLoader (requireMethod) {
       // rather than returning a promise, presets can return a builder function
       // which accepts a config object (allowing for customization) and returns
       // a promise.
-      if (config && !config.then && typeof path === 'object') {
-        return config(path)
+      if (config && !config.then) {
+        const options = typeof path === 'object' ? path : {}
+        return config(options)
       } else {
         // require returned a promise that resolves to a config object.
         return config


### PR DESCRIPTION
fix(preset-loader): fix handling conventionalcommits preset without config object