### PR TITLE
feat: support slash in headerPattern default options

### DIFF
--- a/packages/conventional-commits-parser/index.js
+++ b/packages/conventional-commits-parser/index.js
@@ -7,7 +7,7 @@ var _ = require('lodash')
 
 function assignOpts (options) {
   options = _.extend({
-    headerPattern: /^(\w*)(?:\(([\w$.\-* ]*)\))?: (.*)$/,
+    headerPattern: /^(\w*)(?:\(([\w$.\-*/ ]*)\))?: (.*)$/,
     headerCorrespondence: ['type', 'scope', 'subject'],
     referenceActions: [
       'close',

--- a/packages/conventional-commits-parser/test/index.spec.js
+++ b/packages/conventional-commits-parser/test/index.spec.js
@@ -331,4 +331,13 @@ describe('sync', function () {
       repository: null
     }])
   })
+
+  it('should parse slash in the header with default headerPattern option', () => {
+    var commit = 'feat(hello/world): message'
+    var result = conventionalCommitsParser.sync(commit)
+
+    expect(result.type).to.equal('feat')
+    expect(result.scope).to.equal('hello/world')
+    expect(result.subject).to.equal('message')
+  })
 })


### PR DESCRIPTION
Currently, if you're using a "/" character in the scope of your commit and using the default option for "headerPattern", the Regex doesn't match the scope and the commit is considered as invalid.

This pull request adds the "/" character to the default "headerPattern" option.