### PR TITLE
feat: add support for '--skip-unstable' option

### DIFF
--- a/packages/conventional-changelog-cli/cli.js
+++ b/packages/conventional-changelog-cli/cli.js
@@ -37,6 +37,8 @@ var cli = meow(`
                                 If 0, the whole changelog will be regenerated and the outfile will be overwritten
                                 Default: 1
 
+      --skip-unstable           If given, unstable tags will be skipped, e.g., x.x.x-alpha.1, x.x.x-rc.2
+
       -u, --output-unreleased   Output unreleased changelog
 
       -v, --verbose             Verbose output. Use this for debugging
@@ -80,6 +82,9 @@ var cli = meow(`
       alias: 'r',
       type: 'number'
     },
+    'skip-unstable': {
+      type: 'boolean'
+    },
     'output-unreleased': {
       alias: 'u',
       type: 'boolean'
@@ -114,6 +119,7 @@ var outfile = flags.outfile
 var sameFile = flags.sameFile
 var append = flags.append
 var releaseCount = flags.releaseCount
+var skipUnstable = flags.skipUnstable
 
 if (infile && infile === outfile) {
   sameFile = true
@@ -133,6 +139,7 @@ var options = _.omitBy({
   },
   append: append,
   releaseCount: releaseCount,
+  skipUnstable: skipUnstable,
   outputUnreleased: flags.outputUnreleased,
   lernaPackage: flags.lernaPackage,
   tagPrefix: flags.tagPrefix

--- a/packages/conventional-changelog-core/README.md
+++ b/packages/conventional-changelog-core/README.md
@@ -64,6 +64,12 @@ Type: `number` Default: `1`
 
 How many releases of changelog you want to generate. It counts from the upcoming release. Useful when you forgot to generate any previous changelog. Set to `0` to regenerate all.
 
+##### skipUnstable
+
+Type: `boolean` Default: `false`
+
+If set, unstable release tags will be skipped, e.g., x.x.x-rc.
+
 ##### debug
 
 Type: `function` Default: `function() {}`

--- a/packages/conventional-changelog-core/lib/merge-config.js
+++ b/packages/conventional-changelog-core/lib/merge-config.js
@@ -21,7 +21,7 @@ var rhosts = /github|bitbucket|gitlab/i
 
 function semverTagsPromise (options) {
   return Q.Promise(function (resolve, reject) {
-    gitSemverTags({ lernaTags: !!options.lernaPackage, package: options.lernaPackage, tagPrefix: options.tagPrefix }, function (err, result) {
+    gitSemverTags({ lernaTags: !!options.lernaPackage, package: options.lernaPackage, tagPrefix: options.tagPrefix, skipUnstable: options.skipUnstable }, function (err, result) {
       if (err) {
         reject(err)
       } else {
@@ -70,6 +70,7 @@ function mergeConfig (options, context, gitRawCommitsOpts, parserOpts, writerOpt
     },
     append: false,
     releaseCount: 1,
+    skipUnstable: false,
     debug: function () {},
     transform: function (commit, cb) {
       if (_.isString(commit.gitTags)) {

--- a/packages/git-semver-tags/index.js
+++ b/packages/git-semver-tags/index.js
@@ -5,6 +5,7 @@ var exec = require('child_process').exec
 var semverValid = require('semver').valid
 var regex = /tag:\s*(.+?)[,)]/gi
 var cmd = 'git log --decorate --no-color'
+var unstableTagTest = /.*-\w*\.\d$/
 
 function lernaTag (tag, pkg) {
   if (pkg && !(new RegExp('^' + pkg + '@')).test(tag)) {
@@ -41,6 +42,12 @@ module.exports = function gitSemverTags (opts, callback) {
       var match
       while ((match = regex.exec(decorations))) {
         var tag = match[1]
+
+        if (options.skipUnstable && unstableTagTest.test(tag)) {
+          // skip unstable tag
+          continue
+        }
+
         if (options.lernaTags) {
           if (lernaTag(tag, options.package)) {
             tags.push(tag)

--- a/packages/git-semver-tags/test.js
+++ b/packages/git-semver-tags/test.js
@@ -196,6 +196,27 @@ describe('git-semver-tags', function () {
       done()
     })
   })
+
+  it('should skip unstable tags', function (done) {
+    writeFileSync('test7', '')
+    shell.exec('git add --all && git commit -m"twelfth commit"')
+    shell.exec('git tag skip/8.0.0')
+    writeFileSync('test8', '')
+    shell.exec('git add --all && git commit -m"thirteenth commit"')
+    shell.exec('git tag skip/9.0.0-alpha.1')
+    writeFileSync('test9', '')
+    shell.exec('git add --all && git commit -m"fourteenth commit"')
+    shell.exec('git tag skip/9.0.0-rc.1')
+    writeFileSync('test10', '')
+    shell.exec('git add --all && git commit -m"fifteenth commit"')
+    shell.exec('git tag skip/9.0.0')
+
+    gitSemverTags({ tagPrefix: 'skip/', skipUnstable: true }, function (err, tags) {
+      if (err) done(err)
+      assert.deepStrictEqual(tags, ['skip/9.0.0', 'skip/8.0.0'])
+      done()
+    })
+  })
 })
 
 describe('git semver tags on different cwd', function () {


### PR DESCRIPTION
Hi

during usage of your great tool in our team, we came with this little improvement that makes our lives easier.

During our development workflow we often create a few :smile: release candidates in process, which then makes changelog generation little tricky as their number vary.

This new _--skip-unstable_ simply skips all those (_alpha_, _beta_, _whatever_ too), so the default _--release-count=1_ works as expected.

Maybe this will be useful for some other too.

BR
Arnost