### PR TITLE
chore: add repository directory for all packages.json

### DIFF
--- a/packages/conventional-changelog-angular/package.json
+++ b/packages/conventional-changelog-angular/package.json
@@ -8,7 +8,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/conventional-changelog/conventional-changelog.git"
+    "url": "https://github.com/conventional-changelog/conventional-changelog",
+    "directory": "packages/conventional-changelog-angular"
   },
   "keywords": [
     "conventional-changelog",

--- a/packages/conventional-changelog-atom/package.json
+++ b/packages/conventional-changelog-atom/package.json
@@ -8,7 +8,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/conventional-changelog/conventional-changelog.git"
+    "url": "https://github.com/conventional-changelog/conventional-changelog",
+    "directory": "packages/conventional-changelog-atom"
   },
   "keywords": [
     "conventional-changelog",

--- a/packages/conventional-changelog-cli/package.json
+++ b/packages/conventional-changelog-cli/package.json
@@ -8,7 +8,8 @@
   "homepage": "https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-cli#readme",
   "repository": {
     "type": "git",
-    "url": "https://github.com/conventional-changelog/conventional-changelog.git"
+    "url": "https://github.com/conventional-changelog/conventional-changelog",
+    "directory": "packages/conventional-changelog-cli"
   },
   "author": {
     "name": "Steve Mao",

--- a/packages/conventional-changelog-codemirror/package.json
+++ b/packages/conventional-changelog-codemirror/package.json
@@ -8,7 +8,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/conventional-changelog/conventional-changelog.git"
+    "url": "https://github.com/conventional-changelog/conventional-changelog",
+    "directory": "packages/conventional-changelog-codemirror"
   },
   "keywords": [
     "conventional-changelog",

--- a/packages/conventional-changelog-conventionalcommits/package.json
+++ b/packages/conventional-changelog-conventionalcommits/package.json
@@ -8,7 +8,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/conventional-changelog/conventional-changelog.git"
+    "url": "https://github.com/conventional-changelog/conventional-changelog",
+    "directory": "packages/conventional-changelog-conventionalcommits"
   },
   "keywords": [
     "conventional-changelog",

--- a/packages/conventional-changelog-core/package.json
+++ b/packages/conventional-changelog-core/package.json
@@ -4,7 +4,8 @@
   "description": "conventional-changelog core",
   "repository": {
     "type": "git",
-    "url": "https://github.com/conventional-changelog/conventional-changelog.git"
+    "url": "https://github.com/conventional-changelog/conventional-changelog",
+    "directory": "packages/conventional-changelog-core"
   },
   "keywords": [
     "conventional-changelog",

--- a/packages/conventional-changelog-ember/package.json
+++ b/packages/conventional-changelog-ember/package.json
@@ -8,7 +8,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/conventional-changelog/conventional-changelog.git"
+    "url": "https://github.com/conventional-changelog/conventional-changelog",
+    "directory": "packages/conventional-changelog-ember"
   },
   "keywords": [
     "conventional-changelog",

--- a/packages/conventional-changelog-eslint/package.json
+++ b/packages/conventional-changelog-eslint/package.json
@@ -8,7 +8,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/conventional-changelog/conventional-changelog.git"
+    "url": "https://github.com/conventional-changelog/conventional-changelog",
+    "directory": "packages/conventional-changelog-eslint"
   },
   "keywords": [
     "conventional-changelog",

--- a/packages/conventional-changelog-express/package.json
+++ b/packages/conventional-changelog-express/package.json
@@ -8,7 +8,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/conventional-changelog/conventional-changelog.git"
+    "url": "https://github.com/conventional-changelog/conventional-changelog",
+    "directory": "packages/conventional-changelog-express"
   },
   "keywords": [
     "conventional-changelog",

--- a/packages/conventional-changelog-jquery/package.json
+++ b/packages/conventional-changelog-jquery/package.json
@@ -8,7 +8,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/conventional-changelog/conventional-changelog.git"
+    "url": "https://github.com/conventional-changelog/conventional-changelog",
+    "directory": "packages/conventional-changelog-jquery"
   },
   "keywords": [
     "conventional-changelog",

--- a/packages/conventional-changelog-jshint/package.json
+++ b/packages/conventional-changelog-jshint/package.json
@@ -8,7 +8,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/conventional-changelog/conventional-changelog.git"
+    "url": "https://github.com/conventional-changelog/conventional-changelog",
+    "directory": "packages/conventional-changelog-jshint"
   },
   "keywords": [
     "conventional-changelog",

--- a/packages/conventional-changelog-preset-loader/package.json
+++ b/packages/conventional-changelog-preset-loader/package.json
@@ -4,7 +4,8 @@
   "description": "Configuration preset loader for `conventional-changelog`.",
   "repository": {
     "type": "git",
-    "url": "https://github.com/conventional-changelog/conventional-changelog.git"
+    "url": "https://github.com/conventional-changelog/conventional-changelog",
+    "directory": "packages/conventional-changelog-preset-loader"
   },
   "keywords": [
     "conventional-changelog",

--- a/packages/conventional-changelog-writer/package.json
+++ b/packages/conventional-changelog-writer/package.json
@@ -13,7 +13,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/conventional-changelog/conventional-changelog.git"
+    "url": "https://github.com/conventional-changelog/conventional-changelog",
+    "directory": "packages/conventional-changelog-writer"
   },
   "license": "MIT",
   "engines": {

--- a/packages/conventional-changelog/package.json
+++ b/packages/conventional-changelog/package.json
@@ -4,7 +4,8 @@
   "description": "Generate a changelog from git metadata",
   "repository": {
     "type": "git",
-    "url": "https://github.com/conventional-changelog/conventional-changelog.git"
+    "url": "https://github.com/conventional-changelog/conventional-changelog",
+    "directory": "packages/conventional-changelog"
   },
   "keywords": [
     "conventional-changelog",

--- a/packages/conventional-commits-filter/package.json
+++ b/packages/conventional-commits-filter/package.json
@@ -8,7 +8,8 @@
   "homepage": "https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-commits-filter#readme",
   "repository": {
     "type": "git",
-    "url": "https://github.com/conventional-changelog/conventional-changelog.git"
+    "url": "https://github.com/conventional-changelog/conventional-changelog",
+    "directory": "packages/conventional-commits-filter"
   },
   "author": {
     "name": "Steve Mao",

--- a/packages/conventional-commits-parser/package.json
+++ b/packages/conventional-commits-parser/package.json
@@ -13,7 +13,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/conventional-changelog/conventional-changelog.git"
+    "url": "https://github.com/conventional-changelog/conventional-changelog",
+    "directory": "packages/conventional-commits-parser"
   },
   "license": "MIT",
   "engines": {

--- a/packages/conventional-recommended-bump/package.json
+++ b/packages/conventional-recommended-bump/package.json
@@ -13,7 +13,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/conventional-changelog/conventional-changelog.git"
+    "url": "https://github.com/conventional-changelog/conventional-changelog",
+    "directory": "packages/conventional-recommended-bump"
   },
   "license": "MIT",
   "engines": {

--- a/packages/git-raw-commits/package.json
+++ b/packages/git-raw-commits/package.json
@@ -13,7 +13,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/conventional-changelog/conventional-changelog.git"
+    "url": "https://github.com/conventional-changelog/conventional-changelog",
+    "directory": "packages/git-raw-commits"
   },
   "license": "MIT",
   "engines": {

--- a/packages/git-semver-tags/package.json
+++ b/packages/git-semver-tags/package.json
@@ -13,7 +13,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/conventional-changelog/conventional-changelog.git"
+    "url": "https://github.com/conventional-changelog/conventional-changelog",
+    "directory": "packages/git-semver-tags"
   },
   "license": "MIT",
   "engines": {

--- a/packages/gulp-conventional-changelog/package.json
+++ b/packages/gulp-conventional-changelog/package.json
@@ -9,7 +9,8 @@
   "homepage": "https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/gulp-conventional-changelog#readme",
   "repository": {
     "type": "git",
-    "url": "https://github.com/conventional-changelog/conventional-changelog.git"
+    "url": "https://github.com/conventional-changelog/conventional-changelog",
+    "directory": "packages/gulp-conventional-changelog"
   },
   "author": {
     "name": "Steve Mao",

--- a/packages/standard-changelog/package.json
+++ b/packages/standard-changelog/package.json
@@ -8,7 +8,8 @@
   "homepage": "https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/standard-changelog#readme",
   "repository": {
     "type": "git",
-    "url": "https://github.com/conventional-changelog/conventional-changelog.git"
+    "url": "https://github.com/conventional-changelog/conventional-changelog",
+    "directory": "packages/standard-changelog"
   },
   "keywords": [
     "conventional-changelog",


### PR DESCRIPTION
> If the package.json for your package is not in the root directory (for example if it is part of a monorepo), you can specify the directory in which it lives:
> ```json
> "repository": {
>   "type" : "git",
>   "url" : "https://github.com/facebook/react.git",
>   "directory": "packages/react-dom"
> }
> ```
> — https://docs.npmjs.com/cli/v6/configuring-npm/package-json#repository

I use a lot https://njt.vercel.app/ to jump to different packages information,
and with this PR we can know exactly what package in what folder lives

Made the changes with a script to make it easier 🙂

https://gist.github.com/iamandrewluca/5cc85b56a595056f0099d04ed6dd8a79