### PR TITLE
feat(git-raw-commits): Support multiple path filters

### DIFF
--- a/packages/git-raw-commits/index.js
+++ b/packages/git-raw-commits/index.js
@@ -29,13 +29,16 @@ function getGitArgs (gitOpts) {
 
   const gitArgs = ['log', gitFormat, gitFromTo]
     .concat(dargs(gitOpts, {
-      excludes: ['debug', 'from', 'to', 'format', 'path']
+      excludes: ['debug', 'from', 'to', 'format', 'path', 'paths']
     }))
 
   // allow commits to focus on a single directory
   // this is useful for monorepos.
   if (gitOpts.path) {
     gitArgs.push('--', gitOpts.path)
+  }
+  if (gitOpts.paths) {
+    gitOpts.paths.forEach(path => gitArgs.push('--', path))
   }
 
   return gitArgs

--- a/packages/git-raw-commits/index.js
+++ b/packages/git-raw-commits/index.js
@@ -29,16 +29,17 @@ function getGitArgs (gitOpts) {
 
   const gitArgs = ['log', gitFormat, gitFromTo]
     .concat(dargs(gitOpts, {
-      excludes: ['debug', 'from', 'to', 'format', 'path', 'paths']
+      excludes: ['debug', 'from', 'to', 'format', 'path']
     }))
 
   // allow commits to focus on a single directory
   // this is useful for monorepos.
   if (gitOpts.path) {
-    gitArgs.push('--', gitOpts.path)
-  }
-  if (gitOpts.paths) {
-    gitOpts.paths.forEach(path => gitArgs.push('--', path))
+    if (Array.isArray(gitOpts.path)) {
+      gitOpts.path.forEach(path => gitArgs.push('--', path))
+    } else {
+      gitArgs.push('--', gitOpts.path)
+    }
   }
 
   return gitArgs

--- a/packages/git-raw-commits/test.js
+++ b/packages/git-raw-commits/test.js
@@ -239,42 +239,13 @@ describe('git-raw-commits', function () {
 
     let chunks = []
     gitRawCommits({
-      paths: ['./packages/foo', './packages/common'],
+      path: ['./packages/foo', './packages/common'],
     })
       .pipe(through(function (chunk, enc, cb) {
         chunks.push(chunk.toString())
         cb()
       }, function () {
         expect(chunks).to.have.ordered.members([
-          'Seventh commit\n\n',
-          'Fifth commit\n\n',
-          'Fourth commit\n\n',
-          'First commit\n\n',
-        ])
-        done()
-      }))
-  })
-
-  it('should allow commits to be scoped using both path and paths', function (done) {
-    try {
-      fs.mkdirSync('./packages/other', { recursive: true })
-      writeFileSync('./packages/other/test1', 'hello')
-      exec('git add --all && git commit -m"Eighth commit"')
-    } catch(e) {
-      fail(e)
-    }
-
-    let chunks = []
-    gitRawCommits({
-      path: './packages/foo',
-      paths: ['./packages/other', './packages/common'],
-    })
-      .pipe(through(function (chunk, enc, cb) {
-        chunks.push(chunk.toString())
-        cb()
-      }, function () {
-        expect(chunks).to.have.ordered.members([
-          'Eighth commit\n\n',
           'Seventh commit\n\n',
           'Fifth commit\n\n',
           'Fourth commit\n\n',


### PR DESCRIPTION
This PR updates the `gitOpts` object passed to `git-raw-commits` to support multiple values being passed in to the `path` param. This can be done by either passing `gitOpts.path` as an array when using this via JavaScript, or by passing multiple `--path` values via the cli (e.g. `node .\cli.js --path ./CHANGELOG.md --path ./README.md`).

Fixes #944