### PR TITLE
docs(conventionalcommits): fix template examples

### DIFF
--- a/packages/conventional-changelog-conventionalcommits/README.md
+++ b/packages/conventional-changelog-conventionalcommits/README.md
@@ -20,7 +20,7 @@ const config = require('conventional-changelog-conventionalcommits')
 
 module.exports = config({
     "issuePrefixes": ["TEST-"],
-    "issueUrlFormat": "myBugTracker.com/{prefix}{id}"
+    "issueUrlFormat": "https://myBugTracker.com/{{prefix}}{{id}}"
 })
 ```
 
@@ -31,7 +31,7 @@ or json config like that:
         "preset": {
             "name": "conventionalchangelog",
             "issuePrefixes": ["TEST-"],
-            "issueUrlFormat": "myBugTracker.com/{prefix}{id}"
+            "issueUrlFormat": "https://myBugTracker.com/{{prefix}}{{id}}"
         }
     }
 }


### PR DESCRIPTION
Placeholders are denoted with two curly braces.

The examples were helpful for a quick start, but I was wondering why the template was not expanded. Needed to look in the source code to find out why and then it was obvious.