### PR TITLE
fix(conventionalcommits): always use h2

### DIFF
--- a/packages/conventional-changelog-conventionalcommits/templates/header.hbs
+++ b/packages/conventional-changelog-conventionalcommits/templates/header.hbs
@@ -1,13 +1,9 @@
-{{#if isPatch~}}
-  ###
-{{~else~}}
-  ##
-{{~/if}} {{#if @root.linkCompare~}}
-  [{{version}}]({{compareUrlFormat}})
-{{~else}}
-  {{~version}}
-{{~/if}}
-{{~#if title}} "{{title}}"
-{{~/if}}
-{{~#if date}} ({{date}})
-{{/if}}
+## {{#if @root.linkCompare~}}
+    [{{version}}]({{compareUrlFormat}})
+  {{~else}}
+    {{~version}}
+  {{~/if}}
+  {{~#if title}} "{{title}}"
+  {{~/if}}
+  {{~#if date}} ({{date}})
+  {{/if}}


### PR DESCRIPTION
Now H2 is used all the time whether it is a patch or not.
Before an H3 was used when it was a patch, but this is bad, because what is supposed to be the title is of the same level as its content (the changelogs sections), so the title (when it was a patch) was hardly differentiable from its content (same title level: H3).
Moreover it could avoid bugging tools that are based on the title level.