### PR TITLE
feat(conventional-changelog-conventionalcommits): add option to remove duplicate issues

### DIFF
--- a/packages/conventional-changelog-conventionalcommits/test/test.js
+++ b/packages/conventional-changelog-conventionalcommits/test/test.js
@@ -86,6 +86,9 @@ betterThanBefore.setups([
       'chore: release at different version',
       'Release-As: v3.0.2'
     ])
+  },
+  function () {
+    gitDummyCommit(['feat(awesome): remove duplicates', 'fixes A of #107', 'fixes B of #107', ' closes #107'])
   }
 ])
 
@@ -611,6 +614,24 @@ describe('conventionalcommits.org preset', function () {
       .pipe(through(function (chunk) {
         chunk = chunk.toString()
         expect(chunk).to.match(/release at different version/)
+        done()
+      }))
+  })
+  it('should remove all duplicate issues', function (done) {
+    preparing(12)
+
+    conventionalChangelogCore({
+      config: getPreset({
+        removeDuplicateIssues: true
+      })
+    })
+      .on('error', function (err) {
+        done(err)
+      })
+      .pipe(through(function (chunk) {
+        chunk = chunk.toString()
+        const matches = [...chunk.matchAll(/\[#107\]\(.*\)/g)]
+        expect(chunk).to.satisfy(() => matches.length === 1)
         done()
       }))
   })

--- a/packages/conventional-changelog-conventionalcommits/writer-opts.js
+++ b/packages/conventional-changelog-conventionalcommits/writer-opts.js
@@ -144,13 +144,26 @@ function getWriterOpts (config) {
       }
 
       // remove references that already appear in the subject
-      commit.references = commit.references.filter(reference => {
-        if (issues.indexOf(reference.prefix + reference.issue) === -1) {
-          return true
-        }
+      if (config.removeIssuesShownInSubject) {
+        commit.references = commit.references.filter(reference => {
+          if (issues.indexOf(reference.prefix + reference.issue) === -1) {
+            return true
+          }
 
-        return false
-      })
+          return false
+        })
+      }
+
+      // remove references with duplicate issues
+      if (config.removeDuplicateIssues) {
+        commit.references = commit.references.reduce(
+          (uniqueReferences, reference) =>
+            uniqueReferences.find(({ issue }) => issue === reference.issue)
+              ? uniqueReferences
+              : [...uniqueReferences, reference],
+          []
+        )
+      }
 
       return commit
     },
@@ -199,6 +212,8 @@ function defaultConfig (config) {
   config.userUrlFormat = config.userUrlFormat ||
     '{{host}}/{{user}}'
   config.issuePrefixes = config.issuePrefixes || ['#']
+  config.removeIssuesShownInSubject = config.removeIssuesShownInSubject || true
+  config.removeDuplicateIssues = config.removeDuplicateIssues || false
 
   return config
 }


### PR DESCRIPTION
Fix https://github.com/conventional-changelog/conventional-changelog/issues/926 by providing an option to remove duplicate issues.