### PR TITLE
fix(conventional-changelog-core): fix duplicated commits when `from` is specified

### DIFF
--- a/packages/conventional-changelog-core/index.js
+++ b/packages/conventional-changelog-core/index.js
@@ -51,7 +51,7 @@ function conventionalChangelog (options, context, gitRawCommitsOpts, parserOpts,
         const from = i > 0
           ? reverseTags[i - 1]
           : gitRawCommitsOpts.from || ''
-        if (gitRawCommitsOpts.from) {
+        if (gitRawCommitsOpts.from && gitRawCommitsOpts.from !== from) {
           let hasData = false
           return commitsRange(gitRawCommitsOpts.from, to)
             .on('data', function () {

--- a/packages/conventional-changelog-core/test/test.js
+++ b/packages/conventional-changelog-core/test/test.js
@@ -803,6 +803,28 @@ describe('conventionalChangelogCore', function () {
       }))
   })
 
+  it('should read each commit range exactly once', function (done) {
+    preparing(9)
+
+    conventionalChangelogCore({
+      preset: {
+        compareUrlFormat: '/compare/{{previousTag}}...{{currentTag}}'
+      }
+    }, {}, {}, {}, {
+      headerPartial: '',
+      commitPartial: '* {{header}}\n'
+    })
+      .pipe(through(function (chunk, enc, cb) {
+        chunk = chunk.toString()
+
+        expect(chunk).to.equal('\n* test8\n* test8\n* test9\n\n\n\n')
+
+        cb()
+      }, function () {
+        done()
+      }))
+  })
+
   it('should recreate the changelog from scratch', function (done) {
     preparing(10)
 


### PR DESCRIPTION
fixes #567