### PR TITLE
fix(writer): CHANGELOG created by parseArray contained extra \n

### DIFF
--- a/packages/conventional-changelog-writer/index.js
+++ b/packages/conventional-changelog-writer/index.js
@@ -197,7 +197,7 @@ conventionalChangelogWriterParseStream.parseArray = (rawCommits, context, option
     entries.reverse()
     return util.generate(options, commits, context, savedKeyCommit) + entries.join('')
   } else {
-    return entries.join('') + util.generate(options, commits, context, savedKeyCommit)
+    return entries.join('') + util.generate(options, commits, context, savedKeyCommit).trim()
   }
 }
 


### PR DESCRIPTION
`parseArray` added additional `\n` characters, vs., the streaming mode.