### PR TITLE
Update get-pkg-repo to ^4.0.0

### DIFF
--- a/packages/conventional-changelog-core/lib/merge-config.js
+++ b/packages/conventional-changelog-core/lib/merge-config.js
@@ -180,7 +180,7 @@ function mergeConfig (options, context, gitRawCommitsOpts, parserOpts, writerOpt
           }
           context.owner = context.owner || repo.user || ''
           context.repository = context.repository || repo.project
-          context.repoUrl = browse
+          context.repoUrl = /undefined/i.exec(browse) ? context.host : browse
         }
 
         context.packageData = pkg

--- a/packages/conventional-changelog-core/package.json
+++ b/packages/conventional-changelog-core/package.json
@@ -30,7 +30,7 @@
     "conventional-changelog-writer": "^5.0.0",
     "conventional-commits-parser": "^3.2.0",
     "dateformat": "^3.0.0",
-    "get-pkg-repo": "^1.0.0",
+    "get-pkg-repo": "^4.0.0",
     "git-raw-commits": "^2.0.8",
     "git-remote-origin-url": "^2.0.0",
     "git-semver-tags": "^4.1.1",


### PR DESCRIPTION
Update `get-pkg-repo` to fix [this](https://github.com/advisories/GHSA-7p7h-4mm5-852v).

Also updated a the return of the `repoUrl` to fix tests.

related: https://github.com/conventional-changelog/conventional-changelog/pull/809