### PR TITLE
(conventional-recommended-bump) Specify base tag to analyze tags from

### DIFF
--- a/packages/conventional-changelog-cli/cli.js
+++ b/packages/conventional-changelog-cli/cli.js
@@ -50,6 +50,7 @@ const cli = meow(`
       -c, --context             A filepath of a json that is used to define template variables
       -l, --lerna-package       Generate a changelog for a specific lerna package (:pkg-name@1.0.0)
       -t, --tag-prefix          Tag prefix to consider when reading the tags
+      --tag-from                Tag to start reading from when reading the tags
       --commit-path             Generate a changelog scoped to a specific directory
 `, {
   booleanDefault: undefined,
@@ -171,7 +172,9 @@ try {
   process.exit(1)
 }
 
-const gitRawCommitsOpts = _.merge({}, config.gitRawCommitsOpts || {})
+const gitRawCommitsOpts = _.merge({
+  from: flags.tagFrom
+}, config.gitRawCommitsOpts || {})
 if (flags.commitPath) gitRawCommitsOpts.path = flags.commitPath
 
 const changelogStream = conventionalChangelog(options, templateContext, gitRawCommitsOpts, config.parserOpts, config.writerOpts)

--- a/packages/conventional-recommended-bump/README.md
+++ b/packages/conventional-recommended-bump/README.md
@@ -9,21 +9,27 @@ Got the idea from https://github.com/conventional-changelog/conventional-changel
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
 
-- [Install](#install)
-- [Usage](#usage)
-- [API](#api)
-    - [options](#options)
-      - [ignoreReverted](#ignorereverted)
-      - [preset](#preset)
-      - [config](#config)
-      - [whatBump](#whatbump)
-      - [tagPrefix](#tagprefix)
-      - [skipUnstable](#skipunstable)
-      - [lernaPackage](#lernapackage)
-      - [path](#path)
-    - [parserOpts](#parseropts)
-    - [callback](#callback)
-- [License](#license)
+- [conventional-recommended-bump](#conventional-recommended-bump)
+  - [Table of Contents](#table-of-contents)
+  - [Install](#install)
+  - [Usage](#usage)
+  - [API](#api)
+      - [options](#options)
+        - [ignoreReverted](#ignorereverted)
+        - [preset](#preset)
+        - [config](#config)
+        - [whatBump](#whatbump)
+        - [tagPrefix](#tagprefix)
+        - [skipUnstable](#skipunstable)
+        - [lernaPackage](#lernapackage)
+        - [path](#path)
+        - [tagFrom](#tagfrom)
+      - [parserOpts](#parseropts)
+      - [callback](#callback)
+  - [Debugging](#debugging)
+  - [Node Support Policy](#node-support-policy)
+  - [Contributing](#contributing)
+  - [License](#license)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -68,6 +74,7 @@ In the case you don't want to provide `parserOpts`, then `callback` must be prov
 * preset
 * config
 * whatBump
+* tagFrom
 
 ##### ignoreReverted
 
@@ -132,6 +139,14 @@ For instance if your project contained a package named `conventional-changelog`,
 **Type:** `string`
 
 Specify the path to only calculate with git commits related to the path. If you want to calculate recommended bumps of packages in a [Lerna](https://lernajs.io/)-managed repository, `path` should be use along with `lernaPackage` for each of the package.
+
+##### tagFrom
+
+**Type:** `string`
+
+Specify the base tag to use as the base from which to analyze the commits. Can be any tag, not just a semver tag.
+
+If not specified the most recent semver tag will be chosen.
 
 #### parserOpts
 

--- a/packages/conventional-recommended-bump/cli.js
+++ b/packages/conventional-recommended-bump/cli.js
@@ -27,6 +27,7 @@ const cli = meow(`
       -t, --tag-prefix               Tag prefix to consider when reading the tags
       --commit-path                  Recommend a bump scoped to a specific directory
       --skip-unstable                If given, unstable tags will be skipped, e.g., x.x.x-alpha.1, x.x.x-rc.2
+      --tag-from                     Tag to start reading from when reading the tags
 `, {
   flags: {
     preset: {
@@ -81,6 +82,11 @@ if (preset) {
 } else if (config) {
   options.config = require(path.resolve(process.cwd(), config))
   delete flags.config
+}
+
+if (flags.tagFrom) {
+  options.tagFrom = flags.tagFrom
+  delete flags.tagFrom
 }
 
 if (flags.verbose) {

--- a/packages/conventional-recommended-bump/index.js
+++ b/packages/conventional-recommended-bump/index.js
@@ -70,11 +70,15 @@ function conventionalRecommendedBump (optionsArgument, parserOptsArgument, cbArg
         return cb(err)
       }
 
-      gitRawCommits({
+      const commitStream = gitRawCommits({
         format: '%B%n-hash-%n%H',
-        from: tags[0] || '',
+        from: options.tagFrom || tags[0] || '',
         path: options.path
       })
+
+      commitStream.on('error', cb)
+
+      commitStream
         .pipe(conventionalCommitsParser(parserOpts))
         .pipe(concat(data => {
           const commits = options.ignoreReverted ? conventionalCommitsFilter(data) : data

--- a/packages/conventional-recommended-bump/test/index.spec.js
+++ b/packages/conventional-recommended-bump/test/index.spec.js
@@ -42,6 +42,11 @@ betterThanBefore.setups([
   () => { // 7
     shell.exec('git tag my-package@1.0.0')
     gitDummyCommit(['feat: this should have been working'])
+  },
+  () => { // 8
+    gitDummyCommit(['feat: should not be taken into account - at not-a-version', 'BREAKING CHANGE: I broke the API'])
+    shell.exec('git tag not-a-version')
+    gitDummyCommit(['feat: this should have been working - post not-a-version'])
   }
 ])
 
@@ -331,6 +336,32 @@ describe('conventional-recommended-bump API', () => {
         whatBump: commits => {
           assert.strictEqual(commits.length, 1)
           assert.strictEqual(commits[0].type, 'feat')
+          done()
+        }
+      }, () => {})
+    })
+  })
+
+  describe('optional tagFrom', () => {
+    it('should return an error when tagFrom option references a non-existent tag', done => {
+      preparing(8)
+
+      conventionalRecommendedBump({
+        tagFrom: 'not-an-existing-tag'
+      }, {}, err => {
+        assert.ok(err)
+        done()
+      })
+    })
+
+    it('should recommend \'minor\' version bump when tagFrom option is set to an existing arbitrary tag', done => {
+      preparing(8)
+
+      conventionalRecommendedBump({
+        tagFrom: 'not-a-version',
+        whatBump: commits => {
+          assert.strictEqual(commits[0].type, 'feat')
+          assert.strictEqual(commits.length, 1)
           done()
         }
       }, () => {})


### PR DESCRIPTION
This feature allows the user to specify the base tag from which to scan for version tags, allowing for tooling like standard-version to pull the previous version from some other location than the most recent tag. As simple icing I added the flag to the both the recommended-bump and changelog CLIs so that users of those tools can enjoy this feature there as well.

I chose not to attempt a "to" flag as that would make this much more complex and is not needed for my use case just now.

Also [fixes a bug in conventional-recommended-bump](https://github.com/conventional-changelog/conventional-changelog/commit/6644339e81c39a73df414e57a7c5d51e72e6cbe4) that would cause a callback to not be called if the `gitRawCommits` function emitted an error instead of returning a stream.

AFAICT this could be a fix for both #194 and #612, but this was mainly to solve a problem in standard-version.  I'll link the PR to that repo once I've got it created.

In my use-case I don't store the changelog in the committed code as it has problems when dealing with branches.  I don't see any generic way to solve that problem, so instead I use my own repo-specific algorithm to determine which tag in the history is the "correct" parent tag depending on several bits of repo-specific context and then need to generate the changelog and recommended bump based off that tag, and not before.