### PR TITLE
fix(conventional-commits-parser): Added missing separator pipe to non tty parser

### DIFF
--- a/packages/conventional-commits-parser/cli.js
+++ b/packages/conventional-commits-parser/cli.js
@@ -137,6 +137,7 @@ if (process.stdin.isTTY) {
 } else {
   options.warn = true
   process.stdin
+    .pipe(split(separator))
     .pipe(conventionalCommitsParser(options))
     .on('error', function (err) {
       console.error(err.toString())

--- a/packages/conventional-commits-parser/test/cli.spec.js
+++ b/packages/conventional-commits-parser/test/cli.spec.js
@@ -144,6 +144,22 @@ describe('changelog-parser cli', function () {
       }))
   })
 
+  it('should seperate if it is not a tty', function (done) {
+    var cp = spawn(cliPath, ['==='], {
+      stdio: [fs.openSync('./fixtures/log2.txt', 'r'), null, null]
+    })
+
+    cp.stdout
+      .pipe(concat(function (chunk) {
+        chunk = chunk.toString()
+
+        expect(chunk).to.include('"type":"docs","scope":"ngMessageExp","subject":"split ngMessage docs up to show its alias more clearly"')
+        expect(chunk).to.include('"type":"fix","scope":"$animate","subject":"applyStyles from options on leave"')
+
+        done()
+      }))
+  })
+
   it('should error if it is not a tty and commit cannot be parsed', function (done) {
     var cp = spawn(cliPath, [], {
       stdio: [fs.openSync('./fixtures/bad_commit.txt', 'r'), null, null]


### PR DESCRIPTION
fix https://github.com/conventional-changelog/conventional-changelog/issues/539

Adds a separator to the non tty path with unit test