### PR TITLE
fix: use full commit hash in commit link

### DIFF
--- a/packages/conventional-changelog-angular/templates/commit.hbs
+++ b/packages/conventional-changelog-angular/templates/commit.hbs
@@ -6,7 +6,7 @@
 {{~/if}}
 
 {{~!-- commit link --}} {{#if @root.linkReferences~}}
-  ([{{hash}}](
+  ([{{shortHash}}](
   {{~#if @root.repository}}
     {{~#if @root.host}}
       {{~@root.host}}/
@@ -20,7 +20,7 @@
   {{~/if}}/
   {{~@root.commit}}/{{hash}}))
 {{~else}}
-  {{~hash}}
+  {{~shortHash}}
 {{~/if}}
 
 {{~!-- commit references --}}

--- a/packages/conventional-changelog-angular/writer-opts.js
+++ b/packages/conventional-changelog-angular/writer-opts.js
@@ -62,7 +62,7 @@ function getWriterOpts () {
       }
 
       if (typeof commit.hash === `string`) {
-        commit.hash = commit.hash.substring(0, 7)
+        commit.shortHash = commit.hash.substring(0, 7)
       }
 
       if (typeof commit.subject === `string`) {

--- a/packages/conventional-changelog-atom/templates/commit.hbs
+++ b/packages/conventional-changelog-atom/templates/commit.hbs
@@ -1,5 +1,5 @@
 * {{#if shortDesc}}{{shortDesc}}{{else}}{{header}}{{/if}}
 
-{{~!-- commit hash --}} {{#if @root.linkReferences}}([{{hash}}]({{#if @root.host}}{{@root.host}}/{{/if}}{{#if @root.owner}}{{@root.owner}}/{{/if}}{{@root.repository}}/{{@root.commit}}/{{hash}})){{else}}{{hash~}}{{/if}}
+{{~!-- commit hash --}} {{#if @root.linkReferences}}([{{shortHash}}]({{#if @root.host}}{{@root.host}}/{{/if}}{{#if @root.owner}}{{@root.owner}}/{{/if}}{{@root.repository}}/{{@root.commit}}/{{hash}})){{else}}{{shortHash~}}{{/if}}
 
 {{~!-- commit references --}}{{#if references}}, closes{{~#each references}} {{#if @root.linkReferences}}[{{#if this.owner}}{{this.owner}}/{{/if}}{{this.repository}}#{{this.issue}}]({{#if @root.host}}{{@root.host}}/{{/if}}{{#if this.repository}}{{#if this.owner}}{{this.owner}}/{{/if}}{{this.repository}}{{else}}{{#if @root.owner}}{{@root.owner}}/{{/if}}{{@root.repository}}{{/if}}/{{@root.issue}}/{{this.issue}}){{else}}{{#if this.owner}}{{this.owner}}/{{/if}}{{this.repository}}#{{this.issue}}{{/if}}{{/each}}{{/if}}

--- a/packages/conventional-changelog-atom/writer-opts.js
+++ b/packages/conventional-changelog-atom/writer-opts.js
@@ -32,7 +32,7 @@ function getWriterOpts () {
       emojiLength = commit.emoji.length
 
       if (typeof commit.hash === `string`) {
-        commit.hash = commit.hash.substring(0, 7)
+        commit.shortHash = commit.hash.substring(0, 7)
       }
 
       if (typeof commit.shortDesc === `string`) {

--- a/packages/conventional-changelog-codemirror/templates/commit.hbs
+++ b/packages/conventional-changelog-codemirror/templates/commit.hbs
@@ -1,5 +1,5 @@
 {{#if type}}**{{type}}** {{/if}}{{message}}
 
-{{~!-- commit hash --}} {{#if @root.linkReferences}}([{{hash}}]({{#if @root.host}}{{@root.host}}/{{/if}}{{#if @root.owner}}{{@root.owner}}/{{/if}}{{@root.repository}}/{{@root.commit}}/{{hash}})){{else}}{{hash~}}{{/if}}
+{{~!-- commit hash --}} {{#if @root.linkReferences}}([{{shortHash}}]({{#if @root.host}}{{@root.host}}/{{/if}}{{#if @root.owner}}{{@root.owner}}/{{/if}}{{@root.repository}}/{{@root.commit}}/{{hash}})){{else}}{{shortHash~}}{{/if}}
 
 {{~!-- commit references --}}{{#if references}}, closes{{~#each references}} {{#if @root.linkReferences}}[{{#if this.owner}}{{this.owner}}/{{/if}}{{this.repository}}#{{this.issue}}]({{#if @root.host}}{{@root.host}}/{{/if}}{{#if this.repository}}{{#if this.owner}}{{this.owner}}/{{/if}}{{this.repository}}{{else}}{{#if @root.owner}}{{@root.owner}}/{{/if}}{{@root.repository}}{{/if}}/{{@root.issue}}/{{this.issue}}){{else}}{{#if this.owner}}{{this.owner}}/{{/if}}{{this.repository}}#{{this.issue}}{{/if}}{{/each}}{{/if}}

--- a/packages/conventional-changelog-codemirror/writer-opts.js
+++ b/packages/conventional-changelog-codemirror/writer-opts.js
@@ -27,7 +27,7 @@ function getWriterOpts () {
       }
 
       if (typeof commit.hash === `string`) {
-        commit.hash = commit.hash.substring(0, 7)
+        commit.shortHash = commit.hash.substring(0, 7)
       }
 
       return commit

--- a/packages/conventional-changelog-conventionalcommits/templates/commit.hbs
+++ b/packages/conventional-changelog-conventionalcommits/templates/commit.hbs
@@ -6,9 +6,9 @@
 {{~/if}}
 
 {{~!-- commit link --}} {{#if @root.linkReferences~}}
-  ([{{hash}}]({{commitUrlFormat}}))
+  ([{{shortHash}}]({{commitUrlFormat}}))
 {{~else}}
-  {{~hash}}
+  {{~shortHash}}
 {{~/if}}
 
 {{~!-- commit references --}}

--- a/packages/conventional-changelog-conventionalcommits/writer-opts.js
+++ b/packages/conventional-changelog-conventionalcommits/writer-opts.js
@@ -88,7 +88,7 @@ function getWriterOpts (config) {
       }
 
       if (typeof commit.hash === `string`) {
-        commit.hash = commit.hash.substring(0, 7)
+        commit.shortHash = commit.hash.substring(0, 7)
       }
 
       if (typeof commit.subject === `string`) {

--- a/packages/conventional-changelog-ember/writer-opts.js
+++ b/packages/conventional-changelog-ember/writer-opts.js
@@ -41,7 +41,7 @@ function getWriterOpts () {
       }
 
       if (typeof commit.hash === `string`) {
-        commit.hash = commit.hash.substring(0, 7)
+        commit.shortHash = commit.hash.substring(0, 7)
       }
 
       return commit

--- a/packages/conventional-changelog-jquery/templates/commit.hbs
+++ b/packages/conventional-changelog-jquery/templates/commit.hbs
@@ -6,7 +6,7 @@
 
 {{~!-- commit link --}}
 {{~#if @root.linkReferences~}}
-  ([{{hash}}](
+  ([{{shortHash}}](
   {{~#if @root.host}}
     {{~@root.host}}/
   {{~/if}}
@@ -15,7 +15,7 @@
   {{~/if}}
   {{~@root.repository}}/{{@root.commit}}/{{hash}}))
 {{~else}}
-  {{~hash}}
+  {{~shortHash}}
 {{~/if}}
 
 {{~!-- commit references --}}

--- a/packages/conventional-changelog-jquery/writer-opts.js
+++ b/packages/conventional-changelog-jquery/writer-opts.js
@@ -27,7 +27,7 @@ function getWriterOpts () {
       }
 
       if (typeof commit.hash === `string`) {
-        commit.hash = commit.hash.substring(0, 7)
+        commit.shortHash = commit.hash.substring(0, 7)
       }
 
       commit.references.forEach(function (reference) {

--- a/packages/conventional-changelog-jshint/templates/commit.hbs
+++ b/packages/conventional-changelog-jshint/templates/commit.hbs
@@ -1,5 +1,5 @@
 * {{#if shortDesc}}{{shortDesc}}{{else}}{{header}}{{/if}}
 
-{{~!-- commit hash --}} {{#if @root.linkReferences}}([{{hash}}]({{#if @root.host}}{{@root.host}}/{{/if}}{{#if @root.owner}}{{@root.owner}}/{{/if}}{{@root.repository}}/{{@root.commit}}/{{hash}})){{else}}{{hash~}}{{/if}}
+{{~!-- commit hash --}} {{#if @root.linkReferences}}([{{shortHash}}]({{#if @root.host}}{{@root.host}}/{{/if}}{{#if @root.owner}}{{@root.owner}}/{{/if}}{{@root.repository}}/{{@root.commit}}/{{hash}})){{else}}{{shortHash~}}{{/if}}
 
 {{~!-- commit references --}}{{#if references}}, closes{{~#each references}} {{#if @root.linkReferences}}[{{#if this.owner}}{{this.owner}}/{{/if}}{{this.repository}}#{{this.issue}}]({{#if @root.host}}{{@root.host}}/{{/if}}{{#if this.repository}}{{#if this.owner}}{{this.owner}}/{{/if}}{{this.repository}}{{else}}{{#if @root.owner}}{{@root.owner}}/{{/if}}{{@root.repository}}{{/if}}/{{@root.issue}}/{{this.issue}}){{else}}{{#if this.owner}}{{this.owner}}/{{/if}}{{this.repository}}#{{this.issue}}{{/if}}{{/each}}{{/if}}


### PR DESCRIPTION
fixes  #476

 conventional-changelog/standard-version#452