### PR TITLE
fix(docs): update list of available presets

### DIFF
--- a/packages/conventional-changelog-cli/cli.js
+++ b/packages/conventional-changelog-cli/cli.js
@@ -25,7 +25,7 @@ const cli = meow(`
       -s, --same-file           Outputting to the infile so you don't need to specify the same file as outfile
 
       -p, --preset              Name of the preset you want to use. Must be one of the following:
-                                angular, atom, codemirror, ember, eslint, express, jquery, jscs or jshint
+                                angular, atom, codemirror, conventionalcommits, ember, eslint, express, jquery or jshint
 
       -k, --pkg                 A filepath of where your package.json is located
                                 Default is the closest package.json from cwd

--- a/packages/conventional-changelog/README.md
+++ b/packages/conventional-changelog/README.md
@@ -42,7 +42,7 @@ See the [conventional-changelog-core](https://github.com/conventional-changelog/
 
 ##### preset
 
-Type: `string` Possible values: `'angular', 'atom', 'codemirror', 'ember', 'eslint', 'express', 'jquery', 'jscs', 'jshint'`
+Type: `string` Possible values: `'angular', 'atom', 'codemirror', 'conventionalcommits', 'ember', 'eslint', 'express', 'jquery', 'jshint'`
 
 It's recommended to use a preset so you don't have to define everything yourself. Presets are names of built-in `config`.
 


### PR DESCRIPTION
As I understand it, there should be "conventionalcommits" and should not be "jscs".

Related:

- https://github.com/conventional-changelog/conventional-changelog/pull/421
- https://github.com/conventional-changelog/conventional-changelog/pull/293