### PR TITLE
feat: add issuePrefixesCaseSensitive parser option

### DIFF
--- a/packages/conventional-commits-parser/README.md
+++ b/packages/conventional-commits-parser/README.md
@@ -193,6 +193,12 @@ Type: `array` of `string` or `string` Default: `['#']`
 
 The prefixes of an issue. EG: In `gh-123` `gh-` is the prefix.
 
+##### issuePrefixesCaseSensitive
+
+Type: `boolean` Default: false
+
+Used to define if `issuePrefixes` should be considered case sensitive.
+
 ##### noteKeywords
 
 Type: `array` of `string` or `string` Default: `['BREAKING CHANGE']`

--- a/packages/conventional-commits-parser/cli.js
+++ b/packages/conventional-commits-parser/cli.js
@@ -31,15 +31,16 @@ var cli = meow(`
       conventional-commits-parser log2.txt '===' >> parsed.txt
 
     Options
-      -p, --header-pattern           Regex to match header pattern
-      -c, --header-correspondence    Comma separated parts used to define what capturing group of 'headerPattern' captures what
-      -r, --reference-actions        Comma separated keywords that used to reference issues
-      -i, --issue-prefixes           Comma separated prefixes of an issue
-      -n, --note-keywords            Comma separated keywords for important notes
-      -f, --field-pattern            Regex to match other fields
-      --revert-pattern               Regex to match revert pattern
-      --revert-correspondence        Comma separated fields used to define what the commit reverts
-      -v, --verbose                  Verbose output
+      -p, --header-pattern              Regex to match header pattern
+      -c, --header-correspondence       Comma separated parts used to define what capturing group of 'headerPattern' captures what
+      -r, --reference-actions           Comma separated keywords that used to reference issues
+      -i, --issue-prefixes              Comma separated prefixes of an issue
+      --issue-prefixes-case-sensitive   Treat issue prefixes as case sensitive
+      -n, --note-keywords               Comma separated keywords for important notes
+      -f, --field-pattern               Regex to match other fields
+      --revert-pattern                  Regex to match revert pattern
+      --revert-correspondence           Comma separated fields used to define what the commit reverts
+      -v, --verbose                     Verbose output
 `, {
   flags: {
     'header-pattern': {
@@ -57,6 +58,9 @@ var cli = meow(`
     'issue-prefixes': {
       alias: 'i',
       type: 'string'
+    },
+    'issue-prefixes-case-sensitive': {
+      type: 'boolean'
     },
     'note-keywords': {
       alias: 'n',

--- a/packages/conventional-commits-parser/lib/regex.js
+++ b/packages/conventional-commits-parser/lib/regex.js
@@ -21,12 +21,13 @@ function getNotesRegex (noteKeywords) {
   return new RegExp('^[\\s|*]*(' + join(noteKeywords, '|') + ')[:\\s]+(.*)', 'i')
 }
 
-function getReferencePartsRegex (issuePrefixes) {
+function getReferencePartsRegex (issuePrefixes, issuePrefixesCaseSensitive) {
   if (!issuePrefixes) {
     return reNomatch
   }
 
-  return new RegExp('(?:.*?)??\\s*([\\w-\\.\\/]*?)??(' + join(issuePrefixes, '|') + ')([\\w-]*\\d+)', 'gi')
+  var flags = issuePrefixesCaseSensitive ? 'g' : 'gi'
+  return new RegExp('(?:.*?)??\\s*([\\w-\\.\\/]*?)??(' + join(issuePrefixes, '|') + ')([\\w-]*\\d+)', flags)
 }
 
 function getReferencesRegex (referenceActions) {
@@ -42,7 +43,7 @@ function getReferencesRegex (referenceActions) {
 module.exports = function (options) {
   options = options || {}
   var reNotes = getNotesRegex(options.noteKeywords)
-  var reReferenceParts = getReferencePartsRegex(options.issuePrefixes)
+  var reReferenceParts = getReferencePartsRegex(options.issuePrefixes, options.issuePrefixesCaseSensitive)
   var reReferences = getReferencesRegex(options.referenceActions)
 
   return {

--- a/packages/conventional-commits-parser/test/regex.spec.js
+++ b/packages/conventional-commits-parser/test/regex.spec.js
@@ -259,6 +259,20 @@ describe('regex', function () {
       expect(match[3]).to.equal('3')
     })
 
+    it('should be case sensitve if set in options', function () {
+      var string = 'closes gh-1, amends GH-2, fixes #3'
+      reReferenceParts = regex({
+        issuePrefixes: ['GH-'],
+        issuePrefixesCaseSensitive: true
+      }).referenceParts
+
+      var match = reReferenceParts.exec(string)
+      expect(match[0]).to.equal('closes gh-1, amends GH-2')
+      expect(match[1]).to.equal(undefined)
+      expect(match[2]).to.equal('GH-')
+      expect(match[3]).to.equal('2')
+    })
+
     it('should match nothing if there is no customized prefix', function () {
       var string = 'closes gh-1, amends #2, fixes prefix-3'
       reReferenceParts = regex().referenceParts


### PR DESCRIPTION
Currently issuePrefixes are always treated as case insensitive. 

This is problematic for JIRA-type prefixes (i.e. {some-letters}-) as it creates a lot of false positives. Example: `upgrade dependency to foobar-12` causes foobar-12 to be treated as a reference.

This MR adds an option to control that behaviour. The default is `false` so it is backwards compatible.