### PR TITLE
fix: drop compare-func making sort consistent across node versions

### DIFF
--- a/packages/conventional-changelog-writer/README.md
+++ b/packages/conventional-changelog-writer/README.md
@@ -169,15 +169,11 @@ Type: `function`, `string` or `array`
 
 A compare function used to sort commit groups. If it's a string or array, it sorts on the property(ies) by `localeCompare`. Will not sort if this is a falsy value.
 
-The string can be a dot path to a nested object property.
-
 ##### commitsSort
 
 Type: `function`, `string` or `array` Default: `'header'`
 
 A compare function used to sort commits. If it's a string or array, it sorts on the property(ies) by `localeCompare`. Will not sort if this is a falsy value.
-
-The string can be a dot path to a nested object property.
 
 ##### noteGroupsSort
 
@@ -185,15 +181,11 @@ Type: `function`, `string` or `array` Default: `'title'`
 
 A compare function used to sort note groups. If it's a string or array, it sorts on the property(ies) by `localeCompare`. Will not sort if this is a falsy value.
 
-The string can be a dot path to a nested object property.
-
 ##### notesSort
 
 Type: `function`, `string` or `array` Default: `'text'`
 
 A compare function used to sort note groups. If it's a string or array, it sorts on the property(ies) by `localeCompare`. Will not sort if this is a falsy value.
-
-The string can be a dot path to a nested object property.
 
 ##### generateOn
 

--- a/packages/conventional-changelog-writer/lib/util.js
+++ b/packages/conventional-changelog-writer/lib/util.js
@@ -1,5 +1,4 @@
 'use strict'
-const compareFunc = require('compare-func')
 const conventionalCommitsFilter = require('conventional-commits-filter')
 const Handlebars = require('handlebars')
 const semver = require('semver')
@@ -38,9 +37,23 @@ function compileTemplates (templates) {
 
 function functionify (strOrArr) {
   if (strOrArr && !_.isFunction(strOrArr)) {
-    return compareFunc(strOrArr)
+    return (a, b) => {
+      let str1 = ''
+      let str2 = ''
+      if (Array.isArray(strOrArr)) {
+        for (const key of strOrArr) {
+          str1 += a[key] || ''
+          str2 += b[key] || ''
+        }
+      } else {
+        str1 += a[strOrArr]
+        str2 += b[strOrArr]
+      }
+      return str1.localeCompare(str2)
+    }
+  } else {
+    return strOrArr
   }
-  return strOrArr
 }
 
 function getCommitGroups (groupBy, commits, groupsSort, commitsSort) {

--- a/packages/conventional-changelog-writer/package.json
+++ b/packages/conventional-changelog-writer/package.json
@@ -36,7 +36,6 @@
     "logs"
   ],
   "dependencies": {
-    "compare-func": "^2.0.0",
     "conventional-commits-filter": "^2.0.7",
     "dateformat": "^3.0.0",
     "handlebars": "^4.7.6",


### PR DESCRIPTION
BREAKING CHANGE: nested object properties no longer supported

Refs: https://github.com/googleapis/release-please/issues/601
Refs: https://github.com/googleapis/release-please/pull/581