### PR TITLE
docs(conventional-recommended-bump/README): add options.path

### DIFF
--- a/packages/conventional-recommended-bump/README.md
+++ b/packages/conventional-recommended-bump/README.md
@@ -19,6 +19,7 @@ Got the idea from https://github.com/conventional-changelog/conventional-changel
       - [whatBump](#whatbump)
       - [tagPrefix](#tagprefix)
       - [lernaPackage](#lernapackage)
+      - [path](#path)
     - [parserOpts](#parseropts)
     - [callback](#callback)
 - [License](#license)
@@ -118,6 +119,12 @@ For instance if your version tag is prefixed by `version/` instead of `v` you wo
 Specify the name of a package in a [Lerna](https://lernajs.io/)-managed repository. The package name will be used when fetching all changes to a package since the last time that package was released.
 
 For instance if your project contained a package named `conventional-changelog`, you could have only commits that have happened since the last release of `conventional-changelog` was tagged by specifying `--lernaPackage=conventional-changelog` using the CLI, or `conventional-changelog` as the value of the `lernaPackage` option.
+
+##### path
+
+**Type:** `string`
+
+Specify the path to only calculate with git commits related to the path. If you want to calculate recommended bumps of packages in a [Lerna](https://lernajs.io/)-managed repository, `path` should be use along with `lernaPackage` for each of the package.
 
 #### parserOpts
 


### PR DESCRIPTION
As you can see #596, I think `options.path` is good to be documented.

Thanks!