### PR TITLE
feat: conventional-recommended-bump accepts `options.cwd`

### DIFF
--- a/packages/conventional-recommended-bump/index.js
+++ b/packages/conventional-recommended-bump/index.js
@@ -64,7 +64,8 @@ function conventionalRecommendedBump (optionsArgument, parserOptsArgument, cbArg
       lernaTags: !!options.lernaPackage,
       package: options.lernaPackage,
       tagPrefix: options.tagPrefix,
-      skipUnstable: options.skipUnstable
+      skipUnstable: options.skipUnstable,
+      cwd: options.cwd
     }, (err, tags) => {
       if (err) {
         return cb(err)
@@ -74,6 +75,8 @@ function conventionalRecommendedBump (optionsArgument, parserOptsArgument, cbArg
         format: '%B%n-hash-%n%H',
         from: tags[0] || '',
         path: options.path
+      }, {
+        cwd: options.cwd
       })
         .pipe(conventionalCommitsParser(parserOpts))
         .pipe(concat(data => {


### PR DESCRIPTION
Fixes #792 