### PR TITLE
dep(conventional-changelog-core): remove unnecessary shelljs

### DIFF
--- a/packages/conventional-changelog-core/index.js
+++ b/packages/conventional-changelog-core/index.js
@@ -7,7 +7,7 @@ const conventionalChangelogWriter = require('conventional-changelog-writer')
 const _ = require('lodash')
 const stream = require('stream')
 const through = require('through2')
-const shell = require('shelljs')
+const execFileSync = require('child_process').execFileSync
 
 const mergeConfig = require('./lib/merge-config')
 function conventionalChangelog (options, context, gitRawCommitsOpts, parserOpts, writerOpts, gitRawExecOpts) {
@@ -47,7 +47,10 @@ function conventionalChangelog (options, context, gitRawCommitsOpts, parserOpts,
       writerOpts = data.writerOpts
       gitRawExecOpts = data.gitRawExecOpts
 
-      if (shell.exec('git rev-parse --verify HEAD', { silent: true }).code === 0) {
+      try {
+        execFileSync('git', ['rev-parse', '--verify', 'HEAD'], {
+          stdio: 'ignore'
+        })
         let reverseTags = context.gitSemverTags.slice(0).reverse()
         reverseTags.push('HEAD')
 
@@ -81,7 +84,7 @@ function conventionalChangelog (options, context, gitRawCommitsOpts, parserOpts,
           .on('end', function () {
             setImmediate(commitsStream.emit.bind(commitsStream), 'end')
           })
-      } else {
+      } catch (_e) {
         commitsStream = gitRawCommits(gitRawCommitsOpts, gitRawExecOpts)
       }
 

--- a/packages/conventional-changelog-core/package.json
+++ b/packages/conventional-changelog-core/package.json
@@ -39,7 +39,6 @@
     "q": "^1.5.1",
     "read-pkg": "^3.0.0",
     "read-pkg-up": "^3.0.0",
-    "shelljs": "^0.8.3",
     "through2": "^4.0.0"
   },
   "scripts": {


### PR DESCRIPTION
This is only place where `shelljs` is used within code base, this library is also used within tests but its inherited from root package.json #753

https://github.com/conventional-changelog/conventional-changelog/blob/d9feeb605de28c00ef55b5c8e229efd1289dd6e8/package.json#L68

this is simmilar use case as in
https://github.com/conventional-changelog/conventional-changelog/blob/d9feeb605de28c00ef55b5c8e229efd1289dd6e8/packages/git-raw-commits/index.js#L4

https://github.com/conventional-changelog/conventional-changelog/blob/d9feeb605de28c00ef55b5c8e229efd1289dd6e8/packages/git-raw-commits/index.js#L58-L61