### PR TITLE
parser: add breaking change notes if header match `breakingHeaderPattern`

### DIFF
--- a/packages/conventional-commits-parser/lib/parser.js
+++ b/packages/conventional-commits-parser/lib/parser.js
@@ -253,6 +253,17 @@ function parser (raw, options, regex) {
     }
   })
 
+  if (options.breakingHeaderPattern && notes.length === 0) {
+    var breakingHeader = header.match(options.breakingHeaderPattern)
+    if (breakingHeader) {
+      const noteText = breakingHeader[3] // the description of the change.
+      notes.push({
+        title: 'BREAKING CHANGE',
+        text: noteText
+      })
+    }
+  }
+
   while ((mentionsMatch = regex.mentions.exec(raw))) {
     mentions.push(mentionsMatch[1])
   }

--- a/packages/conventional-commits-parser/test/parser.spec.js
+++ b/packages/conventional-commits-parser/test/parser.spec.js
@@ -925,6 +925,42 @@ describe('parser', function () {
       }])
       expect(msg.footer).to.equal('Kills gh-1, #123\nother\nBREAKING AMEND: some breaking change')
     })
+
+    it('should add the subject as note if it match breakingHeaderPattern', function () {
+      var options = {
+        headerPattern: /^(\w*)(?:\(([\w$.\-* ]*)\))?: (.*)$/,
+        breakingHeaderPattern: /^(\w*)(?:\((.*)\))?!: (.*)$/,
+        headerCorrespondence: ['type', 'scope', 'subject']
+      }
+      var msg = parser(
+        'feat!: breaking change feature',
+        options,
+        reg
+      )
+      expect(msg.notes[0]).to.eql({
+        title: 'BREAKING CHANGE',
+        text: 'breaking change feature'
+      })
+    })
+
+    it('should not duplicate notes if the subject match breakingHeaderPattern', function () {
+      var options = {
+        headerPattern: /^(\w*)(?:\(([\w$.\-* ]*)\))?: (.*)$/,
+        breakingHeaderPattern: /^(\w*)(?:\((.*)\))?!: (.*)$/,
+        headerCorrespondence: ['type', 'scope', 'subject'],
+        noteKeywords: ['BREAKING AMEND']
+      }
+      var msg = parser(
+        'feat!: breaking change feature\nBREAKING AMEND: some breaking change',
+        options,
+        reg
+      )
+      expect(msg.notes[0]).to.eql({
+        title: 'BREAKING AMEND',
+        text: 'some breaking change'
+      })
+      expect(msg.notes.length).to.eql(1)
+    })
   })
 
   describe('others', function () {


### PR DESCRIPTION
fix #543

For every presets, a breaking can be determined by testing the length of `commit.notes` however the `conventionalcommits` convention specify that a commit can be a breaking change if it has an `!` after the type/scope even if it doesn't have a `BREAKING CHANGE` note in the footer.
So in such case the `notes` property of the parsed commit will be an empty array and there is no way to determine if the parsed commit is a breaking or not.

This PR add something similar to what `conventional-changelog-conventionalcommits` does for the writer: https://github.com/conventional-changelog/conventional-changelog/blob/63d8cbedd24d957c759865211dd2341fd4a3e1f2/packages/conventional-changelog-conventionalcommits/writer-opts.js#L65

The commit `feat!: breaking change feature` will now be parsed as:
```
{
  message: 'feat!: some breaking feature',
  type: 'feat',
  subject: 'some breaking feature',
  header: 'feat!: some breaking feature',
  notes: [{title: 'BREAKING CHANGE', text: 'some breaking feature' }],
}
```
