### PR TITLE
fix: support having branches and tags with the same name

### DIFF
--- a/packages/conventional-recommended-bump/index.js
+++ b/packages/conventional-recommended-bump/index.js
@@ -71,9 +71,10 @@ function conventionalRecommendedBump (optionsArgument, parserOptsArgument, cbArg
 
       gitRawCommits({
         format: '%B%n-hash-%n%H',
-        from: tags[0] || '',
+        from: tags[0] ? `refs/tags/${tags[0]}` : '',
         path: options.path
       })
+        .on('error', (err) => cb(err))
         .pipe(conventionalCommitsParser(parserOpts))
         .pipe(concat(data => {
           const commits = options.ignoreReverted ? conventionalCommitsFilter(data) : data

--- a/packages/conventional-recommended-bump/test/index.spec.js
+++ b/packages/conventional-recommended-bump/test/index.spec.js
@@ -11,6 +11,8 @@ const shell = require('shelljs')
 const temp = require('temp')
 
 const preparing = betterThanBefore.preparing
+const tearsWithJoy = betterThanBefore.tearsWithJoy
+
 shell.config.silent = true
 
 betterThanBefore.setups([
@@ -45,7 +47,21 @@ betterThanBefore.setups([
   }
 ])
 
+tearsWithJoy(() => {
+  // do nothing, cleanup is built-in into setups
+})
+
 describe('conventional-recommended-bump API', () => {
+  // placing this test 1st so tearsWithJoy could clean-up extra branch setup
+  it('should work if there is a branch of the same name as a tag', (done) => {
+    preparing(4)
+    shell.exec('git branch v1.0.0')
+    conventionalRecommendedBump({}, {}, (err) => {
+      assert.ok(err === null)
+      done()
+    })
+  })
+
   describe('options object', () => {
     it('should throw an error if an \'options\' object is not provided', done => {
       assert.throws(() => conventionalRecommendedBump())

--- a/packages/git-raw-commits/index.js
+++ b/packages/git-raw-commits/index.js
@@ -62,6 +62,10 @@ function gitRawCommits (rawGitOpts, rawExecOpts) {
   child.stdout
     .pipe(split(DELIMITER + '\n'))
     .pipe(through(function (chunk, enc, cb) {
+      if (isError) {
+        return cb()
+      }
+
       readable.push(chunk)
       isError = false
 


### PR DESCRIPTION
### Reason
I have a real-life use-case of having both branches and tags with the same name (`vX.X.X`) in the release process.
When using `standard-version` under such circumstances, I'm getting an error:
 `Error: warning: refname 'release-1.1.0' is ambiguous`.
Basically, git shows the warning when trying to show commit history and the tool crashes due to uncaught exception.

### Solution
The issue could be solved by using explicit `refs/tags/tag-name` reference.
I've also added some error handling so the tool won't crash and properly finish its work.

Please see commit messages for further details.