### PR TITLE
fix(deps): update lodash to fix security issue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2551,7 +2551,7 @@
       "requires": {
         "add-stream": "^1.0.0",
         "conventional-changelog": "file:packages/conventional-changelog",
-        "lodash": "^4.14.14",
+        "lodash": "^4.17.15",
         "meow": "^4.0.0",
         "tempfile": "^3.0.0"
       },
@@ -2587,7 +2587,7 @@
       "version": "file:packages/conventional-changelog-conventionalcommits",
       "requires": {
         "compare-func": "^1.3.1",
-        "lodash": "^4.2.1",
+        "lodash": "^4.17.15",
         "q": "^1.5.1"
       }
     },
@@ -2601,7 +2601,7 @@
         "git-raw-commits": "2.0.0",
         "git-remote-origin-url": "^2.0.0",
         "git-semver-tags": "file:packages/git-semver-tags",
-        "lodash": "^4.2.1",
+        "lodash": "^4.17.15",
         "normalize-package-data": "^2.3.5",
         "q": "^1.5.1",
         "read-pkg": "^3.0.0",
@@ -2703,7 +2703,7 @@
         "dateformat": "^3.0.0",
         "handlebars": "^4.4.0",
         "json-stringify-safe": "^5.0.1",
-        "lodash": "^4.2.1",
+        "lodash": "^4.17.15",
         "meow": "^4.0.0",
         "semver": "^6.0.0",
         "split": "^1.0.0",
@@ -2749,6 +2749,11 @@
           "requires": {
             "text-extensions": "^2.0.0"
           }
+        },
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
         },
         "text-extensions": {
           "version": "2.0.0",
@@ -8689,7 +8694,7 @@
         "conventional-changelog-core": "file:packages/conventional-changelog-core",
         "figures": "^3.0.0",
         "fs-access": "^1.0.0",
-        "lodash": "^4.2.1",
+        "lodash": "^4.17.15",
         "meow": "^4.0.0",
         "rimraf": "^2.5.2",
         "sprintf-js": "^1.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2735,7 +2735,7 @@
       "requires": {
         "JSONStream": "^1.0.4",
         "is-text-path": "^2.0.0",
-        "lodash": "^4.2.1",
+        "lodash": "^4.17.15",
         "meow": "^4.0.0",
         "split2": "^2.0.0",
         "through2": "^3.0.0",

--- a/packages/conventional-changelog-cli/package.json
+++ b/packages/conventional-changelog-cli/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "add-stream": "^1.0.0",
     "conventional-changelog": "file:../conventional-changelog",
-    "lodash": "^4.14.14",
+    "lodash": "^4.17.15",
     "meow": "^4.0.0",
     "tempfile": "^3.0.0"
   },

--- a/packages/conventional-changelog-conventionalcommits/package.json
+++ b/packages/conventional-changelog-conventionalcommits/package.json
@@ -35,7 +35,7 @@
   "homepage": "https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-angular#readme",
   "dependencies": {
     "compare-func": "^1.3.1",
-    "lodash": "^4.2.1",
+    "lodash": "^4.17.15",
     "q": "^1.5.1"
   }
 }

--- a/packages/conventional-changelog-core/package.json
+++ b/packages/conventional-changelog-core/package.json
@@ -33,7 +33,7 @@
     "git-raw-commits": "2.0.0",
     "git-remote-origin-url": "^2.0.0",
     "git-semver-tags": "file:../git-semver-tags",
-    "lodash": "^4.2.1",
+    "lodash": "^4.17.15",
     "normalize-package-data": "^2.3.5",
     "q": "^1.5.1",
     "read-pkg": "^3.0.0",

--- a/packages/conventional-changelog-writer/package.json
+++ b/packages/conventional-changelog-writer/package.json
@@ -41,7 +41,7 @@
     "dateformat": "^3.0.0",
     "handlebars": "^4.4.0",
     "json-stringify-safe": "^5.0.1",
-    "lodash": "^4.2.1",
+    "lodash": "^4.17.15",
     "meow": "^4.0.0",
     "semver": "^6.0.0",
     "split": "^1.0.0",

--- a/packages/conventional-commits-parser/package.json
+++ b/packages/conventional-commits-parser/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "JSONStream": "^1.0.4",
     "is-text-path": "^2.0.0",
-    "lodash": "^4.2.1",
+    "lodash": "^4.17.15",
     "meow": "^4.0.0",
     "split2": "^2.0.0",
     "through2": "^3.0.0",

--- a/packages/standard-changelog/package.json
+++ b/packages/standard-changelog/package.json
@@ -32,7 +32,7 @@
     "conventional-changelog-core": "file:../conventional-changelog-core",
     "figures": "^3.0.0",
     "fs-access": "^1.0.0",
-    "lodash": "^4.2.1",
+    "lodash": "^4.17.15",
     "meow": "^4.0.0",
     "rimraf": "^2.5.2",
     "sprintf-js": "^1.1.1",


### PR DESCRIPTION
This includes fixes for CVE-2019-1010266, CVE-2019-10744 and
CVE-2018-16487.