### PR TITLE
fix(preset:angular): escaped scoped string should not be seen as GitHub username (#601)

### DIFF
--- a/packages/conventional-changelog-angular/test/test.js
+++ b/packages/conventional-changelog-angular/test/test.js
@@ -57,6 +57,9 @@ betterThanBefore.setups([
   function () {
     gitDummyCommit(['fix: use npm@5 (@username)'])
     gitDummyCommit(['build(deps): bump @dummy/package from 7.1.2 to 8.0.0', 'BREAKING CHANGE: The Change is huge.'])
+    gitDummyCommit(['fix: remove \\`@internal\\` in comments of property'])
+    gitDummyCommit(['fix(test): fix \\`code example\\` by @dlmr'])
+    gitDummyCommit(['feat: adding support for \\` by @superitman!'])
   },
   function () {
     gitDummyCommit(['Revert \\"feat: default revert format\\"', 'This reverts commit 1234.'])
@@ -324,6 +327,12 @@ describe('angular preset', function () {
 
         expect(chunk).to.not.include('(https://github.com/5')
         expect(chunk).to.include('(https://github.com/username')
+        expect(chunk).to.include('(https://github.com/dlmr)')
+        expect(chunk).to.include('(https://github.com/superitman)')
+        expect(chunk).to.match(/adding support for (\\)?` by \[@superitman\]/)
+
+        expect(chunk).to.not.include('(https://github.com/internal')
+        expect(chunk).to.match(/remove (\\)?`@internal(\\)?` in comments/)
 
         expect(chunk).to.not.include('[@dummy](https://github.com/dummy)/package')
         expect(chunk).to.include('bump @dummy/package from')

--- a/packages/conventional-changelog-angular/writer-opts.js
+++ b/packages/conventional-changelog-angular/writer-opts.js
@@ -80,7 +80,13 @@ function getWriterOpts () {
         if (context.host) {
           // User URLs.
           commit.subject = commit.subject.replace(/\B@([a-z0-9](?:-?[a-z0-9/]){0,38})/g, (_, username) => {
-            if (username.includes('/')) {
+            const splitSubject = commit.subject.split(`@${username}`)
+
+            // Check if there is an odd number of occurrences of the char "`" before and after the username.
+            // If so, that means the username is a piece of code
+            // Check also if there is a "/" in the username. If so, this is package and not a user
+            if (((splitSubject[0].match(/`/g) || []).length % 2 !== 0 && (splitSubject[1].match(/`/g) || []).length % 2 !== 0) ||
+              username.includes('/')) {
               return `@${username}`
             }
 


### PR DESCRIPTION
ISSUES CLOSED: #601 