### PR TITLE
Update handlebars due to minimist vulnerability

### DIFF
--- a/packages/conventional-changelog-writer/package.json
+++ b/packages/conventional-changelog-writer/package.json
@@ -39,7 +39,7 @@
     "compare-func": "^1.3.1",
     "conventional-commits-filter": "file:../conventional-commits-filter",
     "dateformat": "^3.0.0",
-    "handlebars": "^4.4.0",
+    "handlebars": "^4.7.6",
     "json-stringify-safe": "^5.0.1",
     "lodash": "^4.17.15",
     "meow": "^5.0.0",


### PR DESCRIPTION
[CVE-2020-7598](https://github.com/advisories/GHSA-vh95-rmgr-6w4m) is affected by the minimist version used by handlebar, used bi this repo.