### PR TITLE
feat(conventionalcommits): include or exclude scopes in types

### DIFF
--- a/packages/conventional-changelog-conventionalcommits/test/test.js
+++ b/packages/conventional-changelog-conventionalcommits/test/test.js
@@ -167,6 +167,60 @@ describe('conventionalcommits.org preset', function () {
       }))
   })
 
+  it('should include only the scopes defined in the inclusion list', function (done) {
+    preparing(1)
+    conventionalChangelogCore({
+      config: require('../')({
+        types: [
+          {
+            type: 'fix',
+            includedScopes: [
+              'changelog'
+            ]
+          }
+        ]
+      })
+    })
+      .on('error', function (err) {
+        done(err)
+      })
+      .pipe(through(function (chunk) {
+        chunk = chunk.toString()
+
+        expect(chunk).to.include('proper issue links')
+
+        expect(chunk).to.not.include('oops')
+        done()
+      }))
+  })
+
+  it('should not include the scopes defined in the exclusion list', function (done) {
+    preparing(1)
+    conventionalChangelogCore({
+      config: require('../')({
+        types: [
+          {
+            type: 'fix',
+            excludedScopes: [
+              'changelog'
+            ]
+          }
+        ]
+      })
+    })
+      .on('error', function (err) {
+        done(err)
+      })
+      .pipe(through(function (chunk) {
+        chunk = chunk.toString()
+
+        expect(chunk).to.include('oops')
+
+        expect(chunk).to.not.include('proper issue links')
+        done()
+      }))
+  })
+
   it('should properly format external repository issues', function (done) {
     preparing(1)
     conventionalChangelogCore({

--- a/packages/conventional-changelog-conventionalcommits/writer-opts.js
+++ b/packages/conventional-changelog-conventionalcommits/writer-opts.js
@@ -81,7 +81,17 @@ function getWriterOpts (config) {
       if (discard && (typesLookup[typeKey] === undefined ||
           typesLookup[typeKey].hidden)) return
 
-      if (typesLookup[typeKey]) commit.type = typesLookup[typeKey].section
+      if (typesLookup[typeKey]) {
+        commit.type = typesLookup[typeKey].section
+
+        // if includedScopes is defined, ignore commits not matching that scope
+        if (typesLookup[typeKey].includedScopes &&
+            typesLookup[typeKey].includedScopes.findIndex(scope => commit.scope.toLowerCase() === scope.toLowerCase()) === -1) return
+
+        // if excludedScopes is defined, ignore commits matching that scope
+        if (typesLookup[typeKey].excludedScopes &&
+            typesLookup[typeKey].excludedScopes.findIndex(scope => commit.scope.toLowerCase() === scope.toLowerCase()) !== -1) return
+      }
 
       if (commit.scope === `*`) {
         commit.scope = ``


### PR DESCRIPTION
Fixes #705