### PR TITLE
fix(git-raw-commits): revert "normalize git show signature option to false"

### DIFF
--- a/packages/git-raw-commits/index.js
+++ b/packages/git-raw-commits/index.js
@@ -19,7 +19,6 @@ function normalizeGitOpts (gitOpts) {
   gitOpts = gitOpts || {}
   gitOpts.format = gitOpts.format || '%B'
   gitOpts.from = gitOpts.from || ''
-  gitOpts.showSignature = gitOpts.showSignature || false
   gitOpts.to = gitOpts.to || 'HEAD'
   return gitOpts
 }


### PR DESCRIPTION
@thesmiley1 rolling back for now, until we figure out what we want to do.

one thought, why don't we only add the flag if it's been provided by the user, vs., defaulting the flag to false?

Reverts conventional-changelog/conventional-changelog#671