### PR TITLE
feat(conventional-changelog-angular): Support for multiple feat and s…

### DIFF
--- a/packages/conventional-changelog-angular/parser-opts.js
+++ b/packages/conventional-changelog-angular/parser-opts.js
@@ -1,7 +1,7 @@
 'use strict'
 
 module.exports = {
-  headerPattern: /^(\w*)(?:\((.*)\))?: (.*)$/,
+  headerPattern: /^(\w*)(?:\(([^:]*)\))?: (.*)$/,
   headerCorrespondence: [
     'type',
     'scope',


### PR DESCRIPTION
When we squash commits of a pull request we will keep the original commit message in the body of the new commit message.
This causes commitlint to fail because there is a second type and scope in the commit message.

**Example:**
A PR with the title 
"feat(pencil): add with and color option" 

That contains the commits
"feat(pencil): add with option" 
"feat(pencil): add color option" 

Wil result in the commit msg
"feat(pencil): add with and color option\n
feat(pencil): add with option\n 
"feat(pencil): add color option\n
Reviewed-on: <some PR info>"  

**Original regex:**
https://regex101.com/r/on6Ouy/2
*New regex*
https://regex101.com/r/on6Ouy/1

**workaround fix**
```js
// commitlint.config.js

module.exports = {
  parserPreset: {
    parserOpts: {
      headerPattern: /^(\w*)(?:\(([^:]*)\))?: (.*)$/,
    },
  },
}
```