### PR TITLE
Respect commits merge order

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2704,6 +2704,7 @@
     "conventional-changelog-core": {
       "version": "file:packages/conventional-changelog-core",
       "requires": {
+        "add-stream": "^1.0.0",
         "conventional-changelog-writer": "file:packages/conventional-changelog-writer",
         "conventional-commits-parser": "file:packages/conventional-commits-parser",
         "dateformat": "^3.0.0",

--- a/packages/conventional-changelog-core/index.js
+++ b/packages/conventional-changelog-core/index.js
@@ -8,7 +8,7 @@ const _ = require('lodash')
 const stream = require('stream')
 const through = require('through2')
 const mergeConfig = require('./lib/merge-config')
-function conventionalChangelog(options, context, gitRawCommitsOpts, parserOpts, writerOpts, gitRawExecOpts) {
+function conventionalChangelog (options, context, gitRawCommitsOpts, parserOpts, writerOpts, gitRawExecOpts) {
   writerOpts = writerOpts || {}
 
   var readable = new stream.Readable({
@@ -34,7 +34,7 @@ function conventionalChangelog(options, context, gitRawCommitsOpts, parserOpts, 
       })
       commitsStream._read = function () { }
 
-      function commitsRange(from, to) {
+      function commitsRange (from, to) {
         return gitRawCommits(_.merge({}, gitRawCommitsOpts, {
           from: from,
           to: to

--- a/packages/conventional-changelog-core/package.json
+++ b/packages/conventional-changelog-core/package.json
@@ -26,6 +26,7 @@
   },
   "homepage": "https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-core#readme",
   "dependencies": {
+    "add-stream": "^1.0.0",
     "conventional-changelog-writer": "file:../conventional-changelog-writer",
     "conventional-commits-parser": "file:../conventional-commits-parser",
     "dateformat": "^3.0.0",

--- a/packages/conventional-changelog-core/test/test.js
+++ b/packages/conventional-changelog-core/test/test.js
@@ -119,11 +119,11 @@ betterThanBefore.setups([
     gitDummyCommit('merged, unreleased')
     shell.exec('git checkout master')
     gitDummyCommit('included in 4.0.0')
-    shell.exec('git tag 4.0.0')
+    shell.exec('git tag v4.0.0')
     shell.exec('git merge feature -m"Merge branch \'feature\'"')
     writeFileSync('./package.json', '{"version": "5.0.0"}') // required by angular preset.
     shell.exec('git add --all && git commit -m"5.0.0"')
-    shell.exec('git tag 5.0.0')
+    shell.exec('git tag v5.0.0')
     shell.exec('git merge feature2 -m"Merge branch \'feature2\'"')
   }
 ])

--- a/packages/conventional-changelog-core/test/test.js
+++ b/packages/conventional-changelog-core/test/test.js
@@ -111,6 +111,20 @@ betterThanBefore.setups([
   function () { // 18
     gitDummyCommit()
     shell.exec('git tag 3.0.0')
+  },
+  function () { // 19
+    shell.exec('git checkout feature')
+    gitDummyCommit('included in 5.0.0')
+    shell.exec('git checkout -b feature2')
+    gitDummyCommit('merged, unreleased')
+    shell.exec('git checkout master')
+    gitDummyCommit('included in 4.0.0')
+    shell.exec('git tag 4.0.0')
+    shell.exec('git merge feature -m"Merge branch \'feature\'"')
+    writeFileSync('./package.json', '{"version": "5.0.0"}') // required by angular preset.
+    shell.exec('git add --all && git commit -m"5.0.0"')
+    shell.exec('git tag 5.0.0')
+    shell.exec('git merge feature2 -m"Merge branch \'feature2\'"')
   }
 ])
 
@@ -1005,6 +1019,36 @@ describe('conventionalChangelogCore', function () {
           cb()
         }, function () {
           expect(i).to.equal(3)
+          done()
+        }))
+    })
+
+    it('should respect merge order', function (done) {
+      preparing(19)
+      var i = 0
+
+      conventionalChangelogCore({
+        releaseCount: 0,
+        append: true,
+        outputUnreleased: true
+      }, {}, {}, {}, {})
+        .pipe(through(function (chunk, enc, cb) {
+          chunk = chunk.toString()
+
+          if (i === 4) {
+            expect(chunk).to.contain('included in 4.0.0')
+            expect(chunk).to.not.contain('included in 5.0.0')
+          } else if (i === 5) {
+            expect(chunk).to.contain('included in 5.0.0')
+            expect(chunk).to.not.contain('merged, unreleased')
+          } else if (i === 6) {
+            expect(chunk).to.contain('merged, unreleased')
+          }
+
+          i++
+          cb()
+        }, function () {
+          expect(i).to.equal(7)
           done()
         }))
     })

--- a/packages/conventional-changelog-core/test/test.js
+++ b/packages/conventional-changelog-core/test/test.js
@@ -866,6 +866,36 @@ describe('conventionalChangelogCore', function () {
       }))
   })
 
+  it('should respect merge order', function (done) {
+    preparing(19)
+    var i = 0
+
+    conventionalChangelogCore({
+      releaseCount: 0,
+      append: true,
+      outputUnreleased: true
+    }, {}, {}, {}, {})
+      .pipe(through(function (chunk, enc, cb) {
+        chunk = chunk.toString()
+
+        if (i === 4) {
+          expect(chunk).to.contain('included in 4.0.0')
+          expect(chunk).to.not.contain('included in 5.0.0')
+        } else if (i === 5) {
+          expect(chunk).to.contain('included in 5.0.0')
+          expect(chunk).to.not.contain('merged, unreleased')
+        } else if (i === 6) {
+          expect(chunk).to.contain('merged, unreleased')
+        }
+
+        i++
+        cb()
+      }, function () {
+        expect(i).to.equal(7)
+        done()
+      }))
+  })
+
   describe('finalizeContext', function () {
     it('should make `context.previousTag` default to a previous semver version of generated log (prepend)', function (done) {
       var tail = preparing(11).tail
@@ -1019,36 +1049,6 @@ describe('conventionalChangelogCore', function () {
           cb()
         }, function () {
           expect(i).to.equal(3)
-          done()
-        }))
-    })
-
-    it('should respect merge order', function (done) {
-      preparing(19)
-      var i = 0
-
-      conventionalChangelogCore({
-        releaseCount: 0,
-        append: true,
-        outputUnreleased: true
-      }, {}, {}, {}, {})
-        .pipe(through(function (chunk, enc, cb) {
-          chunk = chunk.toString()
-
-          if (i === 4) {
-            expect(chunk).to.contain('included in 4.0.0')
-            expect(chunk).to.not.contain('included in 5.0.0')
-          } else if (i === 5) {
-            expect(chunk).to.contain('included in 5.0.0')
-            expect(chunk).to.not.contain('merged, unreleased')
-          } else if (i === 6) {
-            expect(chunk).to.contain('merged, unreleased')
-          }
-
-          i++
-          cb()
-        }, function () {
-          expect(i).to.equal(7)
           done()
         }))
     })


### PR DESCRIPTION
Call `gitRawCommits` with ranges `[tag1..tag2, tag2..tag3, ..., tagX..HEAD]` to make sure commits are returned in right order.

fixes #408 