### PR TITLE
fix: properly deep clones the commit before modifying it

### DIFF
--- a/packages/conventional-changelog-writer/lib/util.js
+++ b/packages/conventional-changelog-writer/lib/util.js
@@ -151,6 +151,30 @@ function immutableSet (context, path, value) {
   }
 }
 
+function cloneCommit (commit) {
+  if (!commit || typeof commit !== 'object') {
+    return commit
+  } else
+  if (Array.isArray(commit)) {
+    return commit.map(cloneCommit)
+  }
+
+  const commitClone = {}
+  let value
+
+  for (const key in commit) {
+    value = commit[key]
+
+    if (typeof value === 'object') {
+      commitClone[key] = cloneCommit(value)
+    } else {
+      commitClone[key] = value
+    }
+  }
+
+  return commitClone
+}
+
 function processCommit (chunk, transform, context) {
   let commit
 
@@ -158,8 +182,7 @@ function processCommit (chunk, transform, context) {
     chunk = JSON.parse(chunk)
   } catch (e) {}
 
-  // ensure two 100% separate objects (for saving to raw)
-  commit = JSON.parse(JSON.stringify(chunk))
+  commit = cloneCommit(chunk)
 
   if (typeof transform === 'function') {
     commit = transform(commit, context)

--- a/packages/conventional-changelog-writer/lib/util.js
+++ b/packages/conventional-changelog-writer/lib/util.js
@@ -158,9 +158,8 @@ function processCommit (chunk, transform, context) {
     chunk = JSON.parse(chunk)
   } catch (e) {}
 
-  commit = {
-    ...chunk
-  }
+  // ensure two 100% separate objects (for saving to raw)
+  commit = JSON.parse(JSON.stringify(chunk))
 
   if (typeof transform === 'function') {
     commit = transform(commit, context)

--- a/packages/conventional-changelog-writer/test/index.spec.js
+++ b/packages/conventional-changelog-writer/test/index.spec.js
@@ -239,6 +239,7 @@ describe('conventionalChangelogWriter', function () {
       })
       // the original commit should not be changed
       expect(commits[1].notes[0].title).to.equal('BREAKING CHANGE')
+      done()
     })
 
     it('should merge with the provided transform object', function (done) {

--- a/packages/conventional-changelog-writer/test/index.spec.js
+++ b/packages/conventional-changelog-writer/test/index.spec.js
@@ -220,6 +220,27 @@ describe('conventionalChangelogWriter', function () {
         }))
     })
 
+    it('should leave the original commits objects unchanged', function (done) {
+      expect(commits[1].notes[0].title).to.equal('BREAKING CHANGE')
+      conventionalChangelogWriter.parseArray(commits, {}, {
+        transform: {
+          notes: function (notes) {
+            notes.map(function (note) {
+              if (note.title === 'BREAKING CHANGE') {
+                note.title = 'BREAKING CHANGES'
+              }
+
+              return note
+            })
+
+            return notes
+          }
+        }
+      })
+      // the original commit should not be changed
+      expect(commits[1].notes[0].title).to.equal('BREAKING CHANGE')
+    })
+
     it('should merge with the provided transform object', function (done) {
       let i = 0
       const changelog = conventionalChangelogWriter.parseArray(commits, {}, {


### PR DESCRIPTION
Includes a test that failed prior to this fix.

fixes #1043