### PR TITLE
fix: Don't allow word-characters in "issue-separator"

### DIFF
--- a/packages/conventional-commits-parser/lib/regex.js
+++ b/packages/conventional-commits-parser/lib/regex.js
@@ -33,7 +33,7 @@ function getReferencePartsRegex (issuePrefixes, issuePrefixesCaseSensitive) {
   }
 
   const flags = issuePrefixesCaseSensitive ? 'g' : 'gi'
-  return new RegExp('(?:.*?)??\\s*([\\w-\\.\\/]*?)??(' + join(issuePrefixes, '|') + ')([\\w-]*\\d+)', flags)
+  return new RegExp('(?:.*?)??\\s*([\\w-\\.\\/]*?)??(' + join(issuePrefixes, '|') + ')([-]*\\d+)', flags)
 }
 
 function getReferencesRegex (referenceActions) {


### PR DESCRIPTION
With the current implementation of the RegExp on master, it seems to NOT be possible to use a pattern as issuePrefix, without messing up the other matchingGroups. My simple usecase/problem/example is jira-issues, which should be a common scenario.

So jira is allowing up to 10 characters as project-key (the part before the issue-number), for example:

valid ->`JIRA-123`
valid -> `JIRAJIRA-123`
not valid -> `JIRAJIRAJIRA-123`

In our company we want to rollout conventional-changelogs in all projects, and for billing-purposes our project-key change or extend from time to time. So instead of adding/editing our issuePrefixes all the time, I wanted to simply use a RegExp as issuePrefix.  But whatever I tried, I ended up messing up the matchingGroups.

In [parser.js:61](https://github.com/conventional-changelog/conventional-changelog/blob/master/packages/conventional-commits-parser/lib/parser.js#L61) I can see that the third matchingGroup should be issue-number, but the related part in the RegExp is allowing word-characters in the "separator", when I remove this, the matches seem to me *way* more correct.

So is there something I oversee? Or is this allowed word-characters really a bug (that this PR would fix)?

## How to reproduce?

For reproduction of my problem one could use this COMMITMSG:
```
fix(config): Some informative commit headline

Refs: JIRA-123 JIRAJIRA-124 JIRAJIRAJIRA-125
```

and this regex as issuePrefix:
```
\\s[\\w\\d]{1,10}-
```