### PR TITLE
Update get-pkg-repo module

### DIFF
--- a/packages/conventional-changelog-core/package.json
+++ b/packages/conventional-changelog-core/package.json
@@ -30,7 +30,7 @@
     "conventional-changelog-writer": "^5.0.0",
     "conventional-commits-parser": "^3.2.0",
     "dateformat": "^3.0.0",
-    "get-pkg-repo": "^1.0.0",
+    "get-pkg-repo": "^4.0.0",
     "git-raw-commits": "^2.0.8",
     "git-remote-origin-url": "^2.0.0",
     "git-semver-tags": "^4.1.1",


### PR DESCRIPTION
Update get-pkg-repo module to avoid ddos vulnerability in downstream dependency trim-newlines V1.0.0.

Reference: https://snyk.io/vuln/SNYK-JS-TRIMNEWLINES-1298042

Dependency tree when running `yarn why trim-newlines`:

`=> Found "get-pkg-repo#trim-newlines@1.0.0"`
`info Reasons this module exists`
`- "standard-version#conventional-changelog#conventional-changelog-core#get-pkg-repo#meow" depends on it`
`- Hoisted from "standard-version#conventional-changelog#conventional-changelog-core#get-pkg-repo#meow#trim-newlines"`

This change fixes the vulnerability described above. 
