### PR TITLE
chore(deps): use @rubendew/get-pkg-repo

### DIFF
--- a/packages/conventional-changelog-core/package.json
+++ b/packages/conventional-changelog-core/package.json
@@ -30,7 +30,7 @@
     "conventional-changelog-writer": "^5.0.0",
     "conventional-commits-parser": "^3.2.0",
     "dateformat": "^3.0.0",
-    "get-pkg-repo": "^4.0.0",
+    "@rubendew/get-pkg-repo": "^4.2.0",
     "git-raw-commits": "^2.0.8",
     "git-remote-origin-url": "^2.0.0",
     "git-semver-tags": "^4.1.1",


### PR DESCRIPTION
Several people have been waiting for an update of `get-pkg-repo` since June. This [update](https://github.com/conventional-changelog/get-pkg-repo/pull/62) fixes a [security vulnerability](https://github.com/conventional-changelog/get-pkg-repo/issues/60), but it hangs on a [permissions issue](https://github.com/conventional-changelog/get-pkg-repo/pull/66) when publishing to npm. 
So, it may not be the most elegant solution and may not be desirable, but I would like to offer the package `get-pkg-repo` under my own npm account.
https://www.npmjs.com/package/@rubendew/get-pkg-repo

https://github.com/conventional-changelog/standard-version/issues/772