### PR TITLE
fix: ignore gpg lines

### DIFF
--- a/packages/conventional-commits-parser/lib/parser.js
+++ b/packages/conventional-commits-parser/lib/parser.js
@@ -96,9 +96,10 @@ function parser (raw, options, regex) {
   var commentFilter = typeof options.commentChar === 'string'
     ? getCommentFilter(options.commentChar)
     : passTrough
+  var gpgFilter = line => !line.match(/^\s*gpg:/)
 
   var rawLines = trimOffNewlines(raw).split(/\r?\n/)
-  var lines = truncateToScissor(rawLines).filter(commentFilter)
+  var lines = truncateToScissor(rawLines).filter(commentFilter).filter(gpgFilter)
 
   var continueNote = false
   var isBody = true

--- a/packages/conventional-commits-parser/test/parser.spec.js
+++ b/packages/conventional-commits-parser/test/parser.spec.js
@@ -183,6 +183,43 @@ describe('parser', function () {
     })
   })
 
+  it('should ignore gpg signature lines', function () {
+    expect(parser(
+      'gpg: Signature made Thu Oct 22 12:19:30 2020 EDT\n' +
+      'gpg:                using RSA key ABCDEF1234567890\n' +
+      'gpg: Good signature from "Author <author@example.com>" [ultimate]\n' +
+      'feat(scope): broadcast $destroy event on scope destruction\n' +
+      'perf testing shows that in chrome this change adds 5-15% overhead\n' +
+      'when destroying 10k nested scopes where each scope has a $destroy listener\n' +
+      'BREAKING AMEND: some breaking change\n' +
+      'Kills #1\n',
+      options,
+      reg
+    )).to.eql({
+      merge: null,
+      header: 'feat(scope): broadcast $destroy event on scope destruction',
+      body: 'perf testing shows that in chrome this change adds 5-15% overhead\nwhen destroying 10k nested scopes where each scope has a $destroy listener',
+      footer: 'BREAKING AMEND: some breaking change\nKills #1',
+      notes: [{
+        title: 'BREAKING AMEND',
+        text: 'some breaking change'
+      }],
+      references: [{
+        action: 'Kills',
+        owner: null,
+        repository: null,
+        issue: '1',
+        raw: '#1',
+        prefix: '#'
+      }],
+      mentions: ['example'],
+      revert: null,
+      scope: 'scope',
+      subject: 'broadcast $destroy event on scope destruction',
+      type: 'feat'
+    })
+  })
+
   it('should ignore comments according to commentChar', function () {
     var commentOptions = _.assign({}, options, { commentChar: '#' })
 


### PR DESCRIPTION
When a commit is signed with GPG and `git config log.showSignature true` has been set, it creates additional lines in the raw commit, in this format:

```
gpg: Signature made Thu Oct 22 12:19:30 2020 EDT
gpg:                using RSA key ABCDEF1234567890
gpg: Good signature from "Author <author@example.com>" [ultimate]
```

Because these lines occur before the "real" commit begins, the commit is not parsed properly.

This PR ignores these additional lines in the commit message, as they are irrelevant to versioning.