### PR TITLE
chore: update all badges in readme files for ci and codecov

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Conventional Changelog
 
-[![Build Status](https://travis-ci.org/conventional-changelog/conventional-changelog.svg?branch=master)](https://travis-ci.org/conventional-changelog/conventional-changelog)
-[![Codecov](https://codecov.io/gh/conventional-changelog/conventional-changelog/branch/master/graph/badge.svg)](https://codecov.io/gh/conventional-changelog/conventional-changelog)p
+[![Build Status][ci-image]][ci-url]
+[![Codecov][codecov-image]][codecov-url]
 [![Standard Version](https://img.shields.io/badge/release-standard%20version-brightgreen.svg)](https://github.com/conventional-changelog/standard-version)
-[![community slack](http://devtoolscommunity.herokuapp.com/badge.svg)](http://devtoolscommunity.herokuapp.com)
+[![Community slack][slack-image]][slack-url]
 
 _Having problems? want to contribute? join our [community slack](http://devtoolscommunity.herokuapp.com)_.
 
@@ -54,3 +54,10 @@ As each Node LTS version reaches its end-of-life we will remove that version fro
 We will accept code that allows this package to run on newer, non-LTS, versions of Node. Furthermore, we will attempt to ensure our own changes work on the latest version of Node. To help in that commitment, our continuous integration setup runs against all LTS versions of Node in addition the most recent Node release; called _current_.
 
 JavaScript package managers should allow you to install this package with any version of Node, with, at most, a warning if your version of Node does not fall within the range specified by our `node` `engines` property. If you encounter issues installing this package, please report the issue to your package manager.
+
+[ci-image]: https://github.com/conventional-changelog/conventional-changelog/workflows/ci/badge.svg
+[ci-url]: https://github.com/conventional-changelog/conventional-changelog/actions?query=workflow%3Aci+branch%3Amaster
+[codecov-image]: https://codecov.io/gh/conventional-changelog/conventional-changelog/branch/master/graph/badge.svg
+[codecov-url]: https://codecov.io/gh/conventional-changelog/conventional-changelog
+[slack-image]: http://devtoolscommunity.herokuapp.com/badge.svg
+[slack-url]: http://devtoolscommunity.herokuapp.com

--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
     "chai": "^4.2.0",
     "concat-stream": "^2.0.0",
     "conventional-changelog-core": "^4.2.1",
-    "coveralls": "^3.0.2",
     "eslint": "^7.0.0",
     "eslint-config-standard": "^16.0.1",
     "eslint-plugin-import": "^2.18.2",

--- a/packages/conventional-changelog-angular/README.md
+++ b/packages/conventional-changelog-angular/README.md
@@ -1,4 +1,9 @@
-# [![NPM version][npm-image]][npm-url] [![Build Status][travis-image]][travis-url] [![Dependency Status][daviddm-image]][daviddm-url] [![Coverage Status][coveralls-image]][coveralls-url]
+# conventional-changelog-angular
+
+[![NPM version][npm-image]][npm-url]
+[![Build Status][ci-image]][ci-url]
+[![Dependency Status][daviddm-image]][daviddm-url]
+[![Codecov][codecov-image]][codecov-url]
 
 > [conventional-changelog](https://github.com/ajoslin/conventional-changelog) [angular](https://github.com/angular/angular) preset
 
@@ -95,10 +100,10 @@ A detailed explanation can be found in this [document](#commit-message-format).
 
 [npm-image]: https://badge.fury.io/js/conventional-changelog-angular.svg
 [npm-url]: https://npmjs.org/package/conventional-changelog-angular
-[travis-image]: https://travis-ci.org/conventional-changelog/conventional-changelog-angular.svg?branch=master
-[travis-url]: https://travis-ci.org/conventional-changelog/conventional-changelog-angular
+[ci-image]: https://github.com/conventional-changelog/conventional-changelog/workflows/ci/badge.svg
+[ci-url]: https://github.com/conventional-changelog/conventional-changelog/actions?query=workflow%3Aci+branch%3Amaster
 [daviddm-image]: https://david-dm.org/conventional-changelog/conventional-changelog-angular.svg?theme=shields.io
 [daviddm-url]: https://david-dm.org/conventional-changelog/conventional-changelog-angular
-[coveralls-image]: https://coveralls.io/repos/conventional-changelog/conventional-changelog-angular/badge.svg
-[coveralls-url]: https://coveralls.io/r/conventional-changelog/conventional-changelog-angular
+[codecov-image]: https://codecov.io/gh/conventional-changelog/conventional-changelog/branch/master/graph/badge.svg
+[codecov-url]: https://codecov.io/gh/conventional-changelog/conventional-changelog
 [commit-message-format]: https://docs.google.com/document/d/1QrDFcIiPjSLDn3EL15IJygNPiHORgU1_OOAqWjiDU5Y/edit#

--- a/packages/conventional-changelog-atom/README.md
+++ b/packages/conventional-changelog-atom/README.md
@@ -1,4 +1,9 @@
-#  [![NPM version][npm-image]][npm-url] [![Build Status][travis-image]][travis-url] [![Dependency Status][daviddm-image]][daviddm-url] [![Coverage Status][coveralls-image]][coveralls-url]
+# conventional-changelog-atom
+
+[![NPM version][npm-image]][npm-url]
+[![Build Status][ci-image]][ci-url]
+[![Dependency Status][daviddm-image]][daviddm-url]
+[![Codecov][codecov-image]][codecov-url]
 
 > [conventional-changelog](https://github.com/ajoslin/conventional-changelog) [atom](https://github.com/atom/atom) preset
 
@@ -33,9 +38,9 @@ Based on https://github.com/atom/atom/blob/master/CONTRIBUTING.md#git-commit-mes
 
 [npm-image]: https://badge.fury.io/js/conventional-changelog-atom.svg
 [npm-url]: https://npmjs.org/package/conventional-changelog-atom
-[travis-image]: https://travis-ci.org/stevemao/conventional-changelog-atom.svg?branch=master
-[travis-url]: https://travis-ci.org/stevemao/conventional-changelog-atom
+[ci-image]: https://github.com/conventional-changelog/conventional-changelog/workflows/ci/badge.svg
+[ci-url]: https://github.com/conventional-changelog/conventional-changelog/actions?query=workflow%3Aci+branch%3Amaster
 [daviddm-image]: https://david-dm.org/stevemao/conventional-changelog-atom.svg?theme=shields.io
 [daviddm-url]: https://david-dm.org/stevemao/conventional-changelog-atom
-[coveralls-image]: https://coveralls.io/repos/stevemao/conventional-changelog-atom/badge.svg
-[coveralls-url]: https://coveralls.io/r/stevemao/conventional-changelog-atom
+[codecov-image]: https://codecov.io/gh/conventional-changelog/conventional-changelog/branch/master/graph/badge.svg
+[codecov-url]: https://codecov.io/gh/conventional-changelog/conventional-changelog

--- a/packages/conventional-changelog-cli/README.md
+++ b/packages/conventional-changelog-cli/README.md
@@ -1,6 +1,9 @@
 # conventional-changelog-cli
 
-[![NPM version][npm-image]][npm-url] [![Build Status][travis-image]][travis-url] [![Dependency Status][daviddm-image]][daviddm-url] [![Coverage percentage][coveralls-image]][coveralls-url]
+[![NPM version][npm-image]][npm-url]
+[![Build Status][ci-image]][ci-url]
+[![Dependency Status][daviddm-image]][daviddm-url]
+[![Codecov][codecov-image]][codecov-url]
 
 > Generate a changelog from git metadata
 
@@ -120,9 +123,9 @@ MIT © [Steve Mao](https://github.com/stevemao)
 
 [npm-image]: https://badge.fury.io/js/conventional-changelog-cli.svg
 [npm-url]: https://npmjs.org/package/conventional-changelog-cli
-[travis-image]: https://travis-ci.org/conventional-changelog/conventional-changelog-cli.svg?branch=master
-[travis-url]: https://travis-ci.org/conventional-changelog/conventional-changelog-cli
+[ci-image]: https://github.com/conventional-changelog/conventional-changelog/workflows/ci/badge.svg
+[ci-url]: https://github.com/conventional-changelog/conventional-changelog/actions?query=workflow%3Aci+branch%3Amaster
 [daviddm-image]: https://david-dm.org/conventional-changelog/conventional-changelog-cli.svg?theme=shields.io
 [daviddm-url]: https://david-dm.org/conventional-changelog/conventional-changelog-cli
-[coveralls-image]: https://coveralls.io/repos/conventional-changelog/conventional-changelog-cli/badge.svg
-[coveralls-url]: https://coveralls.io/r/conventional-changelog/conventional-changelog-cli
+[codecov-image]: https://codecov.io/gh/conventional-changelog/conventional-changelog/branch/master/graph/badge.svg
+[codecov-url]: https://codecov.io/gh/conventional-changelog/conventional-changelog

--- a/packages/conventional-changelog-codemirror/README.md
+++ b/packages/conventional-changelog-codemirror/README.md
@@ -1,13 +1,18 @@
-#  [![NPM version][npm-image]][npm-url] [![Build Status][travis-image]][travis-url] [![Dependency Status][daviddm-image]][daviddm-url] [![Coverage Status][coveralls-image]][coveralls-url]
+# conventional-changelog-codemirror
+
+[![NPM version][npm-image]][npm-url]
+[![Build Status][ci-image]][ci-url]
+[![Dependency Status][daviddm-image]][daviddm-url]
+[![Codecov][codecov-image]][codecov-url]
 
 > [conventional-changelog](https://github.com/ajoslin/conventional-changelog) [CodeMirror](https://github.com/codemirror/codemirror) preset
 
 
 [npm-image]: https://badge.fury.io/js/conventional-changelog-codemirror.svg
 [npm-url]: https://npmjs.org/package/conventional-changelog-codemirror
-[travis-image]: https://travis-ci.org/stevemao/conventional-changelog-codemirror.svg?branch=master
-[travis-url]: https://travis-ci.org/stevemao/conventional-changelog-codemirror
+[ci-image]: https://github.com/conventional-changelog/conventional-changelog/workflows/ci/badge.svg
+[ci-url]: https://github.com/conventional-changelog/conventional-changelog/actions?query=workflow%3Aci+branch%3Amaster
 [daviddm-image]: https://david-dm.org/stevemao/conventional-changelog-codemirror.svg?theme=shields.io
 [daviddm-url]: https://david-dm.org/stevemao/conventional-changelog-codemirror
-[coveralls-image]: https://coveralls.io/repos/stevemao/conventional-changelog-codemirror/badge.svg
-[coveralls-url]: https://coveralls.io/r/stevemao/conventional-changelog-codemirror
+[codecov-image]: https://codecov.io/gh/conventional-changelog/conventional-changelog/branch/master/graph/badge.svg
+[codecov-url]: https://codecov.io/gh/conventional-changelog/conventional-changelog

--- a/packages/conventional-changelog-conventionalcommits/README.md
+++ b/packages/conventional-changelog-conventionalcommits/README.md
@@ -1,4 +1,9 @@
-# [![Build Status][travis-image]][travis-url] [![Coverage Status][coveralls-image]][coveralls-url]
+# conventional-changelog-conventionalcommits
+
+[![NPM version][npm-image]][npm-url]
+[![Build Status][ci-image]][ci-url]
+[![Dependency Status][daviddm-image]][daviddm-url]
+[![Codecov][codecov-image]][codecov-url]
 
 ## conventionalcommits.org convention
 
@@ -39,12 +44,15 @@ or json config like that:
 This last json config way passes the `preset` object to the `conventional-changelog-preset-loader` package, that in turn, passes this same `preset` object as the config for the `conventional-changelog-conventionalcommits`.
 
 
-
 See [conventional-changelog-config-spec](https://github.com/conventional-changelog/conventional-changelog-config-spec) for available
 configuration options.
 
 
-[travis-image]: https://travis-ci.org/conventional-changelog/conventional-changelog.svg?branch=master
-[travis-url]: https://travis-ci.org/conventional-changelog/conventional-changelog
-[coveralls-image]: https://coveralls.io/repos/conventional-changelog/conventional-changelog/badge.svg
-[coveralls-url]: https://coveralls.io/r/conventional-changelog/conventional-changelog
+[npm-image]: https://badge.fury.io/js/conventional-changelog-conventionalcommits.svg
+[npm-url]: https://npmjs.org/package/conventional-changelog-conventionalcommits
+[ci-image]: https://github.com/conventional-changelog/conventional-changelog/workflows/ci/badge.svg
+[ci-url]: https://github.com/conventional-changelog/conventional-changelog/actions?query=workflow%3Aci+branch%3Amaster
+[daviddm-image]: https://david-dm.org/conventional-changelog/conventional-changelog-angular.svg?theme=shields.io
+[daviddm-url]: https://david-dm.org/conventional-changelog/conventional-changelog-angular
+[codecov-image]: https://codecov.io/gh/conventional-changelog/conventional-changelog/branch/master/graph/badge.svg
+[codecov-url]: https://codecov.io/gh/conventional-changelog/conventional-changelog

--- a/packages/conventional-changelog-core/README.md
+++ b/packages/conventional-changelog-core/README.md
@@ -1,4 +1,9 @@
-#  [![NPM version][npm-image]][npm-url] [![Build Status: Linux][travis-image]][travis-url] [![Build Status: Windows][appveyor-image]][appveyor-url] [![Dependency Status][daviddm-image]][daviddm-url] [![Coverage Status][coveralls-image]][coveralls-url]
+# conventional-changelog-core
+
+[![NPM version][npm-image]][npm-url]
+[![Build Status][ci-image]][ci-url]
+[![Dependency Status][daviddm-image]][daviddm-url]
+[![Codecov][codecov-image]][codecov-url]
 
 > [conventional-changelog](https://github.com/conventional-changelog/conventional-changelog) core
 
@@ -245,11 +250,9 @@ MIT
 
 [npm-image]: https://badge.fury.io/js/conventional-changelog-core.svg
 [npm-url]: https://npmjs.org/package/conventional-changelog-core
-[travis-image]: https://travis-ci.org/conventional-changelog/conventional-changelog-core.svg?branch=master
-[travis-url]: https://travis-ci.org/conventional-changelog/conventional-changelog-core
-[appveyor-image]: https://ci.appveyor.com/api/projects/status/baoumm34w8c5o0hv/branch/master?svg=true
-[appveyor-url]: https://ci.appveyor.com/project/stevemao/conventional-changelog-core/branch/master
+[ci-image]: https://github.com/conventional-changelog/conventional-changelog/workflows/ci/badge.svg
+[ci-url]: https://github.com/conventional-changelog/conventional-changelog/actions?query=workflow%3Aci+branch%3Amaster
 [daviddm-image]: https://david-dm.org/conventional-changelog/conventional-changelog-core.svg?theme=shields.io
 [daviddm-url]: https://david-dm.org/conventional-changelog/conventional-changelog-core
-[coveralls-image]: https://coveralls.io/repos/conventional-changelog/conventional-changelog-core/badge.svg
-[coveralls-url]: https://coveralls.io/r/conventional-changelog/conventional-changelog-core
+[codecov-image]: https://codecov.io/gh/conventional-changelog/conventional-changelog/branch/master/graph/badge.svg
+[codecov-url]: https://codecov.io/gh/conventional-changelog/conventional-changelog

--- a/packages/conventional-changelog-ember/README.md
+++ b/packages/conventional-changelog-ember/README.md
@@ -1,4 +1,9 @@
-#  [![NPM version][npm-image]][npm-url] [![Build Status][travis-image]][travis-url] [![Dependency Status][daviddm-image]][daviddm-url] [![Coverage Status][coveralls-image]][coveralls-url]
+# conventional-changelog-ember
+
+[![NPM version][npm-image]][npm-url]
+[![Build Status][ci-image]][ci-url]
+[![Dependency Status][daviddm-image]][daviddm-url]
+[![Codecov][codecov-image]][codecov-url]
 
 > [conventional-changelog](https://github.com/ajoslin/conventional-changelog) [ember](https://github.com/emberjs/ember.js) preset
 
@@ -55,9 +60,9 @@ Based on https://github.com/emberjs/ember.js/blob/master/CONTRIBUTING.md
 
 [npm-image]: https://badge.fury.io/js/conventional-changelog-ember.svg
 [npm-url]: https://npmjs.org/package/conventional-changelog-ember
-[travis-image]: https://travis-ci.org/stevemao/conventional-changelog-ember.svg?branch=master
-[travis-url]: https://travis-ci.org/stevemao/conventional-changelog-ember
+[ci-image]: https://github.com/conventional-changelog/conventional-changelog/workflows/ci/badge.svg
+[ci-url]: https://github.com/conventional-changelog/conventional-changelog/actions?query=workflow%3Aci+branch%3Amaster
 [daviddm-image]: https://david-dm.org/stevemao/conventional-changelog-ember.svg?theme=shields.io
 [daviddm-url]: https://david-dm.org/stevemao/conventional-changelog-ember
-[coveralls-image]: https://coveralls.io/repos/stevemao/conventional-changelog-ember/badge.svg
-[coveralls-url]: https://coveralls.io/r/stevemao/conventional-changelog-ember
+[codecov-image]: https://codecov.io/gh/conventional-changelog/conventional-changelog/branch/master/graph/badge.svg
+[codecov-url]: https://codecov.io/gh/conventional-changelog/conventional-changelog

--- a/packages/conventional-changelog-eslint/README.md
+++ b/packages/conventional-changelog-eslint/README.md
@@ -1,4 +1,9 @@
-#  [![NPM version][npm-image]][npm-url] [![Build Status][travis-image]][travis-url] [![Dependency Status][daviddm-image]][daviddm-url] [![Coverage Status][coveralls-image]][coveralls-url]
+# conventional-changelog-eslint
+
+[![NPM version][npm-image]][npm-url]
+[![Build Status][ci-image]][ci-url]
+[![Dependency Status][daviddm-image]][daviddm-url]
+[![Codecov][codecov-image]][codecov-url]
 
 > [conventional-changelog](https://github.com/ajoslin/conventional-changelog) [eslint](https://github.com/eslint/eslint) preset
 
@@ -45,9 +50,9 @@ Based on https://eslint.org/docs/developer-guide/contributing/pull-requests#step
 
 [npm-image]: https://badge.fury.io/js/conventional-changelog-eslint.svg
 [npm-url]: https://npmjs.org/package/conventional-changelog-eslint
-[travis-image]: https://travis-ci.org/stevemao/conventional-changelog-eslint.svg?branch=master
-[travis-url]: https://travis-ci.org/stevemao/conventional-changelog-eslint
+[ci-image]: https://github.com/conventional-changelog/conventional-changelog/workflows/ci/badge.svg
+[ci-url]: https://github.com/conventional-changelog/conventional-changelog/actions?query=workflow%3Aci+branch%3Amaster
 [daviddm-image]: https://david-dm.org/stevemao/conventional-changelog-eslint.svg?theme=shields.io
 [daviddm-url]: https://david-dm.org/stevemao/conventional-changelog-eslint
-[coveralls-image]: https://coveralls.io/repos/stevemao/conventional-changelog-eslint/badge.svg
-[coveralls-url]: https://coveralls.io/r/stevemao/conventional-changelog-eslint
+[codecov-image]: https://codecov.io/gh/conventional-changelog/conventional-changelog/branch/master/graph/badge.svg
+[codecov-url]: https://codecov.io/gh/conventional-changelog/conventional-changelog

--- a/packages/conventional-changelog-express/README.md
+++ b/packages/conventional-changelog-express/README.md
@@ -1,4 +1,9 @@
-#  [![NPM version][npm-image]][npm-url] [![Build Status][travis-image]][travis-url] [![Dependency Status][daviddm-image]][daviddm-url] [![Coverage Status][coveralls-image]][coveralls-url]
+# conventional-changelog-express
+
+[![NPM version][npm-image]][npm-url]
+[![Build Status][ci-image]][ci-url]
+[![Dependency Status][daviddm-image]][daviddm-url]
+[![Codecov][codecov-image]][codecov-url]
 
 > [conventional-changelog](https://github.com/ajoslin/conventional-changelog) [express](https://github.com/strongloop/express) preset
 
@@ -6,9 +11,9 @@
 
 [npm-image]: https://badge.fury.io/js/conventional-changelog-express.svg
 [npm-url]: https://npmjs.org/package/conventional-changelog-express
-[travis-image]: https://travis-ci.org/stevemao/conventional-changelog-express.svg?branch=master
-[travis-url]: https://travis-ci.org/stevemao/conventional-changelog-express
+[ci-image]: https://github.com/conventional-changelog/conventional-changelog/workflows/ci/badge.svg
+[ci-url]: https://github.com/conventional-changelog/conventional-changelog/actions?query=workflow%3Aci+branch%3Amaster
 [daviddm-image]: https://david-dm.org/stevemao/conventional-changelog-express.svg?theme=shields.io
 [daviddm-url]: https://david-dm.org/stevemao/conventional-changelog-express
-[coveralls-image]: https://coveralls.io/repos/stevemao/conventional-changelog-express/badge.svg
-[coveralls-url]: https://coveralls.io/r/stevemao/conventional-changelog-express
+[codecov-image]: https://codecov.io/gh/conventional-changelog/conventional-changelog/branch/master/graph/badge.svg
+[codecov-url]: https://codecov.io/gh/conventional-changelog/conventional-changelog

--- a/packages/conventional-changelog-jquery/README.md
+++ b/packages/conventional-changelog-jquery/README.md
@@ -1,4 +1,9 @@
-#  [![NPM version][npm-image]][npm-url] [![Build Status][travis-image]][travis-url] [![Dependency Status][daviddm-image]][daviddm-url] [![Coverage Status][coveralls-image]][coveralls-url]
+# conventional-changelog-jquery
+
+[![NPM version][npm-image]][npm-url]
+[![Build Status][ci-image]][ci-url]
+[![Dependency Status][daviddm-image]][daviddm-url]
+[![Codecov][codecov-image]][codecov-url]
 
 > [conventional-changelog](https://github.com/ajoslin/conventional-changelog) [jQuery](https://github.com/jquery/jquery) preset
 
@@ -44,9 +49,9 @@ Based on https://github.com/jquery/contribute.jquery.org/blob/master/pages/commi
 
 [npm-image]: https://badge.fury.io/js/conventional-changelog-jquery.svg
 [npm-url]: https://npmjs.org/package/conventional-changelog-jquery
-[travis-image]: https://travis-ci.org/conventional-changelog/conventional-changelog-jquery.svg?branch=master
-[travis-url]: https://travis-ci.org/conventional-changelog/conventional-changelog-jquery
+[ci-image]: https://github.com/conventional-changelog/conventional-changelog/workflows/ci/badge.svg
+[ci-url]: https://github.com/conventional-changelog/conventional-changelog/actions?query=workflow%3Aci+branch%3Amaster
 [daviddm-image]: https://david-dm.org/conventional-changelog/conventional-changelog-jquery.svg?theme=shields.io
 [daviddm-url]: https://david-dm.org/conventional-changelog/conventional-changelog-jquery
-[coveralls-image]: https://coveralls.io/repos/conventional-changelog/conventional-changelog-jquery/badge.svg
-[coveralls-url]: https://coveralls.io/r/conventional-changelog/conventional-changelog-jquery
+[codecov-image]: https://codecov.io/gh/conventional-changelog/conventional-changelog/branch/master/graph/badge.svg
+[codecov-url]: https://codecov.io/gh/conventional-changelog/conventional-changelog

--- a/packages/conventional-changelog-jshint/README.md
+++ b/packages/conventional-changelog-jshint/README.md
@@ -1,4 +1,9 @@
-#  [![NPM version][npm-image]][npm-url] [![Build Status][travis-image]][travis-url] [![Dependency Status][daviddm-image]][daviddm-url] [![Coverage Status][coveralls-image]][coveralls-url]
+# conventional-changelog-jshint
+
+[![NPM version][npm-image]][npm-url]
+[![Build Status][ci-image]][ci-url]
+[![Dependency Status][daviddm-image]][daviddm-url]
+[![Codecov][codecov-image]][codecov-url]
 
 > [conventional-changelog](https://github.com/ajoslin/conventional-changelog) [jshint](https://github.com/jshint/jshint) preset
 
@@ -82,9 +87,9 @@ Based on https://github.com/jshint/jshint/blob/master/CONTRIBUTING.md#commit-mes
 
 [npm-image]: https://badge.fury.io/js/conventional-changelog-jshint.svg
 [npm-url]: https://npmjs.org/package/conventional-changelog-jshint
-[travis-image]: https://travis-ci.org/stevemao/conventional-changelog-jshint.svg?branch=master
-[travis-url]: https://travis-ci.org/stevemao/conventional-changelog-jshint
+[ci-image]: https://github.com/conventional-changelog/conventional-changelog/workflows/ci/badge.svg
+[ci-url]: https://github.com/conventional-changelog/conventional-changelog/actions?query=workflow%3Aci+branch%3Amaster
 [daviddm-image]: https://david-dm.org/stevemao/conventional-changelog-jshint.svg?theme=shields.io
 [daviddm-url]: https://david-dm.org/stevemao/conventional-changelog-jshint
-[coveralls-image]: https://coveralls.io/repos/stevemao/conventional-changelog-jshint/badge.svg
-[coveralls-url]: https://coveralls.io/r/stevemao/conventional-changelog-jshint
+[codecov-image]: https://codecov.io/gh/conventional-changelog/conventional-changelog/branch/master/graph/badge.svg
+[codecov-url]: https://codecov.io/gh/conventional-changelog/conventional-changelog

--- a/packages/conventional-changelog-preset-loader/README.md
+++ b/packages/conventional-changelog-preset-loader/README.md
@@ -1,4 +1,9 @@
-#  [![NPM version][npm-image]][npm-url] [![Build Status: Linux][travis-image]][travis-url] [![Build Status: Windows][appveyor-image]][appveyor-url] [![Dependency Status][daviddm-image]][daviddm-url] [![Coverage Status][coveralls-image]][coveralls-url]
+# conventional-changelog-preset-loader
+
+[![NPM version][npm-image]][npm-url]
+[![Build Status][ci-image]][ci-url]
+[![Dependency Status][daviddm-image]][daviddm-url]
+[![Codecov][codecov-image]][codecov-url]
 
 > Configuration preset loader for `conventional-changelog`.
 
@@ -31,11 +36,9 @@ MIT © [Steve Mao](https://github.com/stevemao)
 
 [npm-image]: https://badge.fury.io/js/conventional-changelog-preset-loader.svg
 [npm-url]: https://npmjs.org/package/conventional-changelog-preset-loader
-[travis-image]: https://travis-ci.org/conventional-changelog/conventional-changelog-preset-loader.svg?branch=master
-[travis-url]: https://travis-ci.org/conventional-changelog/conventional-changelog-preset-loader
-[appveyor-image]: https://ci.appveyor.com/api/projects/status/baoumm34w8c5o0hv/branch/master?svg=true
-[appveyor-url]: https://ci.appveyor.com/project/stevemao/conventional-changelog-preset-loader/branch/master
+[ci-image]: https://github.com/conventional-changelog/conventional-changelog/workflows/ci/badge.svg
+[ci-url]: https://github.com/conventional-changelog/conventional-changelog/actions?query=workflow%3Aci+branch%3Amaster
 [daviddm-image]: https://david-dm.org/conventional-changelog/conventional-changelog-preset-loader.svg?theme=shields.io
 [daviddm-url]: https://david-dm.org/conventional-changelog/conventional-changelog-preset-loader
-[coveralls-image]: https://coveralls.io/repos/conventional-changelog/conventional-changelog-preset-loader/badge.svg
-[coveralls-url]: https://coveralls.io/r/conventional-changelog/conventional-changelog-preset-loader
+[codecov-image]: https://codecov.io/gh/conventional-changelog/conventional-changelog/branch/master/graph/badge.svg
+[codecov-url]: https://codecov.io/gh/conventional-changelog/conventional-changelog

--- a/packages/conventional-changelog-writer/README.md
+++ b/packages/conventional-changelog-writer/README.md
@@ -1,4 +1,9 @@
-#  [![NPM version][npm-image]][npm-url] [![Build Status][travis-image]][travis-url] [![Dependency Status][daviddm-image]][daviddm-url] [![Coverage Status][coveralls-image]][coveralls-url]
+# conventional-changelog-writer
+
+[![NPM version][npm-image]][npm-url]
+[![Build Status][ci-image]][ci-url]
+[![Dependency Status][daviddm-image]][daviddm-url]
+[![Codecov][codecov-image]][codecov-url]
 
 > Write logs based on conventional commits and templates
 
@@ -361,9 +366,9 @@ MIT © [Steve Mao](https://github.com/stevemao)
 
 [npm-image]: https://badge.fury.io/js/conventional-changelog-writer.svg
 [npm-url]: https://npmjs.org/package/conventional-changelog-writer
-[travis-image]: https://travis-ci.org/conventional-changelog/conventional-changelog-writer.svg?branch=master
-[travis-url]: https://travis-ci.org/conventional-changelog/conventional-changelog-writer
+[ci-image]: https://github.com/conventional-changelog/conventional-changelog/workflows/ci/badge.svg
+[ci-url]: https://github.com/conventional-changelog/conventional-changelog/actions?query=workflow%3Aci+branch%3Amaster
 [daviddm-image]: https://david-dm.org/conventional-changelog/conventional-changelog-writer.svg?theme=shields.io
 [daviddm-url]: https://david-dm.org/conventional-changelog/conventional-changelog-writer
-[coveralls-image]: https://coveralls.io/repos/conventional-changelog/conventional-changelog-writer/badge.svg
-[coveralls-url]: https://coveralls.io/r/conventional-changelog/conventional-changelog-writer
+[codecov-image]: https://codecov.io/gh/conventional-changelog/conventional-changelog/branch/master/graph/badge.svg
+[codecov-url]: https://codecov.io/gh/conventional-changelog/conventional-changelog

--- a/packages/conventional-changelog/README.md
+++ b/packages/conventional-changelog/README.md
@@ -1,4 +1,9 @@
-#  [![NPM version][npm-image]][npm-url] [![Build Status][travis-image]][travis-url] [![Dependency Status][daviddm-image]][daviddm-url] [![Coverage Status][coveralls-image]][coveralls-url]
+# conventional-changelog
+
+[![NPM version][npm-image]][npm-url]
+[![Build Status][ci-image]][ci-url]
+[![Dependency Status][daviddm-image]][daviddm-url]
+[![Codecov][codecov-image]][codecov-url]
 
 > Generate a changelog from git metadata
 
@@ -58,9 +63,9 @@ MIT
 
 [npm-image]: https://badge.fury.io/js/conventional-changelog.svg
 [npm-url]: https://npmjs.org/package/conventional-changelog
-[travis-image]: https://travis-ci.org/conventional-changelog/conventional-changelog.svg?branch=master
-[travis-url]: https://travis-ci.org/conventional-changelog/conventional-changelog
+[ci-image]: https://github.com/conventional-changelog/conventional-changelog/workflows/ci/badge.svg
+[ci-url]: https://github.com/conventional-changelog/conventional-changelog/actions?query=workflow%3Aci+branch%3Amaster
 [daviddm-image]: https://david-dm.org/conventional-changelog/conventional-changelog.svg?theme=shields.io
 [daviddm-url]: https://david-dm.org/conventional-changelog/conventional-changelog
-[coveralls-image]: https://coveralls.io/repos/conventional-changelog/conventional-changelog/badge.svg
-[coveralls-url]: https://coveralls.io/r/conventional-changelog/conventional-changelog
+[codecov-image]: https://codecov.io/gh/conventional-changelog/conventional-changelog/branch/master/graph/badge.svg
+[codecov-url]: https://codecov.io/gh/conventional-changelog/conventional-changelog

--- a/packages/conventional-commits-filter/README.md
+++ b/packages/conventional-commits-filter/README.md
@@ -1,6 +1,11 @@
-# conventional-commits-filter [![NPM version][npm-image]][npm-url] [![Build Status][travis-image]][travis-url] [![Dependency Status][daviddm-image]][daviddm-url] [![Coverage percentage][coveralls-image]][coveralls-url]
-> Filter out reverted commits parsed by conventional-commits-parser
+# conventional-commits-filter
 
+[![NPM version][npm-image]][npm-url]
+[![Build Status][ci-image]][ci-url]
+[![Dependency Status][daviddm-image]][daviddm-url]
+[![Codecov][codecov-image]][codecov-url]
+
+> Filter out reverted commits parsed by conventional-commits-parser
 
 ## Install
 
@@ -176,9 +181,9 @@ MIT © [Steve Mao]()
 
 [npm-image]: https://badge.fury.io/js/conventional-commits-filter.svg
 [npm-url]: https://npmjs.org/package/conventional-commits-filter
-[travis-image]: https://travis-ci.org/stevemao/conventional-commits-filter.svg?branch=master
-[travis-url]: https://travis-ci.org/stevemao/conventional-commits-filter
+[ci-image]: https://github.com/conventional-changelog/conventional-changelog/workflows/ci/badge.svg
+[ci-url]: https://github.com/conventional-changelog/conventional-changelog/actions?query=workflow%3Aci+branch%3Amaster
 [daviddm-image]: https://david-dm.org/stevemao/conventional-commits-filter.svg
 [daviddm-url]: https://david-dm.org/stevemao/conventional-commits-filter
-[coveralls-image]: https://coveralls.io/repos/stevemao/conventional-commits-filter/badge.svg?branch=master
-[coveralls-url]: https://coveralls.io/r/stevemao/conventional-commits-filter
+[codecov-image]: https://codecov.io/gh/conventional-changelog/conventional-changelog/branch/master/graph/badge.svg
+[codecov-url]: https://codecov.io/gh/conventional-changelog/conventional-changelog

--- a/packages/conventional-commits-parser/README.md
+++ b/packages/conventional-commits-parser/README.md
@@ -1,4 +1,9 @@
-#  [![NPM version][npm-image]][npm-url] [![Build Status][travis-image]][travis-url] [![Dependency Status][daviddm-image]][daviddm-url] [![Coverage Status][coveralls-image]][coveralls-url]
+# conventional-commits-parser
+
+[![NPM version][npm-image]][npm-url]
+[![Build Status][ci-image]][ci-url]
+[![Dependency Status][daviddm-image]][daviddm-url]
+[![Codecov][codecov-image]][codecov-url]
 
 > Parse raw conventional commits
 
@@ -374,9 +379,9 @@ MIT © [Steve Mao](https://github.com/stevemao)
 
 [npm-image]: https://badge.fury.io/js/conventional-commits-parser.svg
 [npm-url]: https://npmjs.org/package/conventional-commits-parser
-[travis-image]: https://travis-ci.org/conventional-changelog/conventional-commits-parser.svg?branch=master
-[travis-url]: https://travis-ci.org/conventional-changelog/conventional-commits-parser
+[ci-image]: https://github.com/conventional-changelog/conventional-changelog/workflows/ci/badge.svg
+[ci-url]: https://github.com/conventional-changelog/conventional-changelog/actions?query=workflow%3Aci+branch%3Amaster
 [daviddm-image]: https://david-dm.org/conventional-changelog/conventional-commits-parser.svg?theme=shields.io
 [daviddm-url]: https://david-dm.org/conventional-changelog/conventional-commits-parser
-[coveralls-image]: https://coveralls.io/repos/conventional-changelog/conventional-commits-parser/badge.svg
-[coveralls-url]: https://coveralls.io/r/conventional-changelog/conventional-commits-parser
+[codecov-image]: https://codecov.io/gh/conventional-changelog/conventional-changelog/branch/master/graph/badge.svg
+[codecov-url]: https://codecov.io/gh/conventional-changelog/conventional-changelog

--- a/packages/conventional-recommended-bump/README.md
+++ b/packages/conventional-recommended-bump/README.md
@@ -3,7 +3,7 @@
 [![NPM version][npm-image]][npm-url]
 [![Build Status][ci-image]][ci-url]
 [![Dependency Status][daviddm-image]][daviddm-url]
-[![Codecov][codecov-image]][codecov-url]
+[![Coverage Status][coverage-image]][coverage-url]
 
 > Get a recommended version bump based on conventional commits.
 
@@ -201,5 +201,5 @@ MIT © [Steve Mao](https://github.com/stevemao)
 [ci-url]: https://github.com/conventional-changelog/conventional-changelog/actions?query=workflow%3Aci+branch%3Amaster
 [daviddm-image]: https://david-dm.org/conventional-changelog/conventional-recommended-bump.svg?theme=shields.io
 [daviddm-url]: https://david-dm.org/conventional-changelog/conventional-recommended-bump
-[codecov-image]: https://codecov.io/gh/conventional-changelog/conventional-changelog/branch/master/graph/badge.svg
-[codecov-url]: https://codecov.io/gh/conventional-changelog/conventional-changelog
+[coverage-image]: https://coveralls.io/repos/github/conventional-changelog/conventional-changelog/badge.svg?branch=master
+[coverage-url]: https://coveralls.io/github/conventional-changelog/conventional-changelog?branch=master

--- a/packages/conventional-recommended-bump/README.md
+++ b/packages/conventional-recommended-bump/README.md
@@ -1,5 +1,10 @@
 # conventional-recommended-bump
 
+[![NPM version][npm-image]][npm-url]
+[![Build Status][ci-image]][ci-url]
+[![Dependency Status][daviddm-image]][daviddm-url]
+[![Codecov][codecov-image]][codecov-url]
+
 > Get a recommended version bump based on conventional commits.
 
 Got the idea from https://github.com/conventional-changelog/conventional-changelog/pull/29
@@ -189,3 +194,12 @@ Please read our [contributing guide](https://github.com/conventional-changelog/c
 ## License
 
 MIT © [Steve Mao](https://github.com/stevemao)
+
+[npm-image]: https://badge.fury.io/js/conventional-recommended-bump.svg
+[npm-url]: https://npmjs.org/package/conventional-recommended-bump
+[ci-image]: https://github.com/conventional-changelog/conventional-changelog/workflows/ci/badge.svg
+[ci-url]: https://github.com/conventional-changelog/conventional-changelog/actions?query=workflow%3Aci+branch%3Amaster
+[daviddm-image]: https://david-dm.org/conventional-changelog/conventional-recommended-bump.svg?theme=shields.io
+[daviddm-url]: https://david-dm.org/conventional-changelog/conventional-recommended-bump
+[codecov-image]: https://codecov.io/gh/conventional-changelog/conventional-changelog/branch/master/graph/badge.svg
+[codecov-url]: https://codecov.io/gh/conventional-changelog/conventional-changelog

--- a/packages/git-raw-commits/README.md
+++ b/packages/git-raw-commits/README.md
@@ -1,4 +1,9 @@
-#  [![NPM version][npm-image]][npm-url] [![Build Status: Linux][travis-image]][travis-url] [![Build Status: Windows][appveyor-image]][appveyor-url] [![Dependency Status][daviddm-image]][daviddm-url] [![Coverage Status][coveralls-image]][coveralls-url]
+# git-raw-commits
+
+[![NPM version][npm-image]][npm-url]
+[![Build Status][ci-image]][ci-url]
+[![Dependency Status][daviddm-image]][daviddm-url]
+[![Codecov][codecov-image]][codecov-url]
 
 > Get raw git commits out of your repository using git-log(1)
 
@@ -91,11 +96,9 @@ MIT © [Steve Mao](https://github.com/stevemao)
 
 [npm-image]: https://badge.fury.io/js/git-raw-commits.svg
 [npm-url]: https://npmjs.org/package/git-raw-commits
-[travis-image]: https://travis-ci.org/conventional-changelog/git-raw-commits.svg?branch=master
-[travis-url]: https://travis-ci.org/conventional-changelog/git-raw-commits
-[appveyor-image]: https://ci.appveyor.com/api/projects/status/4qm3bjmg41k3dsbv/branch/master?svg=true
-[appveyor-url]: https://ci.appveyor.com/project/stevemao/git-raw-commits/branch/master
+[ci-image]: https://github.com/conventional-changelog/conventional-changelog/workflows/ci/badge.svg
+[ci-url]: https://github.com/conventional-changelog/conventional-changelog/actions?query=workflow%3Aci+branch%3Amaster
 [daviddm-image]: https://david-dm.org/conventional-changelog/git-raw-commits.svg?theme=shields.io
 [daviddm-url]: https://david-dm.org/conventional-changelog/git-raw-commits
-[coveralls-image]: https://coveralls.io/repos/conventional-changelog/git-raw-commits/badge.svg
-[coveralls-url]: https://coveralls.io/r/conventional-changelog/git-raw-commits
+[codecov-image]: https://codecov.io/gh/conventional-changelog/conventional-changelog/branch/master/graph/badge.svg
+[codecov-url]: https://codecov.io/gh/conventional-changelog/conventional-changelog

--- a/packages/git-semver-tags/README.md
+++ b/packages/git-semver-tags/README.md
@@ -1,4 +1,9 @@
-#  [![NPM version][npm-image]][npm-url] [![Build Status][travis-image]][travis-url] [![Dependency Status][daviddm-image]][daviddm-url] [![Coverage Status][coveralls-image]][coveralls-url]
+# git-semver-tags
+
+[![NPM version][npm-image]][npm-url]
+[![Build Status][ci-image]][ci-url]
+[![Dependency Status][daviddm-image]][daviddm-url]
+[![Codecov][codecov-image]][codecov-url]
 
 > Get all git semver tags of your repository in reverse chronological order
 
@@ -46,9 +51,9 @@ MIT © [Steve Mao](https://github.com/stevemao)
 
 [npm-image]: https://badge.fury.io/js/git-semver-tags.svg
 [npm-url]: https://npmjs.org/package/git-semver-tags
-[travis-image]: https://travis-ci.org/conventional-changelog/git-semver-tags.svg?branch=master
-[travis-url]: https://travis-ci.org/conventional-changelog/git-semver-tags
+[ci-image]: https://github.com/conventional-changelog/conventional-changelog/workflows/ci/badge.svg
+[ci-url]: https://github.com/conventional-changelog/conventional-changelog/actions?query=workflow%3Aci+branch%3Amaster
 [daviddm-image]: https://david-dm.org/stevemao/git-semver-tags.svg?theme=shields.io
 [daviddm-url]: https://david-dm.org/stevemao/git-semver-tags
-[coveralls-image]: https://coveralls.io/repos/stevemao/git-semver-tags/badge.svg
-[coveralls-url]: https://coveralls.io/r/stevemao/git-semver-tags
+[codecov-image]: https://codecov.io/gh/conventional-changelog/conventional-changelog/branch/master/graph/badge.svg
+[codecov-url]: https://codecov.io/gh/conventional-changelog/conventional-changelog

--- a/packages/gulp-conventional-changelog/README.md
+++ b/packages/gulp-conventional-changelog/README.md
@@ -1,4 +1,9 @@
-# gulp-conventional-changelog [![NPM version][npm-image]][npm-url] [![Build Status][travis-image]][travis-url] [![Dependency Status][daviddm-image]][daviddm-url] [![Coverage Status][coveralls-image]][coveralls-url]
+# gulp-conventional-changelog
+
+[![NPM version][npm-image]][npm-url]
+[![Build Status][ci-image]][ci-url]
+[![Dependency Status][daviddm-image]][daviddm-url]
+[![Codecov][codecov-image]][codecov-url]
 
 > Generate a changelog using [conventional-changelog](https://github.com/ajoslin/conventional-changelog)
 
@@ -119,9 +124,9 @@ MIT © [Steve Mao](https://github.com/stevemao)
 
 [npm-image]: https://badge.fury.io/js/gulp-conventional-changelog.svg
 [npm-url]: https://npmjs.org/package/gulp-conventional-changelog
-[travis-image]: https://travis-ci.org/conventional-changelog/gulp-conventional-changelog.svg?branch=master
-[travis-url]: https://travis-ci.org/conventional-changelog/gulp-conventional-changelog
+[ci-image]: https://github.com/conventional-changelog/conventional-changelog/workflows/ci/badge.svg
+[ci-url]: https://github.com/conventional-changelog/conventional-changelog/actions?query=workflow%3Aci+branch%3Amaster
 [daviddm-image]: https://david-dm.org/conventional-changelog/gulp-conventional-changelog.svg?theme=shields.io
 [daviddm-url]: https://david-dm.org/conventional-changelog/gulp-conventional-changelog
-[coveralls-image]: https://coveralls.io/repos/github/conventional-changelog/gulp-conventional-changelog/badge.svg
-[coveralls-url]: https://coveralls.io/r/conventional-changelog/gulp-conventional-changelog
+[codecov-image]: https://codecov.io/gh/conventional-changelog/conventional-changelog/branch/master/graph/badge.svg
+[codecov-url]: https://codecov.io/gh/conventional-changelog/conventional-changelog

--- a/packages/standard-changelog/README.md
+++ b/packages/standard-changelog/README.md
@@ -1,6 +1,9 @@
 # Standard CHANGELOG
 
-[![NPM version][npm-image]][npm-url] [![Build Status][travis-image]][travis-url] [![Dependency Status][daviddm-image]][daviddm-url] [![Coverage Status][coveralls-image]][coveralls-url]
+[![NPM version][npm-image]][npm-url]
+[![Build Status][ci-image]][ci-url]
+[![Dependency Status][daviddm-image]][daviddm-url]
+[![Codecov][codecov-image]][codecov-url]
 
 > An opinionated approach to CHANGELOG generation using angular commit conventions.
 
@@ -56,9 +59,9 @@ MIT
 
 [npm-image]: https://badge.fury.io/js/standard-changelog.svg
 [npm-url]: https://npmjs.org/package/standard-changelog
-[travis-image]: https://travis-ci.org/conventional-changelog/standard-changelog.svg?branch=master
-[travis-url]: https://travis-ci.org/conventional-changelog/standard-changelog
+[ci-image]: https://github.com/conventional-changelog/conventional-changelog/workflows/ci/badge.svg
+[ci-url]: https://github.com/conventional-changelog/conventional-changelog/actions?query=workflow%3Aci+branch%3Amaster
 [daviddm-image]: https://david-dm.org/conventional-changelog/standard-changelog.svg?theme=shields.io
 [daviddm-url]: https://david-dm.org/conventional-changelog/standard-changelog
-[coveralls-image]: https://coveralls.io/repos/conventional-changelog/standard-changelog/badge.svg
-[coveralls-url]: https://coveralls.io/r/conventional-changelog/standard-changelog
+[codecov-image]: https://codecov.io/gh/conventional-changelog/conventional-changelog/branch/master/graph/badge.svg
+[codecov-url]: https://codecov.io/gh/conventional-changelog/conventional-changelog


### PR DESCRIPTION
This PR contains overall alignment for all readme files in projects, each package in first line will have name and in 2nd line badges

currently ci badge in projects points sometimes to actions, sometimes to travis and sometimes to appveyor but currently only actions are in use.

related change #762