### PR TITLE
feat(conventionalcommits): enable glob patterns "scope" and "type" in types

### DIFF
--- a/packages/conventional-changelog-conventionalcommits/package.json
+++ b/packages/conventional-changelog-conventionalcommits/package.json
@@ -34,6 +34,7 @@
   },
   "homepage": "https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-conventionalcommits#readme",
   "dependencies": {
-    "compare-func": "^2.0.0"
+    "compare-func": "^2.0.0",
+    "minimatch": "^9.0.0"
   }
 }

--- a/packages/conventional-changelog-conventionalcommits/test/test.js
+++ b/packages/conventional-changelog-conventionalcommits/test/test.js
@@ -90,6 +90,9 @@ betterThanBefore.setups([
       'chore: release at different version',
       'Release-As: v3.0.2'
     ])
+  },
+  function () {
+    gitDummyCommit('fix(awesome): fix the awesome thing')
   }
 ])
 
@@ -206,6 +209,36 @@ describe('conventionalcommits.org preset', function () {
         expect(chunk).to.include('**deps:** upgrade example from 1 to 2')
 
         expect(chunk).to.not.include('release 0.0.0')
+        done()
+      }))
+  })
+
+  it('should allow matching "scope" to configuration using glob patterns', function (done) {
+    preparing(1)
+    conventionalChangelogCore({
+      config: require('../')({
+        types: [
+          { type: 'feat', scope: '!changelog', section: 'Features' },
+          { type: 'fix', scope: '!{changelog,awesome}', section: 'Bug Fixes' }
+        ]
+      })
+    })
+      .on('error', function (err) {
+        done(err)
+      })
+      .pipe(through(function (chunk) {
+        chunk = chunk.toString()
+
+        expect(chunk).to.include('### Features')
+        expect(chunk).to.include('**awesome:** adress EXAMPLE-1')
+
+        expect(chunk).to.not.include('proper issue links')
+
+        expect(chunk).to.include('### Bug Fixes')
+        expect(chunk).to.include('oops')
+
+        expect(chunk).to.not.include('**awesome:** fix the awesome thing')
+        expect(chunk).to.not.include('proper issue links')
         done()
       }))
   })

--- a/packages/conventional-changelog-conventionalcommits/test/test.js
+++ b/packages/conventional-changelog-conventionalcommits/test/test.js
@@ -190,6 +190,28 @@ describe('conventionalcommits.org preset', function () {
       }))
   })
 
+  it('should allow matching "type" to configuration using glob patterns', function (done) {
+    preparing(1)
+    conventionalChangelogCore({
+      config: require('../')({
+        types: [
+          { type: '{chore,ci}', section: 'Chores and CI' }
+        ]
+      })
+    })
+      .on('error', function (err) {
+        done(err)
+      })
+      .pipe(through(function (chunk) {
+        chunk = chunk.toString()
+
+        expect(chunk).to.include('### Chores and CI')
+        expect(chunk).to.include('add TravisCI pipeline')
+        expect(chunk).to.include('upgrade example from 1 to 2')
+        done()
+      }))
+  })
+
   it('should allow matching "scope" to configuration', function (done) {
     preparing(1)
     conventionalChangelogCore({

--- a/packages/conventional-changelog-conventionalcommits/writer-opts.js
+++ b/packages/conventional-changelog-conventionalcommits/writer-opts.js
@@ -4,6 +4,7 @@ const addBangNotes = require('./add-bang-notes')
 const compareFunc = require('compare-func')
 const { readFile } = require('fs').promises
 const { resolve } = require('path')
+const { minimatch } = require('minimatch')
 const releaseAsRe = /release-as:\s*\w*@?([0-9]+\.[0-9]+\.[0-9a-z]+(-[0-9a-z.]+)?)\s*/i
 
 /**
@@ -63,7 +64,10 @@ function findTypeEntry (types, commit) {
     if (entry.type !== typeKey) {
       return false
     }
-    if (entry.scope && entry.scope !== commit.scope) {
+    if (
+      entry.scope &&
+      (!commit.scope || !minimatch(commit.scope, entry.scope))
+    ) {
       return false
     }
     return true

--- a/packages/conventional-changelog-conventionalcommits/writer-opts.js
+++ b/packages/conventional-changelog-conventionalcommits/writer-opts.js
@@ -61,7 +61,7 @@ module.exports = async (config) => {
 function findTypeEntry (types, commit) {
   const typeKey = (commit.revert ? 'revert' : (commit.type || '')).toLowerCase()
   return types.find((entry) => {
-    if (entry.type !== typeKey) {
+    if (!minimatch(typeKey, entry.type)) {
       return false
     }
     if (

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -103,8 +103,10 @@ importers:
   packages/conventional-changelog-conventionalcommits:
     specifiers:
       compare-func: ^2.0.0
+      minimatch: ^9.0.0
     dependencies:
       compare-func: 2.0.0
+      minimatch: 9.0.0
 
   packages/conventional-changelog-core:
     specifiers:
@@ -637,6 +639,12 @@ packages:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
+
+  /brace-expansion/2.0.1:
+    resolution: {integrity: sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==}
+    dependencies:
+      balanced-match: 1.0.2
+    dev: false
 
   /braces/3.0.2:
     resolution: {integrity: sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==}
@@ -1535,7 +1543,7 @@ packages:
       fs.realpath: 1.0.0
       inflight: 1.0.6
       inherits: 2.0.4
-      minimatch: 3.0.4
+      minimatch: 3.1.2
       once: 1.4.0
       path-is-absolute: 1.0.1
     dev: true
@@ -2153,6 +2161,13 @@ packages:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
     dependencies:
       brace-expansion: 1.1.11
+
+  /minimatch/9.0.0:
+    resolution: {integrity: sha512-0jJj8AvgKqWN05mrwuqi8QYKx1WmYSUoKSxu5Qhs9prezTz10sxAHGNZe9J9cqIJzta8DWsleh2KaVaLl6Ru2w==}
+    engines: {node: '>=16 || 14 >=14.17'}
+    dependencies:
+      brace-expansion: 2.0.1
+    dev: false
 
   /minimist-options/4.1.0:
     resolution: {integrity: sha512-Q4r8ghd80yhO/0j1O3B2BjweX3fiHg9cdOwjJd2J76Q135c+NDxGCqdYKQ1SKBuFfgWbAUzBfvYjPUEeNgqN1A==}


### PR DESCRIPTION
This PR adds the ability to specify types with `scope`s and `type`s that match glob patterns, e.g.

```js
types: [
  {
    type: '*',
    scope: '!foo',
    hidden: true,
  },
  ...
```