### PR TITLE
chore: use workspaces instead of post-install script

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,8 +39,7 @@
     "fix": "eslint . --fix --cache --cache-location ./node_modules/.cache/ --ignore-path .gitignore",
     "pretest": "npm run lint",
     "test": "c8 mocha --timeout 30000 packages/*/test{,/*}.js",
-    "test-windows": "c8 mocha --timeout 60000 packages/*/test{,/*}.js",
-    "postinstall": "bash scripts/install.sh"
+    "test-windows": "c8 mocha --timeout 60000 packages/*/test{,/*}.js"
   },
   "version": "1.0.0",
   "devDependencies": {
@@ -72,5 +71,8 @@
     "through2": "^4.0.0",
     "tmp": "^0.2.1",
     "vinyl": "^2.1.0"
-  }
+  },
+  "workspaces": [
+    "packages/*"
+  ]
 }

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-for d in ./packages/* ; do
-  echo "installing deps for $d"
-  cd $d
-  npm i
-  cd ../../
-done


### PR DESCRIPTION
use workspaces instead of post-install script

yarn: supports workspaces for long time - https://classic.yarnpkg.com/en/docs/workspaces/
npm: supports workspaces since version 7.x - https://docs.npmjs.com/cli/v7/using-npm/workspaces
pnpm: supports workspaces (but requires additional configuration) - https://pnpm.js.org/en/workspaces

--------------

## Reason:

currently if i try to execute `yarn` or `npm i` on windows machine its failing, 
there is no issues on linux and macOS

example output from yarn:
> [4/5] Linking dependencies...
error An unexpected error occurred: "ENOENT: no such file or directory, lstat 'E:\\Projects\\conventional-changelog\\node_modules\\conventional-changelog-core\\node_modules\\normalize-package-data\\node_modules'".
info If you think this is a bug, please open a bug report with the information provided in "E:\\Projects\\conventional-changelog\\yarn-error.log".
