### PR TITLE
fix: pass gitRawExecOpts to gitRawCommits

### DIFF
--- a/packages/conventional-changelog-core/index.js
+++ b/packages/conventional-changelog-core/index.js
@@ -29,7 +29,7 @@ function conventionalChangelog (options, context, gitRawCommitsOpts, parserOpts,
     return gitRawCommits(_.merge({}, gitRawCommitsOpts, {
       from: from,
       to: to
-    }))
+    }), gitRawExecOpts)
       .on('error', function (err) {
         if (!commitsErrorThrown) {
           setImmediate(commitsStream.emit.bind(commitsStream), 'error', err)


### PR DESCRIPTION
Hi all,

There's a missing argument.