### PR TITLE
refactor(standard-changelog): replace sprintf-js with util.format

### DIFF
--- a/packages/standard-changelog/index.js
+++ b/packages/standard-changelog/index.js
@@ -6,7 +6,7 @@ const fs = require('fs')
 const accessSync = require('fs-access').sync
 const chalk = require('chalk')
 const figures = require('figures')
-const sprintf = require('sprintf-js').sprintf
+const format = require('util').format
 
 function conventionalChangelog (options, context, gitRawCommitsOpts, parserOpts, writerOpts) {
   options = options || {}
@@ -26,7 +26,7 @@ conventionalChangelog.createIfMissing = function (infile) {
 }
 
 conventionalChangelog.checkpoint = function (msg, args) {
-  console.info(chalk.green(figures.tick) + ' ' + sprintf(msg, args.map(function (arg) {
+  console.info(chalk.green(figures.tick) + ' ' + format(msg, ...args.map(function (arg) {
     return chalk.bold(arg)
   })))
 }

--- a/packages/standard-changelog/package.json
+++ b/packages/standard-changelog/package.json
@@ -35,7 +35,6 @@
     "lodash": "^4.17.15",
     "meow": "^8.0.0",
     "rimraf": "^3.0.0",
-    "sprintf-js": "^1.1.1",
     "tempfile": "^3.0.0"
   },
   "scripts": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -196,14 +196,14 @@ importers:
 
   packages/conventional-commits-parser:
     specifiers:
-      JSONStream: ^1.0.4
       forceable-tty: ^0.1.0
       is-text-path: ^1.0.1
+      JSONStream: ^1.0.4
       meow: ^8.0.0
       split2: ^3.0.0
     dependencies:
-      JSONStream: 1.3.5
       is-text-path: 1.0.1
+      JSONStream: 1.3.5
       meow: 8.1.2
       split2: 3.2.2
     devDependencies:
@@ -272,7 +272,6 @@ importers:
       fs-access: ^1.0.0
       meow: ^8.0.0
       rimraf: ^3.0.0
-      sprintf-js: ^1.1.1
       tempfile: ^3.0.0
     dependencies:
       add-stream: 1.0.0
@@ -283,7 +282,6 @@ importers:
       fs-access: 1.0.1
       meow: 8.1.2
       rimraf: 3.0.2
-      sprintf-js: 1.1.2
       tempfile: 3.0.0
 
 packages:
@@ -2801,10 +2799,6 @@ packages:
   /sprintf-js/1.0.3:
     resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
     dev: true
-
-  /sprintf-js/1.1.2:
-    resolution: {integrity: sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug==}
-    dev: false
 
   /string-width/2.1.1:
     resolution: {integrity: sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==}


### PR DESCRIPTION
https://nodejs.org/docs/latest/api/util.html#util_util_format_format_args

available since node v0.5.3