### PR TITLE
fix: Syntax for prefix and id in JSON config

### DIFF
--- a/packages/conventional-changelog-conventionalcommits/README.md
+++ b/packages/conventional-changelog-conventionalcommits/README.md
@@ -31,7 +31,7 @@ or json config like that:
         "preset": {
             "name": "conventionalchangelog",
             "issuePrefixes": ["TEST-"],
-            "issueUrlFormat": "myBugTracker.com/{prefix}{id}"
+            "issueUrlFormat": "myBugTracker.com/{{prefix}}{{id}}"
         }
     }
 }


### PR DESCRIPTION
At least for the JSON config the prefix and id must use double
curl braces to work {{prefix}} and {{id}}.

Signed-off-by: Thanh Ha <zxiiro@gmail.com>