### PR TITLE
fix(conventional-changelog-conventionalcommits)!: use `## <small>` for patch versions

### DIFF
--- a/packages/conventional-changelog-conventionalcommits/templates/header.hbs
+++ b/packages/conventional-changelog-conventionalcommits/templates/header.hbs
@@ -1,8 +1,6 @@
-{{#if isPatch~}}
-  ###
-{{~else~}}
-  ##
-{{~/if}} {{#if @root.linkCompare~}}
+## {{#if isPatch~}}
+<small>
+{{~/if}}{{#if @root.linkCompare~}}
   [{{version}}]({{compareUrlFormat}})
 {{~else}}
   {{~version}}
@@ -10,4 +8,6 @@
 {{~#if title}} "{{title}}"
 {{~/if}}
 {{~#if date}} ({{date}})
+{{~/if}}{{#if isPatch~}}
+  </small>
 {{/if}}


### PR DESCRIPTION
This is a backwards-incompatible change, so I would understand if it needed to be behind a configuration flag or something. I’ll leave it open pending feedback (or merging, of course!).

Closes #867

EDIT:
I got the tests running but they universally fail even on a clean upstream clone inside a Docker container, so I don’t think they’ll be much help here.