### PR TITLE
fix(conventional-changelog-core): read current version properly when tagPrefix is provided

### DIFF
--- a/packages/conventional-changelog-core/lib/merge-config.js
+++ b/packages/conventional-changelog-core/lib/merge-config.js
@@ -18,7 +18,6 @@ var URL = require('url').URL
 var _ = require('lodash')
 
 var rhosts = /github|bitbucket|gitlab/i
-var rtag = /tag:\s*[v=]?(.+?)[,)]/gi
 
 function semverTagsPromise (options) {
   return Q.Promise(function (resolve, reject) {
@@ -60,6 +59,8 @@ function mergeConfig (options, context, gitRawCommitsOpts, parserOpts, writerOpt
   context = context || {}
   gitRawCommitsOpts = gitRawCommitsOpts || {}
   gitRawExecOpts = gitRawExecOpts || {}
+
+  var rtag = options && options.tagPrefix ? new RegExp(`tag:\\s*[=]?${options.tagPrefix}(.+?)[,)]`, 'gi') : /tag:\s*[v=]?(.+?)[,)]/gi
 
   options = _.merge({
     pkg: {
@@ -303,6 +304,8 @@ function mergeConfig (options, context, gitRawCommitsOpts, parserOpts, writerOpt
             } else if (!context.currentTag) {
               if (options.lernaPackage) {
                 context.currentTag = options.lernaPackage + '@' + context.version
+              } else if (options.tagPrefix) {
+                context.currentTag = options.tagPrefix + context.version
               } else {
                 context.currentTag = guessNextTag(gitSemverTags[0], context.version)
               }

--- a/packages/conventional-changelog-core/test/test.js
+++ b/packages/conventional-changelog-core/test/test.js
@@ -1190,6 +1190,24 @@ describe('conventionalChangelogCore', function () {
           done()
         }))
     })
+
+    it('takes into account tagPrefix option', function (done) {
+      preparing(16)
+
+      conventionalChangelogCore({
+        tagPrefix: 'foo@',
+        config: require('conventional-changelog-angular')
+      }, {}, { path: './packages/foo' })
+        .pipe(through(function (chunk, enc, cb) {
+          chunk = chunk.toString()
+          // confirm that context.currentTag behaves differently when
+          // tagPrefix is used
+          expect(chunk).to.include('foo@1.0.0...foo@2.0.0')
+          cb()
+        }, function () {
+          done()
+        }))
+    })
   })
 
   describe('config', function () {


### PR DESCRIPTION

fixes #562, #337