### PR TITLE
fix(git-raw-commits): silent false success when git is not present

### DIFF
--- a/packages/git-raw-commits/test.js
+++ b/packages/git-raw-commits/test.js
@@ -29,8 +29,6 @@ describe('git-raw-commits', function () {
       })
       .pipe(through(function () {
         done('should error')
-      }, function () {
-        done('should error')
       }))
   })
 
@@ -191,5 +189,25 @@ describe('git-raw-commits', function () {
         expect(i).to.equal(3)
         done()
       }))
+  })
+
+  it('should emit an error if git is not available', function (done) {
+    try {
+      var path = process.env.PATH
+      process.env.PATH = ''
+
+      gitRawCommits()
+        .on('error', function (err) {
+          expect(err).to.be.ok // eslint-disable-line no-unused-expressions
+          done()
+        })
+        .pipe(through(function () {
+          done('should error')
+        }, function () {
+          done('should error')
+        }))
+    } finally {
+      process.env.PATH = path
+    }
   })
 })


### PR DESCRIPTION
Add callback function and error check to `execFile`.

Fixes conventional-changelog/commitlint#2136