### PR TITLE
feat: allows notes pattern to be customized

### DIFF
--- a/packages/conventional-commits-parser/README.md
+++ b/packages/conventional-commits-parser/README.md
@@ -205,6 +205,12 @@ Type: `array` of `string` or `string` Default: `['BREAKING CHANGE']`
 
 Keywords for important notes. This value is case **insensitive**. If it's a `string` it will be converted to an `array` separated by a comma.
 
+##### notesPattern
+
+Type: `function` Default: `noteKeywordsSelection => ^[\\s|*]*(' + noteKeywordsSelection + ')[:\\s]+(.*)` where `noteKeywordsSelection` is `join(noteKeywords, '|')`
+
+A function that takes `noteKeywordsSelection` and returns a `RegExp` to be matched against the notes.
+
 ##### fieldPattern
 
 Type: `regex` or `string` Default: `/^-(.*?)-$/`

--- a/packages/conventional-commits-parser/lib/regex.js
+++ b/packages/conventional-commits-parser/lib/regex.js
@@ -13,12 +13,18 @@ function join (array, joiner) {
     .join(joiner)
 }
 
-function getNotesRegex (noteKeywords) {
+function getNotesRegex (noteKeywords, notesPattern) {
   if (!noteKeywords) {
     return reNomatch
   }
 
-  return new RegExp('^[\\s|*]*(' + join(noteKeywords, '|') + ')[:\\s]+(.*)', 'i')
+  const noteKeywordsSelection = join(noteKeywords, '|')
+
+  if (!notesPattern) {
+    return new RegExp('^[\\s|*]*(' + noteKeywordsSelection + ')[:\\s]+(.*)', 'i')
+  }
+
+  return notesPattern(noteKeywordsSelection)
 }
 
 function getReferencePartsRegex (issuePrefixes, issuePrefixesCaseSensitive) {
@@ -42,7 +48,7 @@ function getReferencesRegex (referenceActions) {
 
 module.exports = function (options) {
   options = options || {}
-  var reNotes = getNotesRegex(options.noteKeywords)
+  var reNotes = getNotesRegex(options.noteKeywords, options.notesPattern)
   var reReferenceParts = getReferencePartsRegex(options.issuePrefixes, options.issuePrefixesCaseSensitive)
   var reReferences = getReferencesRegex(options.referenceActions)
 

--- a/packages/conventional-commits-parser/test/regex.spec.js
+++ b/packages/conventional-commits-parser/test/regex.spec.js
@@ -18,6 +18,18 @@ describe('regex', function () {
       expect(match[2]).to.equal('This is so important.')
     })
 
+    it('should match notes with customized pattern', function () {
+      var reNotes = regex({
+        noteKeywords: ['BREAKING CHANGE'],
+        notesPattern: (noteKeywords) => new RegExp('^[\\s|*]*(' + noteKeywords + ')[:\\s]+(?:\\[.*\\] )(.*)', 'i')
+      }).notes
+      var notes = 'BREAKING CHANGE: [Do not match this prefix.] This is so important.'
+      var match = notes.match(reNotes)
+      expect(match[0]).to.equal(notes)
+      expect(match[1]).to.equal('BREAKING CHANGE')
+      expect(match[2]).to.equal('This is so important.')
+    })
+
     it('should be case insensitive', function () {
       var reNotes = regex({
         noteKeywords: ['Breaking News', 'Breaking Change']


### PR DESCRIPTION
# What is the problem?

Inspired by #13, I would like to customize the [`RegEx` pattern](https://github.com/conventional-changelog/conventional-changelog/blob/master/packages/conventional-commits-parser/lib/regex.js#L21) used for notes similar to the option that is [already available for the header pattern](https://github.com/conventional-changelog/conventional-changelog/blob/master/packages/conventional-commits-parser/lib/parser.js#L169). Using the note keywords does not suffice.

# What could be a solution?

Add an option `notesPattern` that takes a function `(noteKeywords: string) => RegExp`. With this, a user can specify a custom regular expression that incorporates the (already concatenated) note keywords.