### PR TITLE
test: submit correct lcov reports for codecov

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,6 +24,7 @@ jobs:
       - name: coverage
         uses: codecov/codecov-action@v1
         with:
+          files: ./coverage/lcov.info
           name: actions ${{ matrix.node }}
           fail_ci_if_error: true
   windows:
@@ -40,5 +41,6 @@ jobs:
       - name: coverage
         uses: codecov/codecov-action@v1
         with:
+          files: ./coverage/lcov.info
           name: actions windows
           fail_ci_if_error: true

--- a/.nycrc
+++ b/.nycrc
@@ -1,3 +1,4 @@
 {
+  "tempDirectory": ".nyc_output/",
   "reporters": ["lcov", "text"]
 }

--- a/.nycrc
+++ b/.nycrc
@@ -1,4 +1,3 @@
 {
-  "tempDirectory": ".nyc_output/",
   "reporters": ["lcov", "text"]
 }

--- a/package.json
+++ b/package.json
@@ -38,14 +38,14 @@
     "lint": "eslint . --cache --cache-location ./node_modules/.cache/ --ignore-path .gitignore",
     "fix": "eslint . --fix --cache --cache-location ./node_modules/.cache/ --ignore-path .gitignore",
     "pretest": "npm run lint",
-    "test": "c8 mocha --timeout 30000 packages/*/test{,/*}.js",
-    "test-windows": "c8 mocha --timeout 60000 packages/*/test{,/*}.js",
+    "test": "c8 -r lcov mocha --timeout 30000 packages/*/test{,/*}.js",
+    "test-windows": "c8 -r lcov mocha --timeout 60000 packages/*/test{,/*}.js"
     "postinstall": "bash scripts/install.sh"
   },
   "version": "1.0.0",
   "devDependencies": {
     "better-than-before": "^1.0.0",
-    "c8": "^7.1.2",
+    "c8": "^7.5.0",
     "chai": "^4.2.0",
     "concat-stream": "^2.0.0",
     "conventional-changelog-core": "^4.2.1",
@@ -60,7 +60,7 @@
     "git-dummy-commit": "^1.2.0",
     "git-tails": "^1.0.0",
     "mkdirp": "^1.0.0",
-    "mocha": "^8.0.0",
+    "mocha": "^8.3.0",
     "pinkie-promise": "^2.0.0",
     "q": "^1.5.1",
     "safe-buffer": "5.2.1",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "fix": "eslint . --fix --cache --cache-location ./node_modules/.cache/ --ignore-path .gitignore",
     "pretest": "npm run lint",
     "test": "c8 -r lcov mocha --timeout 30000 packages/*/test{,/*}.js",
-    "test-windows": "c8 -r lcov mocha --timeout 60000 packages/*/test{,/*}.js"
+    "test-windows": "c8 -r lcov mocha --timeout 60000 packages/*/test{,/*}.js",
     "postinstall": "bash scripts/install.sh"
   },
   "version": "1.0.0",


### PR DESCRIPTION
correct reporting coverage status to codecov

[![Codecov](https://codecov.io/gh/conventional-changelog/conventional-changelog/branch/master/graph/badge.svg)](https://codecov.io/gh/conventional-changelog/conventional-changelog)

c8 has a bug that ignores config file `.nycrc` if no flags are provided during run, this ensures that coverage is always reported,

i reported this issue in c8 bcoe/c8#289

### New report:

https://codecov.io/gh/conventional-changelog/conventional-changelog/commit/754f499cac59047b7b28bd203b692948242f5391
https://github.com/conventional-changelog/conventional-changelog/pull/768/checks?check_run_id=1916061817

![image](https://user-images.githubusercontent.com/625469/108157626-7bb0bf00-70e3-11eb-9407-469975460484.png)

### Old report:

https://codecov.io/gh/conventional-changelog/conventional-changelog/commit/09ae8956e1f9ae12dc9bda8fcb232e7629158e44/
https://github.com/conventional-changelog/conventional-changelog/runs/1906796612
![image](https://user-images.githubusercontent.com/625469/108156391-e280a900-70e0-11eb-868a-c2724104d428.png)

