### PR TITLE
Ensure outputUnreleased resolved correctly given lernaPackage/tagPrefix

### DIFF
--- a/packages/conventional-changelog-core/lib/merge-config.js
+++ b/packages/conventional-changelog-core/lib/merge-config.js
@@ -228,8 +228,17 @@ export default async function mergeConfig (options, context, gitRawCommitsOpts, 
     semverTags = context.gitSemverTags = tagsObj.value
     fromTag = semverTags[options.releaseCount - 1]
     const lastTag = semverTags[0]
+    let compareTagTo = '';
 
-    if (lastTag === context.version || lastTag === 'v' + context.version) {
+    if (options.lernaPackage) {
+      compareTagTo = options.lernaPackage + '@' + context.version
+    } else if (options.tagPrefix) {
+      compareTagTo = options.tagPrefix + context.version
+    } else {
+      compareTagTo = 'v' + context.version
+    }
+
+    if (lastTag === context.version || lastTag === compareTagTo) {
       if (options.outputUnreleased) {
         context.version = 'Unreleased'
       } else {

--- a/packages/conventional-changelog-core/test/index.spec.js
+++ b/packages/conventional-changelog-core/test/index.spec.js
@@ -1,7 +1,7 @@
-import { afterAll, describe, it, expect } from 'vitest'
+import { afterAll, beforeAll, describe, it, expect } from 'vitest'
 import BetterThanBefore from 'better-than-before'
 import path from 'path'
-import { TestTools } from '../../../tools/index.ts'
+import { TestTools } from '../tools/index.ts'
 import conventionalChangelogCore from '../index.js'
 
 const { setups, preparing, tearsWithJoy } = BetterThanBefore()
@@ -119,6 +119,16 @@ setups([
 
 tearsWithJoy(() => {
   testTools?.cleanup()
+})
+
+beforeAll(() => {
+  process.env.GIT_CONFIG_GLOBAL = path.join(
+    import.meta.dirname,
+    'fixtures',
+    '.gitconfig'
+  );
+
+  process.env.GIT_CONFIG_SYSTEM = '/dev/null';
 })
 
 afterAll(() => {
@@ -1211,14 +1221,16 @@ describe('conventional-changelog-core', () => {
           config: (await import('conventional-changelog-angular')).default
         },
         {},
-        { path: './packages/foo' }
+        {},
+        {},
+        { headerPartial: '{{previousTag}}...{{currentTag}}' }
       )) {
         chunk = chunk.toString()
 
         // confirm that context.currentTag behaves differently when
         // tagPrefix is used
-        expect(chunk).toContain('foo@1.0.0...foo@2.0.0')
-      }
+          expect(chunk).toContain('foo@1.0.0...foo@2.0.0')
+        }
     })
   })
 
@@ -1359,7 +1371,9 @@ describe('conventional-changelog-core', () => {
           config: (await import('conventional-changelog-angular')).default
         },
         {},
-        { path: './packages/foo' }
+        { path: './packages/foo' },
+        {},
+        { headerPartial: '{{previousTag}}...{{currentTag}}' }
       )) {
         chunk = chunk.toString()
 


### PR DESCRIPTION
As of `conventional-changelog-core@4.2.4`, [`options.outputUnreleased` is erroneously set to `true` when using a custom tag prefix via `tagPrefix` or `lernaPackage`](https://github.com/conventional-changelog/conventional-changelog/blob/conventional-changelog-core-v4.2.4/packages/conventional-changelog-core/lib/merge-config.js#L200-L211). This happens because [the check that determines `options.outputUnreleased`'s value is hardcoded expecting `"v" + version`](https://github.com/conventional-changelog/conventional-changelog/blob/conventional-changelog-core-v4.2.4/packages/conventional-changelog-core/lib/merge-config.js#L200) with no regard for custom tag prefixes.

The result is extremely odd behavior when generating changelogs for monorepo packages. In [this example](https://github.com/Xunnamius/typescript-utils/blob/all-types%401.0.0/packages/all-types/CHANGELOG.md), it repeats the entire changelog with the repeated entry using an invalid version. In [this example](https://github.com/Xunnamius/typescript-utils/blob/all-types%401.0.3/packages/all-types/CHANGELOG.md), when used alongside [`semantic-release`](https://github.com/semantic-release/semantic-release)—which can append the old changelog to the new—it repeats the second entry in the changelog twice. In [this example](https://github.com/Xunnamius/typescript-utils/blob/f362c8a2ae5a4306fa6c481f30aa76ce2d515a66/packages/all-types/CHANGELOG.md), without using `semantic-release`, it repeats the top changelog entry; the top entry is empty because there are no "unreleased" commits in this example.

This PR fixes this bug.