### PR TITLE
docs: update readme for gulp plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ You can also use one of the plugins if you are already using the tool:
 ## Plugins Supporting Conventional Changelog
 
 - [grunt](https://github.com/btford/grunt-conventional-changelog)
-- [gulp](https://github.com/conventional-changelog/gulp-conventional-changelog)
+- [gulp](https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/gulp-conventional-changelog)
 - [atom](https://github.com/conventional-changelog/atom-conventional-changelog)
 - [vscode](https://github.com/axetroy/vscode-changelog-generator)
 


### PR DESCRIPTION
It was pointing to a deprecated repo