### PR TITLE
Feature: Implement 2 layer group by for commits

### DIFF
--- a/packages/conventional-changelog-conventionalcommits-grouped/CHANGELOG.md
+++ b/packages/conventional-changelog-conventionalcommits-grouped/CHANGELOG.md
@@ -1,0 +1,4 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.

--- a/packages/conventional-changelog-conventionalcommits-grouped/LICENSE.md
+++ b/packages/conventional-changelog-conventionalcommits-grouped/LICENSE.md
@@ -1,0 +1,15 @@
+### ISC License
+
+Copyright © [conventional-changelog team](https://github.com/conventional-changelog)
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND
+FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+PERFORMANCE OF THIS SOFTWARE. 

--- a/packages/conventional-changelog-conventionalcommits-grouped/README.md
+++ b/packages/conventional-changelog-conventionalcommits-grouped/README.md
@@ -1,0 +1,50 @@
+# [![Build Status][travis-image]][travis-url] [![Coverage Status][coveralls-image]][coveralls-url]
+
+## conventionalcommits.org convention
+
+A concrete implementation of the specification described at
+[conventionalcommits.org](https://conventionalcommits.org/) for automated
+CHANGELOG generation and version management.
+
+
+## Indirect Usage (as preset)
+
+Use the [Conventional Changelog CLI Quick Start](https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-cli#quick-start) with the `-p conventionalcommits` option.
+
+## Direct Usage (as a base preset so you can customize it)
+
+If you want to use this package directly and pass options, you can use the [Conventional Changelog CLI Quick Start](https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-cli#quick-start) and with the `--config` or `-n` parameter, pass a js config that looks like this
+```
+'use strict'
+const config = require('conventional-changelog-conventionalcommits-grouped')
+
+module.exports = config({
+    "issuePrefixes": ["TEST-"],
+    "issueUrlFormat": "https://myBugTracker.com/{{prefix}}{{id}}"
+})
+```
+
+or json config like that:
+```
+{
+    "options": {
+        "preset": {
+            "name": "conventionalchangelog",
+            "issuePrefixes": ["TEST-"],
+            "issueUrlFormat": "https://myBugTracker.com/{{prefix}}{{id}}"
+        }
+    }
+}
+```
+This last json config way passes the `preset` object to the `conventional-changelog-preset-loader` package, that in turn, passes this same `preset` object as the config for the `conventional-changelog-conventionalcommits-grouped`.
+
+
+
+See [conventional-changelog-config-spec](https://github.com/conventional-changelog/conventional-changelog-config-spec) for available
+configuration options.
+
+
+[travis-image]: https://travis-ci.org/conventional-changelog/conventional-changelog.svg?branch=master
+[travis-url]: https://travis-ci.org/conventional-changelog/conventional-changelog
+[coveralls-image]: https://coveralls.io/repos/conventional-changelog/conventional-changelog/badge.svg
+[coveralls-url]: https://coveralls.io/r/conventional-changelog/conventional-changelog

--- a/packages/conventional-changelog-conventionalcommits-grouped/add-bang-notes.js
+++ b/packages/conventional-changelog-conventionalcommits-grouped/add-bang-notes.js
@@ -1,0 +1,11 @@
+const { breakingHeaderPattern } = require('./parser-opts')()
+
+module.exports = (commit) => {
+  const match = commit.header.match(breakingHeaderPattern)
+  if (match && commit.notes.length === 0) {
+    const noteText = match[3] // the description of the change.
+    commit.notes.push({
+      text: noteText
+    })
+  }
+}

--- a/packages/conventional-changelog-conventionalcommits-grouped/conventional-changelog.js
+++ b/packages/conventional-changelog-conventionalcommits-grouped/conventional-changelog.js
@@ -1,0 +1,12 @@
+'use strict'
+
+const Q = require('q')
+const parserOpts = require('./parser-opts')
+const writerOpts = require('./writer-opts')
+
+module.exports = function (config) {
+  return Q.all([parserOpts(config), writerOpts(config)])
+    .spread((parserOpts, writerOpts) => {
+      return { parserOpts, writerOpts }
+    })
+}

--- a/packages/conventional-changelog-conventionalcommits-grouped/conventional-recommended-bump.js
+++ b/packages/conventional-changelog-conventionalcommits-grouped/conventional-recommended-bump.js
@@ -1,0 +1,43 @@
+'use strict'
+
+const addBangNotes = require('./add-bang-notes')
+const parserOpts = require('./parser-opts')
+
+module.exports = function (config) {
+  return {
+    parserOpts: parserOpts(config),
+
+    whatBump: (commits) => {
+      let level = 2
+      let breakings = 0
+      let features = 0
+
+      commits.forEach(commit => {
+        // adds additional breaking change notes
+        // for the special case, test(system)!: hello world, where there is
+        // a '!' but no 'BREAKING CHANGE' in body:
+        addBangNotes(commit)
+        if (commit.notes.length > 0) {
+          breakings += commit.notes.length
+          level = 0
+        } else if (commit.type === 'feat' || commit.type === 'feature') {
+          features += 1
+          if (level === 2) {
+            level = 1
+          }
+        }
+      })
+
+      if (config.preMajor && level < 2) {
+        level++
+      }
+
+      return {
+        level: level,
+        reason: breakings === 1
+          ? `There is ${breakings} BREAKING CHANGE and ${features} features`
+          : `There are ${breakings} BREAKING CHANGES and ${features} features`
+      }
+    }
+  }
+}

--- a/packages/conventional-changelog-conventionalcommits-grouped/index.js
+++ b/packages/conventional-changelog-conventionalcommits-grouped/index.js
@@ -1,0 +1,38 @@
+'use strict'
+const Q = require('q')
+const _ = require('lodash')
+const conventionalChangelog = require('./conventional-changelog')
+const parserOpts = require('./parser-opts')
+const recommendedBumpOpts = require('./conventional-recommended-bump')
+const writerOpts = require('./writer-opts')
+
+module.exports = function (parameter) {
+  // parameter passed can be either a config object or a callback function
+  if (_.isFunction(parameter)) {
+    // parameter is a callback object
+    const config = {}
+    // FIXME: use presetOpts(config) for callback
+    Q.all([
+      conventionalChangelog(config),
+      parserOpts(config),
+      recommendedBumpOpts(config),
+      writerOpts(config)
+    ]).spread((conventionalChangelog, parserOpts, recommendedBumpOpts, writerOpts) => {
+      parameter(null, { gitRawCommitsOpts: { noMerges: null }, conventionalChangelog, parserOpts, recommendedBumpOpts, writerOpts })
+    })
+  } else {
+    const config = parameter || {}
+    return presetOpts(config)
+  }
+}
+
+function presetOpts (config) {
+  return Q.all([
+    conventionalChangelog(config),
+    parserOpts(config),
+    recommendedBumpOpts(config),
+    writerOpts(config)
+  ]).spread((conventionalChangelog, parserOpts, recommendedBumpOpts, writerOpts) => {
+    return { conventionalChangelog, parserOpts, recommendedBumpOpts, writerOpts }
+  })
+}

--- a/packages/conventional-changelog-conventionalcommits-grouped/package.json
+++ b/packages/conventional-changelog-conventionalcommits-grouped/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "conventional-changelog-conventionalcommits-grouped",
+  "version": "4.6.3",
+  "description": "conventional-changelog conventionalcommits.org preset",
+  "main": "index.js",
+  "scripts": {
+    "test-windows": "mocha --timeout 30000"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/conventional-changelog/conventional-changelog.git"
+  },
+  "keywords": [
+    "conventional-changelog",
+    "conventionalcommits.org",
+    "preset"
+  ],
+  "files": [
+    "add-bang-notes.js",
+    "conventional-changelog.js",
+    "conventional-recommended-bump.js",
+    "index.js",
+    "parser-opts.js",
+    "writer-opts.js",
+    "templates"
+  ],
+  "author": "Ben Coe",
+  "engines": {
+    "node": ">=10"
+  },
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/conventional-changelog/conventional-changelog/issues"
+  },
+  "homepage": "https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-conventionalcommits-groupedreadme",
+  "dependencies": {
+    "compare-func": "^2.0.0",
+    "lodash": "^4.17.15",
+    "q": "^1.5.1"
+  }
+}

--- a/packages/conventional-changelog-conventionalcommits-grouped/parser-opts.js
+++ b/packages/conventional-changelog-conventionalcommits-grouped/parser-opts.js
@@ -1,0 +1,25 @@
+'use strict'
+
+module.exports = function (config) {
+  config = defaultConfig(config)
+  return {
+    headerPattern: /^(\w*)(?:\((.*)\))?!?: (.*)$/,
+    breakingHeaderPattern: /^(\w*)(?:\((.*)\))?!: (.*)$/,
+    headerCorrespondence: [
+      'type',
+      'scope',
+      'subject'
+    ],
+    noteKeywords: ['BREAKING CHANGE', 'BREAKING-CHANGE'],
+    revertPattern: /^(?:Revert|revert:)\s"?([\s\S]+?)"?\s*This reverts commit (\w*)\./i,
+    revertCorrespondence: ['header', 'hash'],
+    issuePrefixes: config.issuePrefixes
+  }
+}
+
+// merge user set configuration with default configuration.
+function defaultConfig (config) {
+  config = config || {}
+  config.issuePrefixes = config.issuePrefixes || ['#']
+  return config
+}

--- a/packages/conventional-changelog-conventionalcommits-grouped/templates/commit.hbs
+++ b/packages/conventional-changelog-conventionalcommits-grouped/templates/commit.hbs
@@ -1,0 +1,30 @@
+*{{#if scope}} **{{scope}}:**
+{{~/if}} {{#if subject}}
+  {{~subject}}
+{{~else}}
+  {{~header}}
+{{~/if}}
+
+{{~!-- commit link --}}{{~#if hash}} {{#if @root.linkReferences~}}
+  ([{{shortHash}}]({{commitUrlFormat}}))
+{{~else}}
+  {{~shortHash}}
+{{~/if}}{{~/if}}
+
+{{~!-- commit references --}}
+{{~#if references~}}
+  , closes
+  {{~#each references}} {{#if @root.linkReferences~}}
+    [
+    {{~#if this.owner}}
+      {{~this.owner}}/
+    {{~/if}}
+    {{~this.repository}}{{this.prefix}}{{this.issue}}]({{issueUrlFormat}})
+  {{~else}}
+    {{~#if this.owner}}
+      {{~this.owner}}/
+    {{~/if}}
+    {{~this.repository}}{{this.prefix}}{{this.issue}}
+  {{~/if}}{{/each}}
+{{~/if}}
+

--- a/packages/conventional-changelog-conventionalcommits-grouped/templates/commit.hbs
+++ b/packages/conventional-changelog-conventionalcommits-grouped/templates/commit.hbs
@@ -1,5 +1,4 @@
-*{{#if scope}} **{{scope}}:**
-{{~/if}} {{#if subject}}
+* {{#if subject}}
   {{~subject}}
 {{~else}}
   {{~header}}

--- a/packages/conventional-changelog-conventionalcommits-grouped/templates/header.hbs
+++ b/packages/conventional-changelog-conventionalcommits-grouped/templates/header.hbs
@@ -1,0 +1,13 @@
+{{#if isPatch~}}
+  ###
+{{~else~}}
+  ##
+{{~/if}} {{#if @root.linkCompare~}}
+  [{{version}}]({{compareUrlFormat}})
+{{~else}}
+  {{~version}}
+{{~/if}}
+{{~#if title}} "{{title}}"
+{{~/if}}
+{{~#if date}} ({{date}})
+{{/if}}

--- a/packages/conventional-changelog-conventionalcommits-grouped/templates/template.hbs
+++ b/packages/conventional-changelog-conventionalcommits-grouped/templates/template.hbs
@@ -1,0 +1,23 @@
+{{> header}}
+
+{{#if noteGroups}}
+{{#each noteGroups}}
+
+### ⚠ {{title}}
+
+{{#each notes}}
+* {{#if commit.scope}}**{{commit.scope}}:** {{/if}}{{text}}
+{{/each}}
+{{/each}}
+{{/if}}
+{{#each commitGroups}}
+
+{{#if title}}
+### {{title}}
+
+{{/if}}
+{{#each commits}}
+{{> commit root=@root}}
+{{/each}}
+
+{{/each}}

--- a/packages/conventional-changelog-conventionalcommits-grouped/templates/template.hbs
+++ b/packages/conventional-changelog-conventionalcommits-grouped/templates/template.hbs
@@ -11,13 +11,18 @@
 {{/each}}
 {{/if}}
 {{#each commitGroups}}
-
 {{#if title}}
-### {{title}}
 
+### {{title}}
 {{/if}}
 {{#each commits}}
+{{#if this.title}}
+
+#### {{this.title}}
+{{/if}}
+
+{{#each this.commits}}
 {{> commit root=@root}}
 {{/each}}
-
+{{/each}}
 {{/each}}

--- a/packages/conventional-changelog-conventionalcommits-grouped/test/fixtures/_ghe-host.json
+++ b/packages/conventional-changelog-conventionalcommits-grouped/test/fixtures/_ghe-host.json
@@ -1,0 +1,5 @@
+{
+  "repository": "ghe",
+  "version": "v3.0.0",
+  "repository": "https://github.internal.example.com/conventional-changelog/internal"
+}

--- a/packages/conventional-changelog-conventionalcommits-grouped/test/fixtures/_known-host.json
+++ b/packages/conventional-changelog-conventionalcommits-grouped/test/fixtures/_known-host.json
@@ -1,0 +1,5 @@
+{
+  "repository": "known",
+  "version": "v2.0.0",
+  "repository": "https://github.com/conventional-changelog/example"
+}

--- a/packages/conventional-changelog-conventionalcommits-grouped/test/fixtures/_unknown-host.json
+++ b/packages/conventional-changelog-conventionalcommits-grouped/test/fixtures/_unknown-host.json
@@ -1,0 +1,4 @@
+{
+  "repository": "http://unknown",
+  "version": "v2.0.0"
+}

--- a/packages/conventional-changelog-conventionalcommits-grouped/test/test.js
+++ b/packages/conventional-changelog-conventionalcommits-grouped/test/test.js
@@ -1,0 +1,617 @@
+'use strict'
+const conventionalChangelogCore = require('conventional-changelog-core')
+const getPreset = require('../')
+const preset = getPreset()
+const expect = require('chai').expect
+const mocha = require('mocha')
+const describe = mocha.describe
+const it = mocha.it
+const gitDummyCommit = require('git-dummy-commit')
+const shell = require('shelljs')
+const through = require('through2')
+const path = require('path')
+const betterThanBefore = require('better-than-before')()
+const preparing = betterThanBefore.preparing
+
+betterThanBefore.setups([
+  function () {
+    shell.config.resetForTesting()
+    shell.cd(__dirname)
+    shell.rm('-rf', 'tmp')
+    shell.mkdir('tmp')
+    shell.cd('tmp')
+    shell.mkdir('git-templates')
+    shell.exec('git init --template=./git-templates')
+
+    gitDummyCommit(['build!: first build setup', 'BREAKING CHANGE: New build system.'])
+    gitDummyCommit(['ci(travis): add TravisCI pipeline', 'BREAKING CHANGE: Continuously integrated.'])
+    gitDummyCommit(['Feat: amazing new module', 'BREAKING CHANGE: Not backward compatible.'])
+    gitDummyCommit(['Fix(compile): avoid a bug', 'BREAKING CHANGE: The Change is huge.'])
+    gitDummyCommit(['perf(ngOptions): make it faster', ' closes #1, #2'])
+    gitDummyCommit(['fix(changelog): proper issue links', ' see #1, conventional-changelog/standard-version#358'])
+    gitDummyCommit('revert(ngOptions): bad commit')
+    gitDummyCommit('fix(*): oops')
+    gitDummyCommit(['fix(changelog): proper issue links', ' see GH-1'])
+    gitDummyCommit(['feat(awesome): adress EXAMPLE-1'])
+    gitDummyCommit(['chore(deps): upgrade example from 1 to 2'])
+    gitDummyCommit(['chore(release): release 0.0.0'])
+  },
+  function () {
+    gitDummyCommit(['feat(awesome): addresses the issue brought up in #133'])
+  },
+  function () {
+    gitDummyCommit(['feat(awesome): fix #88'])
+  },
+  function () {
+    gitDummyCommit(['feat(awesome): issue brought up by @bcoe! on Friday'])
+  },
+  function () {
+    gitDummyCommit(['build(npm): edit build script', 'BREAKING CHANGE: The Change is huge.'])
+    gitDummyCommit(['ci(travis): setup travis', 'BREAKING CHANGE: The Change is huge.'])
+    gitDummyCommit(['docs(readme): make it clear', 'BREAKING CHANGE: The Change is huge.'])
+    gitDummyCommit(['style(whitespace): make it easier to read', 'BREAKING CHANGE: The Change is huge.'])
+    gitDummyCommit(['refactor(code): change a lot of code', 'BREAKING CHANGE: The Change is huge.'])
+    gitDummyCommit(['test(*)!: more tests', 'BREAKING CHANGE: The Change is huge.'])
+  },
+  function () {
+    shell.exec('git tag v0.1.0')
+    gitDummyCommit('feat: some more feats')
+  },
+  function () {
+    shell.exec('git tag v0.2.0')
+    gitDummyCommit('feature: some more features')
+  },
+  function () {
+    gitDummyCommit(['feat(*): implementing #5 by @dlmr', ' closes #10'])
+  },
+  function () {
+    gitDummyCommit(['fix: use npm@5 (@username)'])
+    gitDummyCommit(['build(deps): bump @dummy/package from 7.1.2 to 8.0.0', 'BREAKING CHANGE: The Change is huge.'])
+    gitDummyCommit([
+      'feat: complex new feature',
+      'this is a complex new feature with many reviewers',
+      'Reviewer: @hutson',
+      'Fixes: #99',
+      'Refs: #100',
+      'BREAKING CHANGE: this completely changes the API'
+    ])
+    gitDummyCommit(['FEAT(foo)!: incredible new flag FIXES: #33'])
+  },
+  function () {
+    gitDummyCommit(['Revert \\"feat: default revert format\\"', 'This reverts commit 1234.'])
+    gitDummyCommit(['revert: feat: custom revert format', 'This reverts commit 5678.'])
+  },
+  function () {
+    gitDummyCommit([
+      'chore: release at different version',
+      'Release-As: v3.0.2'
+    ])
+  }
+])
+
+describe('conventionalcommits.org preset', function () {
+  it('should work if there is no semver tag', function (done) {
+    preparing(1)
+
+    conventionalChangelogCore({
+      config: preset
+    })
+      .on('error', function (err) {
+        done(err)
+      })
+      .pipe(through(function (chunk) {
+        chunk = chunk.toString()
+
+        expect(chunk).to.include('first build setup')
+        expect(chunk).to.include('**travis:** add TravisCI pipeline')
+        expect(chunk).to.include('**travis:** Continuously integrated.')
+        expect(chunk).to.include('amazing new module')
+        expect(chunk).to.include('**compile:** avoid a bug')
+        expect(chunk).to.include('make it faster')
+        expect(chunk).to.include(', closes [#1](https://github.com/conventional-changelog/conventional-changelog/issues/1) [#2](https://github.com/conventional-changelog/conventional-changelog/issues/2)')
+        expect(chunk).to.include('New build system.')
+        expect(chunk).to.include('Not backward compatible.')
+        expect(chunk).to.include('**compile:** The Change is huge.')
+        expect(chunk).to.include('Build System')
+        expect(chunk).to.include('Continuous Integration')
+        expect(chunk).to.include('Features')
+        expect(chunk).to.include('Bug Fixes')
+        expect(chunk).to.include('Performance Improvements')
+        expect(chunk).to.include('Reverts')
+        expect(chunk).to.include('bad commit')
+        expect(chunk).to.include('BREAKING CHANGE')
+
+        expect(chunk).to.not.include('ci')
+        expect(chunk).to.not.include('feat')
+        expect(chunk).to.not.include('fix')
+        expect(chunk).to.not.include('perf')
+        expect(chunk).to.not.include('revert')
+        expect(chunk).to.not.include('***:**')
+        expect(chunk).to.not.include(': Not backward compatible.')
+
+        // CHANGELOG should group sections in order of importance:
+        expect(
+          chunk.indexOf('BREAKING CHANGE') < chunk.indexOf('Features') &&
+          chunk.indexOf('Features') < chunk.indexOf('Bug Fixes') &&
+          chunk.indexOf('Bug Fixes') < chunk.indexOf('Performance Improvements') &&
+          chunk.indexOf('Performance Improvements') < chunk.indexOf('Reverts')
+        ).to.equal(true)
+
+        done()
+      }))
+  })
+
+  it('should not list breaking change twice if ! is used', function (done) {
+    preparing(1)
+
+    conventionalChangelogCore({
+      config: preset
+    })
+      .on('error', function (err) {
+        done(err)
+      })
+      .pipe(through(function (chunk) {
+        chunk = chunk.toString()
+        expect(chunk).to.not.match(/\* first build setup\r?\n/)
+        done()
+      }))
+  })
+
+  it('should allow alternative "types" configuration to be provided', function (done) {
+    preparing(1)
+    conventionalChangelogCore({
+      config: require('../')({
+        types: []
+      })
+    })
+      .on('error', function (err) {
+        done(err)
+      })
+      .pipe(through(function (chunk) {
+        chunk = chunk.toString()
+
+        expect(chunk).to.include('first build setup')
+        expect(chunk).to.include('**travis:** add TravisCI pipeline')
+        expect(chunk).to.include('**travis:** Continuously integrated.')
+        expect(chunk).to.include('amazing new module')
+        expect(chunk).to.include('**compile:** avoid a bug')
+        expect(chunk).to.include('Feat')
+
+        expect(chunk).to.not.include('make it faster')
+        expect(chunk).to.not.include('Reverts')
+        done()
+      }))
+  })
+
+  it('should allow matching "scope" to configuration', function (done) {
+    preparing(1)
+    conventionalChangelogCore({
+      config: require('../')({
+        types: [
+          { type: 'chore', scope: 'deps', section: 'Dependencies' }
+        ]
+      })
+    })
+      .on('error', function (err) {
+        done(err)
+      })
+      .pipe(through(function (chunk) {
+        chunk = chunk.toString()
+
+        expect(chunk).to.include('### Dependencies')
+        expect(chunk).to.include('**deps:** upgrade example from 1 to 2')
+
+        expect(chunk).to.not.include('release 0.0.0')
+        done()
+      }))
+  })
+
+  it('should properly format external repository issues', function (done) {
+    preparing(1)
+    conventionalChangelogCore({
+      config: preset
+    })
+      .on('error', function (err) {
+        done(err)
+      })
+      .pipe(through(function (chunk) {
+        chunk = chunk.toString()
+        expect(chunk).to.include('[#1](https://github.com/conventional-changelog/conventional-changelog/issues/1)')
+        expect(chunk).to.include('[conventional-changelog/standard-version#358](https://github.com/conventional-changelog/standard-version/issues/358)')
+        done()
+      }))
+  })
+
+  it('should properly format external repository issues given an `issueUrlFormat`', function (done) {
+    preparing(1)
+    conventionalChangelogCore({
+      config: getPreset({
+        issuePrefixes: ['#', 'GH-'],
+        issueUrlFormat: 'issues://{{repository}}/issues/{{id}}'
+      })
+    })
+      .on('error', function (err) {
+        done(err)
+      })
+      .pipe(through(function (chunk) {
+        chunk = chunk.toString()
+        expect(chunk).to.include('[#1](issues://conventional-changelog/issues/1)')
+        expect(chunk).to.include('[conventional-changelog/standard-version#358](issues://standard-version/issues/358)')
+        expect(chunk).to.include('[GH-1](issues://conventional-changelog/issues/1)')
+        done()
+      }))
+  })
+
+  it('should properly format issues in external issue tracker given an `issueUrlFormat` with `prefix`', function (done) {
+    preparing(1)
+    conventionalChangelogCore({
+      config: getPreset({
+        issueUrlFormat: 'https://example.com/browse/{{prefix}}{{id}}',
+        issuePrefixes: ['EXAMPLE-']
+      })
+    })
+      .on('error', function (err) {
+        done(err)
+      })
+      .pipe(through(function (chunk) {
+        chunk = chunk.toString()
+        expect(chunk).to.include('[EXAMPLE-1](https://example.com/browse/EXAMPLE-1)')
+        done()
+      }))
+  })
+
+  it('should replace #[0-9]+ with GitHub format issue URL by default', function (done) {
+    preparing(2)
+
+    conventionalChangelogCore({
+      config: preset
+    })
+      .on('error', function (err) {
+        done(err)
+      })
+      .pipe(through(function (chunk) {
+        chunk = chunk.toString()
+        expect(chunk).to.include('[#133](https://github.com/conventional-changelog/conventional-changelog/issues/133)')
+        done()
+      }))
+  })
+
+  it('should remove the issues that already appear in the subject', function (done) {
+    preparing(3)
+
+    conventionalChangelogCore({
+      config: preset
+    })
+      .on('error', function (err) {
+        done(err)
+      })
+      .pipe(through(function (chunk) {
+        chunk = chunk.toString()
+        expect(chunk).to.include('[#88](https://github.com/conventional-changelog/conventional-changelog/issues/88)')
+        expect(chunk).to.not.include('closes [#88](https://github.com/conventional-changelog/conventional-changelog/issues/88)')
+        done()
+      }))
+  })
+
+  it('should replace @user with configured userUrlFormat', function (done) {
+    preparing(4)
+
+    conventionalChangelogCore({
+      config: require('../')({
+        userUrlFormat: 'https://foo/{{user}}'
+      })
+    })
+      .on('error', function (err) {
+        done(err)
+      })
+      .pipe(through(function (chunk) {
+        chunk = chunk.toString()
+        expect(chunk).to.include('[@bcoe](https://foo/bcoe)')
+        done()
+      }))
+  })
+
+  it('should not discard commit if there is BREAKING CHANGE', function (done) {
+    preparing(5)
+
+    conventionalChangelogCore({
+      config: preset
+    })
+      .on('error', function (err) {
+        done(err)
+      })
+      .pipe(through(function (chunk) {
+        chunk = chunk.toString()
+
+        expect(chunk).to.include('Continuous Integration')
+        expect(chunk).to.include('Build System')
+        expect(chunk).to.include('Documentation')
+        expect(chunk).to.include('Styles')
+        expect(chunk).to.include('Code Refactoring')
+        expect(chunk).to.include('Tests')
+
+        done()
+      }))
+  })
+
+  it('should omit optional ! in breaking commit', function (done) {
+    preparing(5)
+
+    conventionalChangelogCore({
+      config: preset
+    })
+      .on('error', function (err) {
+        done(err)
+      })
+      .pipe(through(function (chunk) {
+        chunk = chunk.toString()
+
+        expect(chunk).to.include('### Tests')
+        expect(chunk).to.include('* more tests')
+
+        done()
+      }))
+  })
+
+  it('should work if there is a semver tag', function (done) {
+    preparing(6)
+    let i = 0
+
+    conventionalChangelogCore({
+      config: preset,
+      outputUnreleased: true
+    })
+      .on('error', function (err) {
+        done(err)
+      })
+      .pipe(through(function (chunk, enc, cb) {
+        chunk = chunk.toString()
+
+        expect(chunk).to.include('some more feats')
+        expect(chunk).to.not.include('BREAKING')
+
+        i++
+        cb()
+      }, function () {
+        expect(i).to.equal(1)
+        done()
+      }))
+  })
+
+  it('should support "feature" as alias for "feat"', function (done) {
+    preparing(7)
+    let i = 0
+
+    conventionalChangelogCore({
+      config: preset,
+      outputUnreleased: true
+    })
+      .on('error', function (err) {
+        done(err)
+      })
+      .pipe(through(function (chunk, enc, cb) {
+        chunk = chunk.toString()
+
+        expect(chunk).to.include('some more features')
+        expect(chunk).to.not.include('BREAKING')
+
+        i++
+        cb()
+      }, function () {
+        expect(i).to.equal(1)
+        done()
+      }))
+  })
+
+  it('should work with unknown host', function (done) {
+    preparing(7)
+    let i = 0
+
+    conventionalChangelogCore({
+      config: require('../')({
+        commitUrlFormat: 'http://unknown/commit/{{hash}}',
+        compareUrlFormat: 'http://unknown/compare/{{previousTag}}...{{currentTag}}'
+      }),
+      pkg: {
+        path: path.join(__dirname, 'fixtures/_unknown-host.json')
+      }
+    })
+      .on('error', function (err) {
+        done(err)
+      })
+      .pipe(through(function (chunk, enc, cb) {
+        chunk = chunk.toString()
+
+        expect(chunk).to.include('(http://unknown/compare')
+        expect(chunk).to.include('](http://unknown/commit/')
+
+        i++
+        cb()
+      }, function () {
+        expect(i).to.equal(1)
+        done()
+      }))
+  })
+
+  it('should work specifying where to find a package.json using conventional-changelog-core', function (done) {
+    preparing(8)
+    let i = 0
+
+    conventionalChangelogCore({
+      config: preset,
+      pkg: {
+        path: path.join(__dirname, 'fixtures/_known-host.json')
+      }
+    })
+      .on('error', function (err) {
+        done(err)
+      })
+      .pipe(through(function (chunk, enc, cb) {
+        chunk = chunk.toString()
+
+        expect(chunk).to.include('(https://github.com/conventional-changelog/example/compare')
+        expect(chunk).to.include('](https://github.com/conventional-changelog/example/commit/')
+        expect(chunk).to.include('](https://github.com/conventional-changelog/example/issues/')
+
+        i++
+        cb()
+      }, function () {
+        expect(i).to.equal(1)
+        done()
+      }))
+  })
+
+  it('should fallback to the closest package.json when not providing a location for a package.json', function (done) {
+    preparing(8)
+    let i = 0
+
+    conventionalChangelogCore({
+      config: preset
+    })
+      .on('error', function (err) {
+        console.info(err)
+        done(err)
+      })
+      .pipe(through(function (chunk, enc, cb) {
+        chunk = chunk.toString()
+
+        expect(chunk).to.include('(https://github.com/conventional-changelog/conventional-changelog/compare')
+        expect(chunk).to.include('](https://github.com/conventional-changelog/conventional-changelog/commit/')
+        expect(chunk).to.include('](https://github.com/conventional-changelog/conventional-changelog/issues/')
+
+        i++
+        cb()
+      }, function () {
+        expect(i).to.equal(1)
+        done()
+      }))
+  })
+
+  it('should support non public GitHub repository locations', function (done) {
+    preparing(8)
+
+    conventionalChangelogCore({
+      config: preset,
+      pkg: {
+        path: path.join(__dirname, 'fixtures/_ghe-host.json')
+      }
+    })
+      .on('error', function (err) {
+        done(err)
+      })
+      .pipe(through(function (chunk) {
+        chunk = chunk.toString()
+
+        expect(chunk).to.include('(https://github.internal.example.com/dlmr')
+        expect(chunk).to.include('(https://github.internal.example.com/conventional-changelog/internal/compare')
+        expect(chunk).to.include('](https://github.internal.example.com/conventional-changelog/internal/commit/')
+        expect(chunk).to.include('5](https://github.internal.example.com/conventional-changelog/internal/issues/5')
+        expect(chunk).to.include(' closes [#10](https://github.internal.example.com/conventional-changelog/internal/issues/10)')
+
+        done()
+      }))
+  })
+
+  it('should only replace with link to user if it is an username', function (done) {
+    preparing(9)
+
+    conventionalChangelogCore({
+      config: preset
+    })
+      .on('error', function (err) {
+        done(err)
+      })
+      .pipe(through(function (chunk) {
+        chunk = chunk.toString()
+
+        expect(chunk).to.not.include('(https://github.com/5')
+        expect(chunk).to.include('(https://github.com/username')
+
+        expect(chunk).to.not.include('[@dummy](https://github.com/dummy)/package')
+        expect(chunk).to.include('bump @dummy/package from')
+        done()
+      }))
+  })
+
+  it('supports multiple lines of footer information', function (done) {
+    preparing(9)
+
+    conventionalChangelogCore({
+      config: preset
+    })
+      .on('error', function (err) {
+        done(err)
+      })
+      .pipe(through(function (chunk) {
+        chunk = chunk.toString()
+        expect(chunk).to.include('closes [#99]')
+        expect(chunk).to.include('[#100]')
+        expect(chunk).to.include('this completely changes the API')
+        done()
+      }))
+  })
+
+  it('does not require that types are case sensitive', function (done) {
+    preparing(9)
+
+    conventionalChangelogCore({
+      config: preset
+    })
+      .on('error', function (err) {
+        done(err)
+      })
+      .pipe(through(function (chunk) {
+        chunk = chunk.toString()
+        expect(chunk).to.include('incredible new flag')
+        done()
+      }))
+  })
+
+  it('populates breaking change if ! is present', function (done) {
+    preparing(9)
+
+    conventionalChangelogCore({
+      config: preset
+    })
+      .on('error', function (err) {
+        done(err)
+      })
+      .pipe(through(function (chunk) {
+        chunk = chunk.toString()
+        expect(chunk).to.match(/incredible new flag FIXES: #33\r?\n/)
+        done()
+      }))
+  })
+
+  it('parses both default (Revert "<subject>") and custom (revert: <subject>) revert commits', function (done) {
+    preparing(10)
+
+    conventionalChangelogCore({
+      config: preset
+    })
+      .on('error', function (err) {
+        done(err)
+      })
+      .pipe(through(function (chunk) {
+        chunk = chunk.toString()
+        expect(chunk).to.match(/custom revert format/)
+        expect(chunk).to.match(/default revert format/)
+        done()
+      }))
+  })
+  it('should include commits with "Release-As:" footer in CHANGELOG', function (done) {
+    preparing(11)
+
+    conventionalChangelogCore({
+      config: preset
+    })
+      .on('error', function (err) {
+        done(err)
+      })
+      .pipe(through(function (chunk) {
+        chunk = chunk.toString()
+        expect(chunk).to.match(/release at different version/)
+        done()
+      }))
+  })
+})

--- a/packages/conventional-changelog-conventionalcommits-grouped/test/test.js
+++ b/packages/conventional-changelog-conventionalcommits-grouped/test/test.js
@@ -102,24 +102,39 @@ describe('conventionalcommits.org preset', function () {
       .pipe(through(function (chunk) {
         chunk = chunk.toString()
 
-        expect(chunk).to.include('first build setup')
-        expect(chunk).to.include('**travis:** add TravisCI pipeline')
+        // Breaking Change summary
         expect(chunk).to.include('**travis:** Continuously integrated.')
-        expect(chunk).to.include('amazing new module')
-        expect(chunk).to.include('**compile:** avoid a bug')
-        expect(chunk).to.include('make it faster')
-        expect(chunk).to.include(', closes [#1](https://github.com/conventional-changelog/conventional-changelog/issues/1) [#2](https://github.com/conventional-changelog/conventional-changelog/issues/2)')
-        expect(chunk).to.include('New build system.')
-        expect(chunk).to.include('Not backward compatible.')
         expect(chunk).to.include('**compile:** The Change is huge.')
-        expect(chunk).to.include('Build System')
-        expect(chunk).to.include('Continuous Integration')
-        expect(chunk).to.include('Features')
-        expect(chunk).to.include('Bug Fixes')
-        expect(chunk).to.include('Performance Improvements')
-        expect(chunk).to.include('Reverts')
-        expect(chunk).to.include('bad commit')
+        expect(chunk).to.include('* New build system.')
+        expect(chunk).to.include('* Not backward compatible.')
         expect(chunk).to.include('BREAKING CHANGE')
+
+        // Other Types summary
+        expect(chunk).to.include('### Features')
+        expect(chunk).to.include('#### awesome')
+        expect(chunk).to.include('* amazing new module')
+
+        expect(chunk).to.include('### Bug Fixes')
+        expect(chunk).to.include('#### compile')
+        expect(chunk).to.include('* avoid a bug')
+        expect(chunk).to.include('#### changelog')
+        expect(chunk).to.include('* proper issue links')
+
+        expect(chunk).to.include('### Performance Improvements')
+        expect(chunk).to.include('#### ngOptions')
+        expect(chunk).to.include('* make it faster')
+        expect(chunk).to.include(', closes [#1](https://github.com/conventional-changelog/conventional-changelog/issues/1) [#2](https://github.com/conventional-changelog/conventional-changelog/issues/2)')
+
+        expect(chunk).to.include('### Reverts')
+        expect(chunk).to.include('#### ngOptions')
+        expect(chunk).to.include('* bad commit')
+
+        expect(chunk).to.include('### Build System')
+        expect(chunk).to.include('* first build setup')
+
+        expect(chunk).to.include('### Continuous Integration')
+        expect(chunk).to.include('#### travis')
+        expect(chunk).to.include('* add TravisCI pipeline')
 
         expect(chunk).to.not.include('ci')
         expect(chunk).to.not.include('feat')
@@ -170,12 +185,23 @@ describe('conventionalcommits.org preset', function () {
       .pipe(through(function (chunk) {
         chunk = chunk.toString()
 
-        expect(chunk).to.include('first build setup')
-        expect(chunk).to.include('**travis:** add TravisCI pipeline')
+        // Breaking Changes Summary
         expect(chunk).to.include('**travis:** Continuously integrated.')
+
+        // Other Types summary
+        expect(chunk).to.include('### build')
+        expect(chunk).to.include('first build setup')
+
+        expect(chunk).to.include('### ci')
+        expect(chunk).to.include('#### travis')
+        expect(chunk).to.include('* add TravisCI pipeline')
+
+        expect(chunk).to.include('### Feat')
         expect(chunk).to.include('amazing new module')
-        expect(chunk).to.include('**compile:** avoid a bug')
-        expect(chunk).to.include('Feat')
+
+        expect(chunk).to.include('### Fix')
+        expect(chunk).to.include('#### compile')
+        expect(chunk).to.include('* avoid a bug')
 
         expect(chunk).to.not.include('make it faster')
         expect(chunk).to.not.include('Reverts')
@@ -199,7 +225,8 @@ describe('conventionalcommits.org preset', function () {
         chunk = chunk.toString()
 
         expect(chunk).to.include('### Dependencies')
-        expect(chunk).to.include('**deps:** upgrade example from 1 to 2')
+        expect(chunk).to.include('#### deps')
+        expect(chunk).to.include('* upgrade example from 1 to 2')
 
         expect(chunk).to.not.include('release 0.0.0')
         done()

--- a/packages/conventional-changelog-conventionalcommits-grouped/writer-opts.js
+++ b/packages/conventional-changelog-conventionalcommits-grouped/writer-opts.js
@@ -1,0 +1,214 @@
+'use strict'
+
+const addBangNotes = require('./add-bang-notes')
+const compareFunc = require('compare-func')
+const Q = require('q')
+const readFile = Q.denodeify(require('fs').readFile)
+const resolve = require('path').resolve
+const releaseAsRe = /release-as:\s*\w*@?([0-9]+\.[0-9]+\.[0-9a-z]+(-[0-9a-z.]+)?)\s*/i
+
+/**
+ * Handlebar partials for various property substitutions based on commit context.
+ */
+const owner = '{{#if this.owner}}{{~this.owner}}{{else}}{{~@root.owner}}{{/if}}'
+const host = '{{~@root.host}}'
+const repository = '{{#if this.repository}}{{~this.repository}}{{else}}{{~@root.repository}}{{/if}}'
+
+module.exports = function (config) {
+  config = defaultConfig(config)
+  const commitUrlFormat = expandTemplate(config.commitUrlFormat, {
+    host,
+    owner,
+    repository
+  })
+  const compareUrlFormat = expandTemplate(config.compareUrlFormat, {
+    host,
+    owner,
+    repository
+  })
+  const issueUrlFormat = expandTemplate(config.issueUrlFormat, {
+    host,
+    owner,
+    repository,
+    id: '{{this.issue}}',
+    prefix: '{{this.prefix}}'
+  })
+
+  return Q.all([
+    readFile(resolve(__dirname, './templates/template.hbs'), 'utf-8'),
+    readFile(resolve(__dirname, './templates/header.hbs'), 'utf-8'),
+    readFile(resolve(__dirname, './templates/commit.hbs'), 'utf-8'),
+    readFile(resolve(__dirname, './templates/footer.hbs'), 'utf-8')
+  ])
+    .spread((template, header, commit, footer) => {
+      const writerOpts = getWriterOpts(config)
+
+      writerOpts.mainTemplate = template
+      writerOpts.headerPartial = header
+        .replace(/{{compareUrlFormat}}/g, compareUrlFormat)
+      writerOpts.commitPartial = commit
+        .replace(/{{commitUrlFormat}}/g, commitUrlFormat)
+        .replace(/{{issueUrlFormat}}/g, issueUrlFormat)
+      writerOpts.footerPartial = footer
+
+      return writerOpts
+    })
+}
+
+function findTypeEntry (types, commit) {
+  const typeKey = (commit.revert ? 'revert' : (commit.type || '')).toLowerCase()
+  return types.find((entry) => {
+    if (entry.type !== typeKey) {
+      return false
+    }
+    if (entry.scope && entry.scope !== commit.scope) {
+      return false
+    }
+    return true
+  })
+}
+
+function getWriterOpts (config) {
+  config = defaultConfig(config)
+
+  return {
+    transform: (commit, context) => {
+      let discard = true
+      const issues = []
+      const entry = findTypeEntry(config.types, commit)
+
+      // adds additional breaking change notes
+      // for the special case, test(system)!: hello world, where there is
+      // a '!' but no 'BREAKING CHANGE' in body:
+      addBangNotes(commit)
+
+      // Add an entry in the CHANGELOG if special Release-As footer
+      // is used:
+      if ((commit.footer && releaseAsRe.test(commit.footer)) ||
+          (commit.body && releaseAsRe.test(commit.body))) {
+        discard = false
+      }
+
+      commit.notes.forEach(note => {
+        note.title = 'BREAKING CHANGES'
+        discard = false
+      })
+
+      // breaking changes attached to any type are still displayed.
+      if (discard && (entry === undefined ||
+          entry.hidden)) return
+
+      if (entry) commit.type = entry.section
+
+      if (commit.scope === '*') {
+        commit.scope = ''
+      }
+
+      if (typeof commit.hash === 'string') {
+        commit.shortHash = commit.hash.substring(0, 7)
+      }
+
+      if (typeof commit.subject === 'string') {
+        // Issue URLs.
+        config.issuePrefixes.join('|')
+        const issueRegEx = '(' + config.issuePrefixes.join('|') + ')' + '([0-9]+)'
+        const re = new RegExp(issueRegEx, 'g')
+
+        commit.subject = commit.subject.replace(re, (_, prefix, issue) => {
+          issues.push(prefix + issue)
+          const url = expandTemplate(config.issueUrlFormat, {
+            host: context.host,
+            owner: context.owner,
+            repository: context.repository,
+            id: issue,
+            prefix: prefix
+          })
+          return `[${prefix}${issue}](${url})`
+        })
+        // User URLs.
+        commit.subject = commit.subject.replace(/\B@([a-z0-9](?:-?[a-z0-9/]){0,38})/g, (_, user) => {
+          // TODO: investigate why this code exists.
+          if (user.includes('/')) {
+            return `@${user}`
+          }
+
+          const usernameUrl = expandTemplate(config.userUrlFormat, {
+            host: context.host,
+            owner: context.owner,
+            repository: context.repository,
+            user: user
+          })
+
+          return `[@${user}](${usernameUrl})`
+        })
+      }
+
+      // remove references that already appear in the subject
+      commit.references = commit.references.filter(reference => {
+        if (issues.indexOf(reference.prefix + reference.issue) === -1) {
+          return true
+        }
+
+        return false
+      })
+
+      return commit
+    },
+    groupBy: 'type',
+    // the groupings of commit messages, e.g., Features vs., Bug Fixes, are
+    // sorted based on their probable importance:
+    commitGroupsSort: (a, b) => {
+      const commitGroupOrder = ['Reverts', 'Performance Improvements', 'Bug Fixes', 'Features']
+      const gRankA = commitGroupOrder.indexOf(a.title)
+      const gRankB = commitGroupOrder.indexOf(b.title)
+      if (gRankA >= gRankB) {
+        return -1
+      } else {
+        return 1
+      }
+    },
+    commitsSort: ['scope', 'subject'],
+    noteGroupsSort: 'title',
+    notesSort: compareFunc
+  }
+}
+
+// merge user set configuration with default configuration.
+function defaultConfig (config) {
+  config = config || {}
+  config.types = config.types || [
+    { type: 'feat', section: 'Features' },
+    { type: 'feature', section: 'Features' },
+    { type: 'fix', section: 'Bug Fixes' },
+    { type: 'perf', section: 'Performance Improvements' },
+    { type: 'revert', section: 'Reverts' },
+    { type: 'docs', section: 'Documentation', hidden: true },
+    { type: 'style', section: 'Styles', hidden: true },
+    { type: 'chore', section: 'Miscellaneous Chores', hidden: true },
+    { type: 'refactor', section: 'Code Refactoring', hidden: true },
+    { type: 'test', section: 'Tests', hidden: true },
+    { type: 'build', section: 'Build System', hidden: true },
+    { type: 'ci', section: 'Continuous Integration', hidden: true }
+  ]
+  config.issueUrlFormat = config.issueUrlFormat ||
+    '{{host}}/{{owner}}/{{repository}}/issues/{{id}}'
+  config.commitUrlFormat = config.commitUrlFormat ||
+    '{{host}}/{{owner}}/{{repository}}/commit/{{hash}}'
+  config.compareUrlFormat = config.compareUrlFormat ||
+    '{{host}}/{{owner}}/{{repository}}/compare/{{previousTag}}...{{currentTag}}'
+  config.userUrlFormat = config.userUrlFormat ||
+    '{{host}}/{{user}}'
+  config.issuePrefixes = config.issuePrefixes || ['#']
+
+  return config
+}
+
+// expand on the simple mustache-style templates supported in
+// configuration (we may eventually want to use handlebars for this).
+function expandTemplate (template, context) {
+  let expanded = template
+  Object.keys(context).forEach(key => {
+    expanded = expanded.replace(new RegExp(`{{${key}}}`, 'g'), context[key])
+  })
+  return expanded
+}

--- a/packages/conventional-changelog-conventionalcommits-grouped/writer-opts.js
+++ b/packages/conventional-changelog-conventionalcommits-grouped/writer-opts.js
@@ -154,7 +154,7 @@ function getWriterOpts (config) {
 
       return commit
     },
-    groupBy: 'type',
+    groupBy: ['type', 'scope'],
     // the groupings of commit messages, e.g., Features vs., Bug Fixes, are
     // sorted based on their probable importance:
     commitGroupsSort: (a, b) => {

--- a/packages/conventional-changelog-writer/lib/util.js
+++ b/packages/conventional-changelog-writer/lib/util.js
@@ -56,7 +56,7 @@ function functionify (strOrArr) {
   }
 }
 
-function getCommitGroups (groupBy, commits, groupsSort, commitsSort) {
+function groupCommitGroups (groupBy, commits, groupsSort, commitsSort) {
   const commitGroups = []
   const commitGroupsObj = _.groupBy(commits, function (commit) {
     return commit[groupBy] || ''
@@ -82,6 +82,43 @@ function getCommitGroups (groupBy, commits, groupsSort, commitsSort) {
   }
 
   return commitGroups
+}
+
+function getCommitGroups (groupBy, commits, groupsSort, commitsSort) {
+  let groupByFirst = null
+  let groupBySecond = null
+
+  if (_.isString(groupBy)) {
+    groupByFirst = groupBy
+  } else if (_.isArray(groupBy)) {
+    if (groupBy.length > 2) {
+      throw new Error('The \'groupBy\' argument can have up to 2 entries.')
+    }
+
+    if (groupBy.length >= 1) {
+      groupByFirst = groupBy[0]
+    }
+
+    if (groupBy.length === 2) {
+      groupBySecond = groupBy[1]
+    }
+  } else if (groupBy) {
+    throw new TypeError('The \'groupBy\' argument must be a string or an array.')
+  }
+
+  const commitGroupsFirstLayer = groupCommitGroups(groupByFirst, commits, groupsSort, commitsSort)
+
+  const commitGroupsSecondLayer = []
+  if (groupBySecond) {
+    _.forEach(commitGroupsFirstLayer, function (r) {
+      const nestedCommits = groupCommitGroups(groupBySecond, r.commits, groupsSort, commitsSort)
+      r.commits = nestedCommits
+      commitGroupsSecondLayer.push(r)
+    })
+    return commitGroupsSecondLayer
+  }
+
+  return commitGroupsFirstLayer
 }
 
 function getNoteGroups (notes, noteGroupsSort, notesSort) {

--- a/packages/conventional-changelog-writer/test/util.spec.js
+++ b/packages/conventional-changelog-writer/test/util.spec.js
@@ -73,6 +73,27 @@ describe('util', function () {
       content: 'this is B and its a bit longer'
     }]
 
+    const groupBy2Layers = [{
+      groupBy: 'A',
+      groupBySecond: '1',
+      content: 'this is A'
+    }, {
+      groupBy: 'A',
+      groupBySecond: '1',
+      content: 'this is another A'
+    }, {
+      groupBy: 'A',
+      groupBySecond: '2',
+      content: 'this is another A; 2'
+    }, {
+      groupBy: 'A',
+      groupBySecond: '2',
+      content: 'this is another A; 3'
+    }, {
+      groupBy: 'Big B',
+      content: 'this is B and its a bit longer'
+    }]
+
     it('should group but not sort groups', function () {
       const commitGroups = util.getCommitGroups('groupBy', commits)
 
@@ -198,6 +219,54 @@ describe('util', function () {
           content: 'this is B and its a bit longer'
         }]
       }])
+    })
+
+    it('should group by 2 layers', function () {
+      const commitGroups = util.getCommitGroups(['groupBy', 'groupBySecond'], groupBy2Layers)
+
+      expect(commitGroups).to.eql([{
+        title: 'A',
+        commits: [{
+          title: '1',
+          commits: [{
+            content: 'this is A',
+            groupBy: 'A',
+            groupBySecond: '1'
+          }, {
+            content: 'this is another A',
+            groupBy: 'A',
+            groupBySecond: '1'
+          }]
+        }, {
+          title: '2',
+          commits: [{
+            content: 'this is another A; 2',
+            groupBy: 'A',
+            groupBySecond: '2'
+          }, {
+            content: 'this is another A; 3',
+            groupBy: 'A',
+            groupBySecond: '2'
+          }]
+        }]
+      }, {
+        title: 'Big B',
+        commits: [{
+          title: false,
+          commits: [{
+            content: 'this is B and its a bit longer',
+            groupBy: 'Big B'
+          }]
+        }]
+      }])
+    })
+
+    it('should error when not a string or array', function () {
+      expect(() => util.getCommitGroups({ something: 'bad' }, [])).to.throw(TypeError, 'The \'groupBy\' argument must be a string or an array.')
+    })
+
+    it('should error when more than 2 entries', function () {
+      expect(() => util.getCommitGroups(['a', 'b', 'c'], [])).to.throw(Error, 'The \'groupBy\' argument can have up to 2 entries.')
     })
   })
 


### PR DESCRIPTION
Hi,

This PR is a potential solution to allow different presets to group commits by up to 2 layers, as existing presets do not have more than 2 properties to categorise a commit.

You may find it easier to review the PR commit by commit.


Potential solution to #439