### PR TITLE
chore: add editor folders to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,7 @@
 /lerna-debug.log
 package-lock.json
 
+# Editors
+.idea
+.vscode
+.DS_Store


### PR DESCRIPTION
.DS_Store - used in macOS - https://en.wikipedia.org/wiki/.DS_Store
.vscode - used by vscode - https://code.visualstudio.com/
.idea - used by webstorm/intelij idea etc. - https://www.jetbrains.com/webstorm/