### PR TITLE
chore(conventional-changelog-writer): bump handlebars to 4.5.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1254,7 +1254,7 @@
         "compare-func": "^1.3.1",
         "conventional-commits-filter": "file:packages/conventional-commits-filter",
         "dateformat": "^3.0.0",
-        "handlebars": "^4.4.0",
+        "handlebars": "^4.5.3",
         "json-stringify-safe": "^5.0.1",
         "lodash": "^4.17.15",
         "meow": "^5.0.0",

--- a/packages/conventional-changelog-writer/package.json
+++ b/packages/conventional-changelog-writer/package.json
@@ -39,7 +39,7 @@
     "compare-func": "^1.3.1",
     "conventional-commits-filter": "file:../conventional-commits-filter",
     "dateformat": "^3.0.0",
-    "handlebars": "^4.4.0",
+    "handlebars": "^4.5.3",
     "json-stringify-safe": "^5.0.1",
     "lodash": "^4.17.15",
     "meow": "^5.0.0",


### PR DESCRIPTION
`handlebars` is vulnerable to arbitrary code execution. The vulnerability exists as the lookup helper does not properly validate templates, allowing the execution of JavaScript code in templates.

Just bump it to `^4.5.3`
