### PR TITLE
fix(conventional-changelog-core): fix duplicated commits when `from` is specified

### DIFF
--- a/packages/conventional-changelog-core/index.js
+++ b/packages/conventional-changelog-core/index.js
@@ -27,6 +27,15 @@ function conventionalChangelog (options, context, gitRawCommitsOpts, parserOpts,
 
       var reverseTags = context.gitSemverTags.slice(0).reverse()
       reverseTags.push('HEAD')
+
+      if (gitRawCommitsOpts.from) {
+        if (reverseTags.indexOf(gitRawCommitsOpts.from) !== -1) {
+          reverseTags = reverseTags.slice(reverseTags.indexOf(gitRawCommitsOpts.from))
+        } else {
+          reverseTags = [gitRawCommitsOpts.from, 'HEAD']
+        }
+      }
+
       var commitsErrorThrown = false
 
       var commitsStream = new stream.Readable({
@@ -47,30 +56,16 @@ function conventionalChangelog (options, context, gitRawCommitsOpts, parserOpts,
           })
       }
 
-      const streams = reverseTags.map((to, i) => {
+      var streams = reverseTags.map((to, i) => {
         const from = i > 0
           ? reverseTags[i - 1]
-          : gitRawCommitsOpts.from || ''
-        if (gitRawCommitsOpts.from && gitRawCommitsOpts.from !== from) {
-          let hasData = false
-          return commitsRange(gitRawCommitsOpts.from, to)
-            .on('data', function () {
-              hasData = true
-            })
-            .pipe(addStream(() => {
-              if (!hasData) {
-                const s = new stream.Readable()
-                s._read = function () { }
-                s.push(null)
-                return s
-              } else {
-                return commitsRange(from, to)
-              }
-            }))
-        } else {
-          return commitsRange(from, to)
-        }
+          : ''
+        return commitsRange(from, to)
       })
+
+      if (gitRawCommitsOpts.from) {
+        streams = streams.splice(1)
+      }
 
       if (gitRawCommitsOpts.reverse) {
         streams.reverse()

--- a/packages/conventional-changelog-core/index.js
+++ b/packages/conventional-changelog-core/index.js
@@ -51,7 +51,7 @@ function conventionalChangelog (options, context, gitRawCommitsOpts, parserOpts,
         const from = i > 0
           ? reverseTags[i - 1]
           : gitRawCommitsOpts.from || ''
-        if (gitRawCommitsOpts.from) {
+        if (gitRawCommitsOpts.from && gitRawCommitsOpts.from !== from) {
           let hasData = false
           return commitsRange(gitRawCommitsOpts.from, to)
             .on('data', function () {

--- a/packages/conventional-changelog-core/test/test.js
+++ b/packages/conventional-changelog-core/test/test.js
@@ -803,6 +803,28 @@ describe('conventionalChangelogCore', function () {
       }))
   })
 
+  it('should read each commit range exactly once', function (done) {
+    preparing(9)
+
+    conventionalChangelogCore({
+      preset: {
+        compareUrlFormat: '/compare/{{previousTag}}...{{currentTag}}'
+      }
+    }, {}, {}, {}, {
+      headerPartial: '',
+      commitPartial: '* {{header}}\n'
+    })
+      .pipe(through(function (chunk, enc, cb) {
+        chunk = chunk.toString()
+
+        expect(chunk).to.equal('\n* test8\n* test8\n* test9\n\n\n\n')
+
+        cb()
+      }, function () {
+        done()
+      }))
+  })
+
   it('should recreate the changelog from scratch', function (done) {
     preparing(10)
 


### PR DESCRIPTION
ref #570