### PR TITLE
feat(conventional-recommended-bump): support for '--skip-unstable'

### DIFF
--- a/packages/conventional-recommended-bump/README.md
+++ b/packages/conventional-recommended-bump/README.md
@@ -18,6 +18,7 @@ Got the idea from https://github.com/conventional-changelog/conventional-changel
       - [config](#config)
       - [whatBump](#whatbump)
       - [tagPrefix](#tagprefix)
+      - [skipUnstable](#skipunstable)
       - [lernaPackage](#lernapackage)
       - [path](#path)
     - [parserOpts](#parseropts)
@@ -111,6 +112,12 @@ This should return an object including but not limited to `level` and `reason`. 
 Specify a prefix for the git tag that will be taken into account during the comparison.
 
 For instance if your version tag is prefixed by `version/` instead of `v` you would specifying `--tagPrefix=version/` using the CLI, or `version/` as the value of the `tagPrefix` option.
+
+##### skipUnstable
+
+**Type:** `boolean`
+
+If true, unstable tags will be skipped, e.g., x.x.x-alpha.1, x.x.x-rc.2
 
 ##### lernaPackage
 

--- a/packages/conventional-recommended-bump/cli.js
+++ b/packages/conventional-recommended-bump/cli.js
@@ -26,6 +26,7 @@ const cli = meow(`
       -l, --lerna-package            Recommend a bump for a specific lerna package (:pkg-name@1.0.0)
       -t, --tag-prefix               Tag prefix to consider when reading the tags
       --commit-path                  Recommend a bump scoped to a specific directory
+      --skip-unstable                If given, unstable tags will be skipped, e.g., x.x.x-alpha.1, x.x.x-rc.2
 `, {
   flags: {
     preset: {
@@ -67,7 +68,8 @@ const cli = meow(`
 const options = {
   path: cli.flags.commitPath,
   lernaPackage: cli.flags.lernaPackage,
-  tagPrefix: cli.flags.tagPrefix
+  tagPrefix: cli.flags.tagPrefix,
+  skipUnstable: cli.flags.skipUnstable
 }
 const flags = cli.flags
 const preset = flags.preset

--- a/packages/conventional-recommended-bump/index.js
+++ b/packages/conventional-recommended-bump/index.js
@@ -63,7 +63,8 @@ function conventionalRecommendedBump (optionsArgument, parserOptsArgument, cbArg
     gitSemverTags({
       lernaTags: !!options.lernaPackage,
       package: options.lernaPackage,
-      tagPrefix: options.tagPrefix
+      tagPrefix: options.tagPrefix,
+      skipUnstable: options.skipUnstable
     }, (err, tags) => {
       if (err) {
         return cb(err)


### PR DESCRIPTION
This [feature](https://github.com/conventional-changelog/conventional-changelog/pull/656) is exactly what I need. But I need it also in the conventional-recommended-bump module.
It should be possible to use the --skip-unstable option, of the git-semver-tags module.

_This is the same [PR](https://github.com/conventional-changelog/conventional-changelog/pull/674) but I had some struggle with updating my fork_