### PR TITLE
fix: bug in unstableTagTest causing a mismatch on beta release higher then beta-9

### DIFF
--- a/packages/git-semver-tags/index.js
+++ b/packages/git-semver-tags/index.js
@@ -5,7 +5,7 @@ var exec = require('child_process').exec
 var semverValid = require('semver').valid
 var regex = /tag:\s*(.+?)[,)]/gi
 var cmd = 'git log --decorate --no-color'
-var unstableTagTest = /.*-\w*\.\d$/
+var unstableTagTest = /.*-\w*\.\d{1,3}$/
 
 function lernaTag (tag, pkg) {
   if (pkg && !(new RegExp('^' + pkg + '@')).test(tag)) {

--- a/packages/git-semver-tags/index.js
+++ b/packages/git-semver-tags/index.js
@@ -5,7 +5,7 @@ var exec = require('child_process').exec
 var semverValid = require('semver').valid
 var regex = /tag:\s*(.+?)[,)]/gi
 var cmd = 'git log --decorate --no-color'
-var unstableTagTest = /.*-\w*\.\d{1,3}$/
+var unstableTagTest = /.*-\w*\.\d+$/
 
 function lernaTag (tag, pkg) {
   if (pkg && !(new RegExp('^' + pkg + '@')).test(tag)) {

--- a/packages/git-semver-tags/index.js
+++ b/packages/git-semver-tags/index.js
@@ -5,7 +5,7 @@ var exec = require('child_process').exec
 var semverValid = require('semver').valid
 var regex = /tag:\s*(.+?)[,)]/gi
 var cmd = 'git log --decorate --no-color'
-var unstableTagTest = /.*-\w*\.\d+$/
+var unstableTagTest = /.+-\w+\.\d+$/
 
 function lernaTag (tag, pkg) {
   if (pkg && !(new RegExp('^' + pkg + '@')).test(tag)) {


### PR DESCRIPTION
Fixes issue #678

### old regex expression
![Schermafbeelding 2020-10-07 om 13 53 11](https://user-images.githubusercontent.com/5745279/95327582-8b520880-08a4-11eb-92af-5188b2a17333.png)

### new regex expression
![Schermafbeelding 2020-10-07 om 13 58 03](https://user-images.githubusercontent.com/5745279/95327965-277c0f80-08a5-11eb-982c-93c47def0851.png)
