### PR TITLE
feat(templates): if hash is nullish, do not display in CHANGELOG

### DIFF
--- a/packages/conventional-changelog-conventionalcommits/templates/commit.hbs
+++ b/packages/conventional-changelog-conventionalcommits/templates/commit.hbs
@@ -5,11 +5,11 @@
   {{~header}}
 {{~/if}}
 
-{{~!-- commit link --}} {{#if @root.linkReferences~}}
-  {{~#if hash}}([{{shortHash}}]({{commitUrlFormat}})){{~/if}}
+{{~!-- commit link --}}{{~#if hash}} {{#if @root.linkReferences~}}
+  ([{{shortHash}}]({{commitUrlFormat}}))
 {{~else}}
-  {{~#if hash}}{{~shortHash}}{{~/if}}
-{{~/if}}
+  {{~shortHash}}
+{{~/if}}{{~/if}}
 
 {{~!-- commit references --}}
 {{~#if references~}}

--- a/packages/conventional-changelog-conventionalcommits/templates/commit.hbs
+++ b/packages/conventional-changelog-conventionalcommits/templates/commit.hbs
@@ -6,9 +6,9 @@
 {{~/if}}
 
 {{~!-- commit link --}} {{#if @root.linkReferences~}}
-  ([{{shortHash}}]({{commitUrlFormat}}))
+  {{~#if hash}}([{{shortHash}}]({{commitUrlFormat}})){{~/if}}
 {{~else}}
-  {{~shortHash}}
+  {{~#if hash}}{{~shortHash}}{{~/if}}
 {{~/if}}
 
 {{~!-- commit references --}}


### PR DESCRIPTION
this makes it possible for upstream tooling to provide a `null` has to omit a SHA.