### PR TITLE
conventional-changelog-conventionalcommits: defaultConfig use immutable assign

### DIFF
--- a/packages/conventional-changelog-conventionalcommits/writer-opts.js
+++ b/packages/conventional-changelog-conventionalcommits/writer-opts.js
@@ -175,7 +175,7 @@ function getWriterOpts (config) {
 
 // merge user set configuration with default configuration.
 function defaultConfig (config) {
-  config = config || {}
+  config = Object.assign({}, config)
   config.types = config.types || [
     { type: 'feat', section: 'Features' },
     { type: 'feature', section: 'Features' },


### PR DESCRIPTION
fix the mutable update operation outer config object

more detail: https://github.com/imcuttle/mometa/commit/c430068d4b91779970591ed33d0131cf9388afdf

![image](https://user-images.githubusercontent.com/13509258/150064857-9beeccbf-eaab-4ff6-8ecd-4a73fdedd173.png)
