### PR TITLE
fix: allow raw commits to be filtered by path and date range

### DIFF
--- a/packages/git-raw-commits/index.js
+++ b/packages/git-raw-commits/index.js
@@ -28,6 +28,9 @@ function getGitArgs (gitOpts) {
   const gitFromTo = [gitOpts.from, gitOpts.to].filter(Boolean).join('..')
 
   const gitArgs = ['log', gitFormat, gitFromTo]
+    .concat(dargs(gitOpts, {
+      excludes: ['debug', 'from', 'to', 'format', 'path']
+    }))
 
   // allow commits to focus on a single directory
   // this is useful for monorepos.
@@ -35,9 +38,7 @@ function getGitArgs (gitOpts) {
     gitArgs.push('--', gitOpts.path)
   }
 
-  return gitArgs.concat(dargs(gitOpts, {
-    excludes: ['debug', 'from', 'to', 'format', 'path']
-  }))
+  return gitArgs
 }
 
 function gitRawCommits (rawGitOpts, rawExecOpts) {


### PR DESCRIPTION
when i use the following code
```js
gitRawCommits({
  path: './packages/foo',
  since
}).pipe(...)
```

the output is not what I expect. In my opinion [since](https://www.git-scm.com/docs/git-log#Documentation/git-log.txt---sinceltdategt) option does not work

the git-log command:
````bash
git log --format=%B%n------------------------ >8 ------------------------ HEAD -- ./packages/foo --since=2021-12-29T08:48:18.749Z
````

[looks like `-- <path>` should be in the last position](https://www.git-scm.com/docs/git-log#_synopsis)

> `git log [<options>] [<revision range>] [[--] <path>…​]`

So I tried to  put the `-- path` at the end, and it works:

```diff
  const gitArgs = ['log', gitFormat, gitFromTo]
+    .concat(dargs(gitOpts, {
+     excludes: ['debug', 'from', 'to', 'format', 'path']
+    }))

  // allow commits to focus on a single directory
  // this is useful for monorepos.
  if (gitOpts.path) {
    gitArgs.push('--', gitOpts.path)
  }

-  return gitArgs.concat(dargs(gitOpts, {
-    excludes: ['debug', 'from', 'to', 'format', 'path']
-  }))
+  return gitArgs
}
```

```
git version 2.33.0.windows.1
node v16.13.0
npm v8.1.0
git-raw-commits v2.0.10
```