### PR TITLE
chore: set `repository.directory` to all sub `package.json` files

### DIFF
--- a/packages/conventional-changelog-angular/package.json
+++ b/packages/conventional-changelog-angular/package.json
@@ -8,7 +8,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/conventional-changelog/conventional-changelog.git"
+    "url": "https://github.com/conventional-changelog/conventional-changelog.git",
+    "directory": "packages/conventional-changelog-angular"
   },
   "keywords": [
     "conventional-changelog",

--- a/packages/conventional-changelog-atom/package.json
+++ b/packages/conventional-changelog-atom/package.json
@@ -8,7 +8,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/conventional-changelog/conventional-changelog.git"
+    "url": "https://github.com/conventional-changelog/conventional-changelog.git",
+    "directory": "packages/conventional-changelog-atom"
   },
   "keywords": [
     "conventional-changelog",

--- a/packages/conventional-changelog-cli/package.json
+++ b/packages/conventional-changelog-cli/package.json
@@ -8,7 +8,8 @@
   "homepage": "https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-cli#readme",
   "repository": {
     "type": "git",
-    "url": "https://github.com/conventional-changelog/conventional-changelog.git"
+    "url": "https://github.com/conventional-changelog/conventional-changelog.git",
+    "directory": "packages/conventional-changelog-cli/test/fixtures"
   },
   "author": {
     "name": "Steve Mao",

--- a/packages/conventional-changelog-codemirror/package.json
+++ b/packages/conventional-changelog-codemirror/package.json
@@ -8,7 +8,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/conventional-changelog/conventional-changelog.git"
+    "url": "https://github.com/conventional-changelog/conventional-changelog.git",
+    "directory": "packages/conventional-changelog-codemirror"
   },
   "keywords": [
     "conventional-changelog",

--- a/packages/conventional-changelog-conventionalcommits/package.json
+++ b/packages/conventional-changelog-conventionalcommits/package.json
@@ -8,7 +8,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/conventional-changelog/conventional-changelog.git"
+    "url": "https://github.com/conventional-changelog/conventional-changelog.git",
+    "directory": "packages/conventional-changelog-conventionalcommits"
   },
   "keywords": [
     "conventional-changelog",

--- a/packages/conventional-changelog-core/package.json
+++ b/packages/conventional-changelog-core/package.json
@@ -4,7 +4,8 @@
   "description": "conventional-changelog core",
   "repository": {
     "type": "git",
-    "url": "https://github.com/conventional-changelog/conventional-changelog.git"
+    "url": "https://github.com/conventional-changelog/conventional-changelog.git",
+    "directory": "packages/conventional-changelog-core/test/fixtures"
   },
   "keywords": [
     "conventional-changelog",

--- a/packages/conventional-changelog-ember/package.json
+++ b/packages/conventional-changelog-ember/package.json
@@ -8,7 +8,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/conventional-changelog/conventional-changelog.git"
+    "url": "https://github.com/conventional-changelog/conventional-changelog.git",
+    "directory": "packages/conventional-changelog-ember"
   },
   "keywords": [
     "conventional-changelog",

--- a/packages/conventional-changelog-eslint/package.json
+++ b/packages/conventional-changelog-eslint/package.json
@@ -8,7 +8,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/conventional-changelog/conventional-changelog.git"
+    "url": "https://github.com/conventional-changelog/conventional-changelog.git",
+    "directory": "packages/conventional-changelog-eslint"
   },
   "keywords": [
     "conventional-changelog",

--- a/packages/conventional-changelog-express/package.json
+++ b/packages/conventional-changelog-express/package.json
@@ -8,7 +8,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/conventional-changelog/conventional-changelog.git"
+    "url": "https://github.com/conventional-changelog/conventional-changelog.git",
+    "directory": "packages/conventional-changelog-express"
   },
   "keywords": [
     "conventional-changelog",

--- a/packages/conventional-changelog-jquery/package.json
+++ b/packages/conventional-changelog-jquery/package.json
@@ -8,7 +8,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/conventional-changelog/conventional-changelog.git"
+    "url": "https://github.com/conventional-changelog/conventional-changelog.git",
+    "directory": "packages/conventional-changelog-jquery"
   },
   "keywords": [
     "conventional-changelog",

--- a/packages/conventional-changelog-jshint/package.json
+++ b/packages/conventional-changelog-jshint/package.json
@@ -8,7 +8,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/conventional-changelog/conventional-changelog.git"
+    "url": "https://github.com/conventional-changelog/conventional-changelog.git",
+    "directory": "packages/conventional-changelog-jshint"
   },
   "keywords": [
     "conventional-changelog",

--- a/packages/conventional-changelog-preset-loader/package.json
+++ b/packages/conventional-changelog-preset-loader/package.json
@@ -4,7 +4,8 @@
   "description": "Configuration preset loader for `conventional-changelog`.",
   "repository": {
     "type": "git",
-    "url": "https://github.com/conventional-changelog/conventional-changelog.git"
+    "url": "https://github.com/conventional-changelog/conventional-changelog.git",
+    "directory": "packages/conventional-changelog-preset-loader"
   },
   "keywords": [
     "conventional-changelog",

--- a/packages/conventional-changelog-writer/package.json
+++ b/packages/conventional-changelog-writer/package.json
@@ -13,7 +13,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/conventional-changelog/conventional-changelog.git"
+    "url": "https://github.com/conventional-changelog/conventional-changelog.git",
+    "directory": "packages/conventional-changelog-writer"
   },
   "license": "MIT",
   "engines": {

--- a/packages/conventional-changelog/package.json
+++ b/packages/conventional-changelog/package.json
@@ -4,7 +4,8 @@
   "description": "Generate a changelog from git metadata",
   "repository": {
     "type": "git",
-    "url": "https://github.com/conventional-changelog/conventional-changelog.git"
+    "url": "https://github.com/conventional-changelog/conventional-changelog.git",
+    "directory": "packages/conventional-changelog"
   },
   "keywords": [
     "conventional-changelog",

--- a/packages/conventional-commits-filter/package.json
+++ b/packages/conventional-commits-filter/package.json
@@ -8,7 +8,8 @@
   "homepage": "https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-commits-filter#readme",
   "repository": {
     "type": "git",
-    "url": "https://github.com/conventional-changelog/conventional-changelog.git"
+    "url": "https://github.com/conventional-changelog/conventional-changelog.git",
+    "directory": "packages/conventional-commits-filter"
   },
   "author": {
     "name": "Steve Mao",

--- a/packages/conventional-commits-parser/package.json
+++ b/packages/conventional-commits-parser/package.json
@@ -13,7 +13,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/conventional-changelog/conventional-changelog.git"
+    "url": "https://github.com/conventional-changelog/conventional-changelog.git",
+    "directory": "packages/conventional-commits-parser"
   },
   "license": "MIT",
   "engines": {
@@ -33,8 +34,8 @@
     "logs"
   ],
   "dependencies": {
-    "JSONStream": "^1.0.4",
     "is-text-path": "^1.0.1",
+    "JSONStream": "^1.0.4",
     "lodash": "^4.17.15",
     "meow": "^8.0.0",
     "split2": "^3.0.0",

--- a/packages/conventional-recommended-bump/package.json
+++ b/packages/conventional-recommended-bump/package.json
@@ -13,7 +13,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/conventional-changelog/conventional-changelog.git"
+    "url": "https://github.com/conventional-changelog/conventional-changelog.git",
+    "directory": "packages/conventional-recommended-bump"
   },
   "license": "MIT",
   "engines": {

--- a/packages/git-raw-commits/package.json
+++ b/packages/git-raw-commits/package.json
@@ -13,7 +13,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/conventional-changelog/conventional-changelog.git"
+    "url": "https://github.com/conventional-changelog/conventional-changelog.git",
+    "directory": "packages/git-raw-commits"
   },
   "license": "MIT",
   "engines": {

--- a/packages/git-semver-tags/package.json
+++ b/packages/git-semver-tags/package.json
@@ -13,7 +13,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/conventional-changelog/conventional-changelog.git"
+    "url": "https://github.com/conventional-changelog/conventional-changelog.git",
+    "directory": "packages/git-semver-tags"
   },
   "license": "MIT",
   "engines": {

--- a/packages/gulp-conventional-changelog/package.json
+++ b/packages/gulp-conventional-changelog/package.json
@@ -9,7 +9,8 @@
   "homepage": "https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/gulp-conventional-changelog#readme",
   "repository": {
     "type": "git",
-    "url": "https://github.com/conventional-changelog/conventional-changelog.git"
+    "url": "https://github.com/conventional-changelog/conventional-changelog.git",
+    "directory": "packages/gulp-conventional-changelog"
   },
   "author": {
     "name": "Steve Mao",

--- a/packages/standard-changelog/package.json
+++ b/packages/standard-changelog/package.json
@@ -8,7 +8,8 @@
   "homepage": "https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/standard-changelog#readme",
   "repository": {
     "type": "git",
-    "url": "https://github.com/conventional-changelog/conventional-changelog.git"
+    "url": "https://github.com/conventional-changelog/conventional-changelog.git",
+    "directory": "packages/standard-changelog/test/fixtures"
   },
   "keywords": [
     "conventional-changelog",


### PR DESCRIPTION
Hi there,

I've created this PR to make npm commands such as [`npm repo`](https://docs.npmjs.com/cli/v7/commands/npm-repo) more useful.
For example, all packages in the Babel repository have that field (babel/babel#11625).

This change sets the `repository.directory` field to all `package.json` files except for `package.json` at the repository root.

See also <https://docs.npmjs.com/cli/v7/configuring-npm/package-json#repository>

### How to create this change

I've created the following Bash script for this PR:

```bash
#!/usr/bin/env bash
set -eu -o pipefail

files=$(git ls-files | grep package.json)
for file in $files; do
  echo "Setting repository.directory to ${file} ..."
  dir=$(dirname $file)
  if [[ $dir != "." ]]; then
    (cd "$dir" && npm pkg set repository.directory="$dir")
  fi
done
```

In addition, I've used the command [`npm-package-json-lint`](https://npmpackagejsonlint.org/) to verify this change as below:

`.npmpackagejsonlintrc.json`:

```json
{
  "rules": {
    "require-repository-directory": "error"
  }
}
```

Run:

```console
$ npx npm-package-json-lint .

./package.json
✖ require-repository-directory - node: repository - repository object missing directory property
1 error
0 warnings

Totals
1 error
0 warnings
0 files ignored
```

Note: `package.json` at the top should not have `directory`, so the error above is expected.

---

I would appreciate it if you could check this PR.
If this PR is undesirable, please feel free to close it. Thank you. 😃 