### PR TITLE
feat(options): add mergeCommitFilter option to cli

### DIFF
--- a/packages/conventional-changelog-cli/cli.js
+++ b/packages/conventional-changelog-cli/cli.js
@@ -36,6 +36,12 @@ var cli = meow(`
       -r, --release-count       How many releases to be generated from the latest
                                 If 0, the whole changelog will be regenerated and the outfile will be overwritten
                                 Default: 1
+                                
+      -m, --merge-commit-filter Configure how to handle merge commits. Must be one of the following:
+                                exclude: Merge commits will be ignored.
+                                include: Merge commits will be included. 
+                                only-merges: Only merge commits will be processed. 
+                                Default: exclude
 
       -u, --output-unreleased   Output unreleased changelog
 
@@ -79,6 +85,10 @@ var cli = meow(`
     'release-count': {
       alias: 'r',
       type: 'number'
+    },
+    'merge-commit-filter': {
+      alias: 'm',
+      type: 'string'
     },
     'output-unreleased': {
       alias: 'u',

--- a/packages/conventional-changelog-cli/cli.js
+++ b/packages/conventional-changelog-cli/cli.js
@@ -178,14 +178,12 @@ try {
 
 var gitRawCommitsOpts = _.merge({}, config.gitRawCommitsOpts || {})
 
-if (options.mergeCommitFilter) {
-  if (options.mergeCommitFilter === 'include') {
-    gitRawCommitsOpts.merges = null
-  } else if (options.mergeCommitFilter === 'only-merges') {
-    gitRawCommitsOpts.merges = true
-  } else { // default to options.mergeCommitFilter === 'exclude'
-    gitRawCommitsOpts.merges = false
-  }
+if (options.mergeCommitFilter === 'include') {
+  gitRawCommitsOpts.merges = null
+} else if (options.mergeCommitFilter === 'only-merges') {
+  gitRawCommitsOpts.merges = true
+} else { // default to 'exclude'
+  gitRawCommitsOpts.merges = false
 }
 
 if (flags.commitPath) gitRawCommitsOpts.path = flags.commitPath

--- a/packages/conventional-changelog-cli/cli.js
+++ b/packages/conventional-changelog-cli/cli.js
@@ -124,6 +124,7 @@ var outfile = flags.outfile
 var sameFile = flags.sameFile
 var append = flags.append
 var releaseCount = flags.releaseCount
+var mergeCommitFilter = flags.mergeCommitFilter || 'exclude'
 
 if (infile && infile === outfile) {
   sameFile = true
@@ -143,6 +144,7 @@ var options = _.omitBy({
   },
   append: append,
   releaseCount: releaseCount,
+  mergeCommitFilter: mergeCommitFilter,
   outputUnreleased: flags.outputUnreleased,
   lernaPackage: flags.lernaPackage,
   tagPrefix: flags.tagPrefix
@@ -175,6 +177,17 @@ try {
 }
 
 var gitRawCommitsOpts = _.merge({}, config.gitRawCommitsOpts || {})
+
+if (options.mergeCommitFilter) {
+  if (options.mergeCommitFilter === 'include') {
+    gitRawCommitsOpts.merges = null
+  } else if (options.mergeCommitFilter === 'only-merges') {
+    gitRawCommitsOpts.merges = true
+  } else { // default to options.mergeCommitFilter === 'exclude'
+    gitRawCommitsOpts.merges = false
+  }
+}
+
 if (flags.commitPath) gitRawCommitsOpts.path = flags.commitPath
 
 var changelogStream = conventionalChangelog(options, templateContext, gitRawCommitsOpts, config.parserOpts, config.writerOpts)

--- a/packages/conventional-changelog-core/lib/merge-config.js
+++ b/packages/conventional-changelog-core/lib/merge-config.js
@@ -69,7 +69,6 @@ function mergeConfig (options, context, gitRawCommitsOpts, parserOpts, writerOpt
       }
     },
     append: false,
-    mergeCommitFilter: 'exclude',
     releaseCount: 1,
     debug: function () {},
     transform: function (commit, cb) {
@@ -241,6 +240,7 @@ function mergeConfig (options, context, gitRawCommitsOpts, parserOpts, writerOpt
       gitRawCommitsOpts = _.assign({
         format: '%B%n-hash-%n%H%n-gitTags-%n%d%n-committerDate-%n%ci',
         from: fromTag,
+        merges: false,
         debug: options.debug
       },
       config.gitRawCommitsOpts,
@@ -249,16 +249,6 @@ function mergeConfig (options, context, gitRawCommitsOpts, parserOpts, writerOpt
 
       if (options.append) {
         gitRawCommitsOpts.reverse = gitRawCommitsOpts.reverse || true
-      }
-
-      if (options.mergeCommitFilter) {
-        if (options.mergeCommitFilter === 'exclude') {
-          gitRawCommitsOpts.merges = false
-        } else if (options.mergeCommitFilter === 'only-merges') {
-          gitRawCommitsOpts.merges = true
-        } else if (options.mergeCommitFilter === 'include') {
-          // noop; just not set `merges` option in rawCommitOpts
-        }
       }
 
       parserOpts = _.assign(

--- a/packages/conventional-changelog-core/lib/merge-config.js
+++ b/packages/conventional-changelog-core/lib/merge-config.js
@@ -69,6 +69,7 @@ function mergeConfig (options, context, gitRawCommitsOpts, parserOpts, writerOpt
       }
     },
     append: false,
+    mergeCommitFilter: 'exclude',
     releaseCount: 1,
     debug: function () {},
     transform: function (commit, cb) {
@@ -240,7 +241,6 @@ function mergeConfig (options, context, gitRawCommitsOpts, parserOpts, writerOpt
       gitRawCommitsOpts = _.assign({
         format: '%B%n-hash-%n%H%n-gitTags-%n%d%n-committerDate-%n%ci',
         from: fromTag,
-        merges: false,
         debug: options.debug
       },
       config.gitRawCommitsOpts,
@@ -249,6 +249,16 @@ function mergeConfig (options, context, gitRawCommitsOpts, parserOpts, writerOpt
 
       if (options.append) {
         gitRawCommitsOpts.reverse = gitRawCommitsOpts.reverse || true
+      }
+
+      if (options.mergeCommitFilter) {
+        if (options.mergeCommitFilter === 'exclude') {
+          gitRawCommitsOpts.merges = false
+        } else if (options.mergeCommitFilter === 'only-merges') {
+          gitRawCommitsOpts.merges = true
+        } else if (options.mergeCommitFilter === 'include') {
+          // noop; just not set `merges` option in rawCommitOpts
+        }
       }
 
       parserOpts = _.assign(

--- a/packages/standard-changelog/cli.js
+++ b/packages/standard-changelog/cli.js
@@ -136,14 +136,12 @@ try {
 
 var gitRawCommitsOpts = {}
 
-if (options.mergeCommitFilter) {
-  if (options.mergeCommitFilter === 'include') {
-    gitRawCommitsOpts.merges = null
-  } else if (options.mergeCommitFilter === 'only-merges') {
-    gitRawCommitsOpts.merges = true
-  } else { // default to options.mergeCommitFilter === 'exclude'
-    gitRawCommitsOpts.merges = false
-  }
+if (options.mergeCommitFilter === 'include') {
+  gitRawCommitsOpts.merges = null
+} else if (options.mergeCommitFilter === 'only-merges') {
+  gitRawCommitsOpts.merges = true
+} else { // default to 'exclude'
+  gitRawCommitsOpts.merges = false
 }
 
 if (flags.commitPath) gitRawCommitsOpts.path = flags.commitPath

--- a/packages/standard-changelog/cli.js
+++ b/packages/standard-changelog/cli.js
@@ -24,6 +24,11 @@ var cli = meow(`
     -k, --pkg                 A filepath of where your package.json is located
     -a, --append              Should the generated block be appended
     -r, --release-count       How many releases to be generated from the latest
+    -m, --merge-commit-filter Configure how to handle merge commits. Must be one of the following:
+                                exclude: Merge commits will be ignored.
+                                include: Merge commits will be included. 
+                                only-merges: Only merge commits will be processed. 
+                                Default: exclude
     -v, --verbose             Verbose output
     -c, --context             A filepath of a json that is used to define template variables
     -l, --lerna-package       Generate a changelog for a specific lerna package (:pkg-name@1.0.0)
@@ -63,6 +68,10 @@ var cli = meow(`
     'release-count': {
       alias: 'r',
       type: 'number'
+    },
+    'merge-commit-filter': {
+      alias: 'm',
+      type: 'string'
     },
     verbose: {
       alias: 'v',

--- a/packages/standard-changelog/test/cli.js
+++ b/packages/standard-changelog/test/cli.js
@@ -303,6 +303,7 @@ describe('standard-changelog cli', function () {
 
   describe('generates changelog respecting --merge-commit-filter', function () {
     function doGitFlow () {
+      shell.rm('-rf', 'CHANGELOG.md')
       shell.exec('git tag -a v0.0.17 -m "old release"')
       shell.exec('git checkout -b "feature/some-feature"')
       shell.exec('> test.txt && git add test.txt')
@@ -324,7 +325,7 @@ describe('standard-changelog cli', function () {
       doGitFlow()
 
       var cp = spawn(process.execPath, [cliPath, '-m', 'include', '--first-release'], {
-        stdio: [process.stdin, process.stdout, null]
+        stdio: [process.stdin, null, null]
       })
 
       cp.on('close', function (code) {
@@ -343,7 +344,7 @@ describe('standard-changelog cli', function () {
       doGitFlow()
 
       var cp = spawn(process.execPath, [cliPath, '-m', 'only-merges', '--first-release'], {
-        stdio: [process.stdin, process.stdout, null]
+        stdio: [process.stdin, null, null]
       })
 
       cp.on('close', function (code) {
@@ -362,7 +363,7 @@ describe('standard-changelog cli', function () {
       doGitFlow()
 
       var cp = spawn(process.execPath, [cliPath, '-m', 'exclude', '--first-release'], {
-        stdio: [process.stdin, process.stdout, null]
+        stdio: [process.stdin, null, null]
       })
 
       cp.on('close', function (code) {
@@ -370,7 +371,7 @@ describe('standard-changelog cli', function () {
         var modified = readFileSync('CHANGELOG.md', 'utf8')
         expect(modified).to.include('First commit')
         expect(modified).to.include('[0.0.17]')
-        expect(modified).to.include('Test commit') // will still be added to the initial
+        expect(modified).to.include('Test commit') // will still be added under the current date but not tag
         expect(modified).to.not.include('[0.0.18]')
         undoGitFlow()
         done()

--- a/packages/standard-changelog/test/cli.js
+++ b/packages/standard-changelog/test/cli.js
@@ -301,6 +301,74 @@ describe('standard-changelog cli', function () {
     })
   })
 
+  describe('generates changelog respecting --merge-commit-filter', function () {
+    function doGitFlow () {
+      shell.exec('git tag -a v0.0.17 -m "old release"')
+      shell.exec('git checkout -b "feature/some-feature"')
+      shell.exec('git add --all && git commit --allow-empty -m "feat: Test commit"')
+      shell.exec('git checkout master')
+      shell.exec('git merge feature/some-feature --no-ff')
+      shell.exec('git tag -a v0.0.18 -m "other old release"')
+    }
+
+    function undoGitFlow () {
+      shell.exec('git tag -d v0.0.17')
+      shell.exec('git tag -d v0.0.18')
+      shell.exec('git branch -d feature/some-feature')
+    }
+
+    it('include', function (done) {
+      doGitFlow()
+
+      var cp = spawn(process.execPath, [cliPath, '-m', 'include', '--first-release'], {
+        stdio: [process.stdin, null, null]
+      })
+
+      cp.on('close', function (code) {
+        expect(code).to.equal(0)
+        var modified = readFileSync('CHANGELOG.md', 'utf8')
+        expect(modified).to.include('First commit')
+        expect(modified).to.include('Test commit')
+        undoGitFlow()
+        done()
+      })
+    })
+
+    it('only-merges', function (done) {
+      doGitFlow()
+
+      var cp = spawn(process.execPath, [cliPath, '-m', 'only-merges', '--first-release'], {
+        stdio: [process.stdin, null, null]
+      })
+
+      cp.on('close', function (code) {
+        expect(code).to.equal(0)
+        var modified = readFileSync('CHANGELOG.md', 'utf8')
+        expect(modified).to.not.include('First commit')
+        expect(modified).to.include('Test commit')
+        undoGitFlow()
+        done()
+      })
+    })
+
+    it('exclude', function (done) {
+      doGitFlow()
+
+      var cp = spawn(process.execPath, [cliPath, '-m', 'exclude', '--first-release'], {
+        stdio: [process.stdin, null, null]
+      })
+
+      cp.on('close', function (code) {
+        expect(code).to.equal(0)
+        var modified = readFileSync('CHANGELOG.md', 'utf8')
+        expect(modified).to.include('First commit')
+        expect(modified).to.not.include('Test commit')
+        undoGitFlow()
+        done()
+      })
+    })
+  })
+
   it('outputs an error if context file is not found', function (done) {
     var output = ''
 


### PR DESCRIPTION
Based off the discussion on https://github.com/conventional-changelog/conventional-changelog/pull/375 and other issues, I started an implementation to add a new option to either include, exclude or only show merge commits when generating the changelog. 

It still needs tests and I need to test the code myself properly, but so far I could already verify that the changelog is complete when just dropping the `merges:false` from the `gitRawCommitOpts` in `merge-config.js`.

For now, I think the option `merge-commit-filter` should default to `exclude`, as this is the current behavior and would not break existing usage.

I will try to clean things up later when I have more time, but please also feel free to contribute.