### PR TITLE
fix(deps): patch the handlebars package

### DIFF
--- a/packages/conventional-changelog-writer/package.json
+++ b/packages/conventional-changelog-writer/package.json
@@ -38,7 +38,7 @@
   "dependencies": {
     "conventional-commits-filter": "^2.0.7",
     "dateformat": "^3.0.0",
-    "handlebars": "^4.7.6",
+    "handlebars": "^4.7.7",
     "json-stringify-safe": "^5.0.1",
     "lodash": "^4.17.15",
     "meow": "^8.0.0",


### PR DESCRIPTION
CVE-2021-23369 is affected by use the handlebars package

Ref: https://github.com/advisories/GHSA-f2jv-r9rf-7988