### PR TITLE
feat(conventionalcommits): include Release-As commits in CHANGELOG

### DIFF
--- a/packages/conventional-changelog-conventionalcommits/test/test.js
+++ b/packages/conventional-changelog-conventionalcommits/test/test.js
@@ -80,6 +80,9 @@ betterThanBefore.setups([
   function () {
     gitDummyCommit(['Revert \\"feat: default revert format\\"', 'This reverts commit 1234.'])
     gitDummyCommit(['revert: feat: custom revert format', 'This reverts commit 5678.'])
+  },
+  function () {
+    gitDummyCommit(['chore: release at different version\nRelease-As: v3.0.2'])
   }
 ])
 
@@ -590,6 +593,21 @@ describe('conventionalcommits.org preset', function () {
         chunk = chunk.toString()
         expect(chunk).to.match(/custom revert format/)
         expect(chunk).to.match(/default revert format/)
+        done()
+      }))
+  })
+  it('should include commits with "Release-As:" footer in CHANGELOG', function (done) {
+    preparing(11)
+
+    conventionalChangelogCore({
+      config: preset
+    })
+      .on('error', function (err) {
+        done(err)
+      })
+      .pipe(through(function (chunk) {
+        chunk = chunk.toString()
+        expect(chunk).to.match(/release at different version/)
         done()
       }))
   })

--- a/packages/conventional-changelog-conventionalcommits/test/test.js
+++ b/packages/conventional-changelog-conventionalcommits/test/test.js
@@ -82,7 +82,10 @@ betterThanBefore.setups([
     gitDummyCommit(['revert: feat: custom revert format', 'This reverts commit 5678.'])
   },
   function () {
-    gitDummyCommit(['chore: release at different version\nRelease-As: v3.0.2'])
+    gitDummyCommit([
+      'chore: release at different version',
+      'Release-As: v3.0.2'
+    ])
   }
 ])
 

--- a/packages/conventional-changelog-conventionalcommits/writer-opts.js
+++ b/packages/conventional-changelog-conventionalcommits/writer-opts.js
@@ -5,6 +5,7 @@ const compareFunc = require('compare-func')
 const Q = require('q')
 const readFile = Q.denodeify(require('fs').readFile)
 const resolve = require('path').resolve
+const releaseAsRe = /release-as:\s*\w*@?([0-9]+\.[0-9]+\.[0-9a-z]+(-[0-9a-z.]+)?)\s*/i
 
 /**
  * Handlebar partials for various property substitutions based on commit context.
@@ -80,6 +81,13 @@ function getWriterOpts (config) {
       // for the special case, test(system)!: hello world, where there is
       // a '!' but no 'BREAKING CHANGE' in body:
       addBangNotes(commit)
+
+      // Add an entry in the CHANGELOG if special Release-As footer
+      // is used:
+      if ((commit.footer && releaseAsRe.test(commit.footer)) ||
+          (commit.body && releaseAsRe.test(commit.body))) {
+        discard = false
+      }
 
       commit.notes.forEach(note => {
         note.title = 'BREAKING CHANGES'


### PR DESCRIPTION
If the special `Release-As` footer is used to correct a bad commit, e.g., merging an unintended breaking change, it should be included in CHANGELOG.