### PR TITLE
fix(git-semver-tags): change --tagPrefix flag to --tag-prefix

### DIFF
--- a/packages/git-semver-tags/cli.js
+++ b/packages/git-semver-tags/cli.js
@@ -10,7 +10,7 @@ var args = meow(`
     --cwd                  path to git repository to be searched
     --lerna                parse lerna style git tags
     --package <name>       when listing lerna style tags, filter by a package
-    --tagPrefix <prefix>   prefix to remove from the tags during their processing`,
+    --tag-prefix <prefix>  prefix to remove from the tags during their processing`,
 {
   booleanDefault: undefined,
   flags: {


### PR DESCRIPTION
BREAKING CHANGE: --tagPrefix flag was changed to --tag-prefix

closes #553