### PR TITLE
feat(options): add mergeCommitFilter option to cli (rebased)

### DIFF
--- a/packages/conventional-changelog-cli/cli.js
+++ b/packages/conventional-changelog-cli/cli.js
@@ -130,6 +130,7 @@ let sameFile = flags.sameFile
 const append = flags.append
 const releaseCount = flags.releaseCount
 const skipUnstable = flags.skipUnstable
+const mergeCommitFilter = flags.mergeCommitFilter || 'exclude'
 
 if (infile && infile === outfile) {
   sameFile = true
@@ -150,6 +151,7 @@ let options = _.omitBy({
   append: append,
   releaseCount: releaseCount,
   skipUnstable: skipUnstable,
+  mergeCommitFilter: mergeCommitFilter,
   outputUnreleased: flags.outputUnreleased,
   lernaPackage: flags.lernaPackage,
   tagPrefix: flags.tagPrefix
@@ -182,6 +184,17 @@ try {
 }
 
 const gitRawCommitsOpts = _.merge({}, config.gitRawCommitsOpts || {})
+
+if (options.mergeCommitFilter) {
+  if (options.mergeCommitFilter === 'include') {
+    gitRawCommitsOpts.merges = null
+  } else if (options.mergeCommitFilter === 'only-merges') {
+    gitRawCommitsOpts.merges = true
+  } else { // default to options.mergeCommitFilter === 'exclude'
+    gitRawCommitsOpts.merges = false
+  }
+}
+
 if (flags.commitPath) gitRawCommitsOpts.path = flags.commitPath
 
 const changelogStream = conventionalChangelog(options, templateContext, gitRawCommitsOpts, config.parserOpts, config.writerOpts)

--- a/packages/conventional-changelog-cli/cli.js
+++ b/packages/conventional-changelog-cli/cli.js
@@ -37,6 +37,12 @@ const cli = meow(`
                                 If 0, the whole changelog will be regenerated and the outfile will be overwritten
                                 Default: 1
 
+      -m, --merge-commit-filter Configure how to handle merge commits. Must be one of the following:
+                                exclude: Merge commits will be ignored.
+                                include: Merge commits will be included.
+                                only-merges: Only merge commits will be processed.
+                                Default: exclude
+
       --skip-unstable           If given, unstable tags will be skipped, e.g., x.x.x-alpha.1, x.x.x-rc.2
 
       -u, --output-unreleased   Output unreleased changelog
@@ -84,6 +90,10 @@ const cli = meow(`
     },
     'skip-unstable': {
       type: 'boolean'
+    },
+    'merge-commit-filter': {
+      alias: 'm',
+      type: 'string'
     },
     'output-unreleased': {
       alias: 'u',

--- a/packages/conventional-changelog-cli/cli.js
+++ b/packages/conventional-changelog-cli/cli.js
@@ -185,14 +185,12 @@ try {
 
 const gitRawCommitsOpts = _.merge({}, config.gitRawCommitsOpts || {})
 
-if (options.mergeCommitFilter) {
-  if (options.mergeCommitFilter === 'include') {
-    gitRawCommitsOpts.merges = null
-  } else if (options.mergeCommitFilter === 'only-merges') {
-    gitRawCommitsOpts.merges = true
-  } else { // default to options.mergeCommitFilter === 'exclude'
-    gitRawCommitsOpts.merges = false
-  }
+if (options.mergeCommitFilter === 'include') {
+  gitRawCommitsOpts.merges = null
+} else if (options.mergeCommitFilter === 'only-merges') {
+  gitRawCommitsOpts.merges = true
+} else { // default to 'exclude'
+  gitRawCommitsOpts.merges = false
 }
 
 if (flags.commitPath) gitRawCommitsOpts.path = flags.commitPath

--- a/packages/conventional-changelog-core/lib/merge-config.js
+++ b/packages/conventional-changelog-core/lib/merge-config.js
@@ -68,7 +68,6 @@ function mergeConfig (options, context, gitRawCommitsOpts, parserOpts, writerOpt
       }
     },
     append: false,
-    mergeCommitFilter: 'exclude',
     releaseCount: 1,
     skipUnstable: false,
     debug: function () {},
@@ -245,6 +244,7 @@ function mergeConfig (options, context, gitRawCommitsOpts, parserOpts, writerOpt
       gitRawCommitsOpts = _.assign({
         format: '%B%n-hash-%n%H%n-gitTags-%n%d%n-committerDate-%n%ci',
         from: fromTag,
+        merges: false,
         debug: options.debug
       },
       config.gitRawCommitsOpts,
@@ -253,16 +253,6 @@ function mergeConfig (options, context, gitRawCommitsOpts, parserOpts, writerOpt
 
       if (options.append) {
         gitRawCommitsOpts.reverse = gitRawCommitsOpts.reverse || true
-      }
-
-      if (options.mergeCommitFilter) {
-        if (options.mergeCommitFilter === 'exclude') {
-          gitRawCommitsOpts.merges = false
-        } else if (options.mergeCommitFilter === 'only-merges') {
-          gitRawCommitsOpts.merges = true
-        } else if (options.mergeCommitFilter === 'include') {
-          // noop; just not set `merges` option in rawCommitOpts
-        }
       }
 
       parserOpts = _.assign(

--- a/packages/conventional-changelog-core/lib/merge-config.js
+++ b/packages/conventional-changelog-core/lib/merge-config.js
@@ -68,6 +68,7 @@ function mergeConfig (options, context, gitRawCommitsOpts, parserOpts, writerOpt
       }
     },
     append: false,
+    mergeCommitFilter: 'exclude',
     releaseCount: 1,
     skipUnstable: false,
     debug: function () {},
@@ -244,7 +245,6 @@ function mergeConfig (options, context, gitRawCommitsOpts, parserOpts, writerOpt
       gitRawCommitsOpts = _.assign({
         format: '%B%n-hash-%n%H%n-gitTags-%n%d%n-committerDate-%n%ci',
         from: fromTag,
-        merges: false,
         debug: options.debug
       },
       config.gitRawCommitsOpts,
@@ -253,6 +253,16 @@ function mergeConfig (options, context, gitRawCommitsOpts, parserOpts, writerOpt
 
       if (options.append) {
         gitRawCommitsOpts.reverse = gitRawCommitsOpts.reverse || true
+      }
+
+      if (options.mergeCommitFilter) {
+        if (options.mergeCommitFilter === 'exclude') {
+          gitRawCommitsOpts.merges = false
+        } else if (options.mergeCommitFilter === 'only-merges') {
+          gitRawCommitsOpts.merges = true
+        } else if (options.mergeCommitFilter === 'include') {
+          // noop; just not set `merges` option in rawCommitOpts
+        }
       }
 
       parserOpts = _.assign(

--- a/packages/standard-changelog/cli.js
+++ b/packages/standard-changelog/cli.js
@@ -136,14 +136,12 @@ try {
 
 const gitRawCommitsOpts = {}
 
-if (options.mergeCommitFilter) {
-  if (options.mergeCommitFilter === 'include') {
-    gitRawCommitsOpts.merges = null
-  } else if (options.mergeCommitFilter === 'only-merges') {
-    gitRawCommitsOpts.merges = true
-  } else { // default to options.mergeCommitFilter === 'exclude'
-    gitRawCommitsOpts.merges = false
-  }
+if (options.mergeCommitFilter === 'include') {
+  gitRawCommitsOpts.merges = null
+} else if (options.mergeCommitFilter === 'only-merges') {
+  gitRawCommitsOpts.merges = true
+} else { // default to 'exclude'
+  gitRawCommitsOpts.merges = false
 }
 
 if (flags.commitPath) gitRawCommitsOpts.path = flags.commitPath

--- a/packages/standard-changelog/cli.js
+++ b/packages/standard-changelog/cli.js
@@ -24,6 +24,11 @@ const cli = meow(`
     -k, --pkg                 A filepath of where your package.json is located
     -a, --append              Should the generated block be appended
     -r, --release-count       How many releases to be generated from the latest
+    -m, --merge-commit-filter Configure how to handle merge commits. Must be one of the following:
+                                exclude: Merge commits will be ignored.
+                                include: Merge commits will be included. 
+                                only-merges: Only merge commits will be processed. 
+                                Default: exclude
     -v, --verbose             Verbose output
     -c, --context             A filepath of a json that is used to define template variables
     -l, --lerna-package       Generate a changelog for a specific lerna package (:pkg-name@1.0.0)
@@ -63,6 +68,10 @@ const cli = meow(`
     'release-count': {
       alias: 'r',
       type: 'number'
+    },
+    'merge-commit-filter': {
+      alias: 'm',
+      type: 'string'
     },
     verbose: {
       alias: 'v',

--- a/packages/standard-changelog/test/cli.js
+++ b/packages/standard-changelog/test/cli.js
@@ -324,13 +324,13 @@ describe('standard-changelog cli', function () {
     it('include', function (done) {
       doGitFlow()
 
-      var cp = spawn(process.execPath, [cliPath, '-m', 'include', '--first-release'], {
+      const cp = spawn(process.execPath, [cliPath, '-m', 'include', '--first-release'], {
         stdio: [process.stdin, null, null]
       })
 
       cp.on('close', function (code) {
         expect(code).to.equal(0)
-        var modified = readFileSync('CHANGELOG.md', 'utf8')
+        const modified = readFileSync('CHANGELOG.md', 'utf8')
         expect(modified).to.include('First commit')
         expect(modified).to.include('[0.0.17]')
         expect(modified).to.include('Test commit')
@@ -343,13 +343,13 @@ describe('standard-changelog cli', function () {
     it('only-merges', function (done) {
       doGitFlow()
 
-      var cp = spawn(process.execPath, [cliPath, '-m', 'only-merges', '--first-release'], {
+      const cp = spawn(process.execPath, [cliPath, '-m', 'only-merges', '--first-release'], {
         stdio: [process.stdin, null, null]
       })
 
       cp.on('close', function (code) {
         expect(code).to.equal(0)
-        var modified = readFileSync('CHANGELOG.md', 'utf8')
+        const modified = readFileSync('CHANGELOG.md', 'utf8')
         expect(modified).to.not.include('First commit')
         expect(modified).to.not.include('[0.0.17]')
         expect(modified).to.include('Test commit')
@@ -362,13 +362,13 @@ describe('standard-changelog cli', function () {
     it('exclude', function (done) {
       doGitFlow()
 
-      var cp = spawn(process.execPath, [cliPath, '-m', 'exclude', '--first-release'], {
+      const cp = spawn(process.execPath, [cliPath, '-m', 'exclude', '--first-release'], {
         stdio: [process.stdin, null, null]
       })
 
       cp.on('close', function (code) {
         expect(code).to.equal(0)
-        var modified = readFileSync('CHANGELOG.md', 'utf8')
+        const modified = readFileSync('CHANGELOG.md', 'utf8')
         expect(modified).to.include('First commit')
         expect(modified).to.include('[0.0.17]')
         expect(modified).to.include('Test commit') // will still be added under the current date but not tag

--- a/packages/standard-changelog/test/cli.js
+++ b/packages/standard-changelog/test/cli.js
@@ -303,6 +303,7 @@ describe('standard-changelog cli', function () {
 
   describe('generates changelog respecting --merge-commit-filter', function () {
     function doGitFlow () {
+      shell.rm('-rf', 'CHANGELOG.md')
       shell.exec('git tag -a v0.0.17 -m "old release"')
       shell.exec('git checkout -b "feature/some-feature"')
       shell.exec('> test.txt && git add test.txt')
@@ -324,7 +325,7 @@ describe('standard-changelog cli', function () {
       doGitFlow()
 
       var cp = spawn(process.execPath, [cliPath, '-m', 'include', '--first-release'], {
-        stdio: [process.stdin, process.stdout, null]
+        stdio: [process.stdin, null, null]
       })
 
       cp.on('close', function (code) {
@@ -343,7 +344,7 @@ describe('standard-changelog cli', function () {
       doGitFlow()
 
       var cp = spawn(process.execPath, [cliPath, '-m', 'only-merges', '--first-release'], {
-        stdio: [process.stdin, process.stdout, null]
+        stdio: [process.stdin, null, null]
       })
 
       cp.on('close', function (code) {
@@ -362,7 +363,7 @@ describe('standard-changelog cli', function () {
       doGitFlow()
 
       var cp = spawn(process.execPath, [cliPath, '-m', 'exclude', '--first-release'], {
-        stdio: [process.stdin, process.stdout, null]
+        stdio: [process.stdin, null, null]
       })
 
       cp.on('close', function (code) {
@@ -370,7 +371,7 @@ describe('standard-changelog cli', function () {
         var modified = readFileSync('CHANGELOG.md', 'utf8')
         expect(modified).to.include('First commit')
         expect(modified).to.include('[0.0.17]')
-        expect(modified).to.include('Test commit') // will still be added to the initial
+        expect(modified).to.include('Test commit') // will still be added under the current date but not tag
         expect(modified).to.not.include('[0.0.18]')
         undoGitFlow()
         done()


### PR DESCRIPTION
This PR re-uses PR #595 and rebases with the upstream master. All credit goes to [mediavrog](https://github.com/mediavrog) 

In addition `var`-variables were changed to `const` in order to stay consistent with the code-base