### PR TITLE
fix: avoid config mutating with default params (fixes #930)

### DIFF
--- a/packages/conventional-changelog-conventionalcommits/parser-opts.js
+++ b/packages/conventional-changelog-conventionalcommits/parser-opts.js
@@ -19,7 +19,7 @@ module.exports = function (config) {
 
 // merge user set configuration with default configuration.
 function defaultConfig (config) {
-  config = config || {}
+  config = { ...config }
   config.issuePrefixes = config.issuePrefixes || ['#']
   return config
 }

--- a/packages/conventional-changelog-conventionalcommits/parser-opts.js
+++ b/packages/conventional-changelog-conventionalcommits/parser-opts.js
@@ -1,7 +1,13 @@
 'use strict'
+const _ = require('lodash')
+
+const defaultConfig = {
+  issuePrefixes: ['#']
+}
 
 module.exports = function (config) {
-  config = defaultConfig(config)
+  const readyConfig = _.defaults(config, defaultConfig)
+
   return {
     headerPattern: /^(\w*)(?:\((.*)\))?!?: (.*)$/,
     breakingHeaderPattern: /^(\w*)(?:\((.*)\))?!: (.*)$/,
@@ -13,13 +19,6 @@ module.exports = function (config) {
     noteKeywords: ['BREAKING CHANGE', 'BREAKING-CHANGE'],
     revertPattern: /^(?:Revert|revert:)\s"?([\s\S]+?)"?\s*This reverts commit (\w*)\./i,
     revertCorrespondence: ['header', 'hash'],
-    issuePrefixes: config.issuePrefixes
+    issuePrefixes: readyConfig.issuePrefixes
   }
-}
-
-// merge user set configuration with default configuration.
-function defaultConfig (config) {
-  config = { ...config }
-  config.issuePrefixes = config.issuePrefixes || ['#']
-  return config
 }

--- a/packages/conventional-changelog-conventionalcommits/writer-opts.js
+++ b/packages/conventional-changelog-conventionalcommits/writer-opts.js
@@ -175,7 +175,7 @@ function getWriterOpts (config) {
 
 // merge user set configuration with default configuration.
 function defaultConfig (config) {
-  config = config || {}
+  config = { ...config }
   config.types = config.types || [
     { type: 'feat', section: 'Features' },
     { type: 'feature', section: 'Features' },


### PR DESCRIPTION
This PR fixes #930. Avoid mutating `lerna.json` with default `changelogPreset` params
![image](https://user-images.githubusercontent.com/5180700/176998442-a22cc336-4bc0-4beb-aa89-4356d66185f7.png)

It'd be wise to add `no-param-reassign` eslint rule and fix this code smell everywhere, but I'd rather like to ask your opinion about this guys.

Thank you.