### PR TITLE
feat(preset-loader): allow use of absolute package path

### DIFF
--- a/packages/conventional-changelog-preset-loader/index.js
+++ b/packages/conventional-changelog-preset-loader/index.js
@@ -7,24 +7,29 @@ module.exports.presetLoader = presetLoader
 
 function presetLoader (requireMethod) {
   return path => {
-    let isAbsolute = false
     let name = ''
     let scope = ''
+    let absolutePath = ''
 
     if (typeof path === 'string') {
       name = path.toLowerCase()
-      isAbsolute = nodePath.isAbsolute(path)
+      if (nodePath.isAbsolute(path)) {
+        absolutePath = path
+      }
     } else if (typeof path === 'object' && path.name) {
       // Rather than a string preset name, options.preset can be an object
       // with a "name" key indicating the preset to load; additinoal key/value
       // pairs are assumed to be configuration for the preset. See the documentation
       // for a given preset for configuration available.
       name = path.name.toLowerCase()
+      if (nodePath.isAbsolute(path.name)) {
+        absolutePath = path.name
+      }
     } else {
       throw Error('preset must be string or object with key name')
     }
 
-    if (!isAbsolute) {
+    if (!absolutePath) {
       if (name[0] === `@`) {
         const parts = name.split(`/`)
         scope = parts.shift() + `/`
@@ -37,7 +42,7 @@ function presetLoader (requireMethod) {
     }
 
     try {
-      const config = requireMethod(isAbsolute ? path : `${scope}${name}`)
+      const config = requireMethod(absolutePath || `${scope}${name}`)
       // rather than returning a promise, presets can return a builder function
       // which accepts a config object (allowing for customization) and returns
       // a promise.

--- a/packages/conventional-changelog-preset-loader/test/test.js
+++ b/packages/conventional-changelog-preset-loader/test/test.js
@@ -91,4 +91,15 @@ describe(`presetLoader`, () => {
     expect(requireMethod).to.have.been.calledOnce
       .and.to.have.been.calledWith(`@scope/conventional-changelog-angular/preset/path`)
   })
+
+  it(`loads package with an absolute file path`, () => {
+    const requireMethod = sinon.spy()
+    const load = presetLoader(requireMethod)
+    const filePath = require.resolve(`conventional-changelog-angular`)
+
+    load(filePath)
+
+    expect(requireMethod).to.have.been.calledOnce
+      .and.to.have.been.calledWith(filePath)
+  })
 })

--- a/packages/conventional-changelog-preset-loader/test/test.js
+++ b/packages/conventional-changelog-preset-loader/test/test.js
@@ -102,4 +102,15 @@ describe(`presetLoader`, () => {
     expect(requireMethod).to.have.been.calledOnce
       .and.to.have.been.calledWith(filePath)
   })
+
+  it(`loads package with an absolute file path name`, () => {
+    const requireMethod = sinon.spy()
+    const load = presetLoader(requireMethod)
+    const filePath = require.resolve(`conventional-changelog-angular`)
+
+    load({ name: filePath })
+
+    expect(requireMethod).to.have.been.calledOnce
+      .and.to.have.been.calledWith(filePath)
+  })
 })


### PR DESCRIPTION
Allow the preset package path to be an absolute file path to support Yarn PnP