### PR TITLE
feat(conventional-changelog-writer): support async `options.transform` and `options.finalizeContext` #471

### DIFF
--- a/packages/conventional-changelog-angular/conventionalRecommendedBump.js
+++ b/packages/conventional-changelog-angular/conventionalRecommendedBump.js
@@ -22,7 +22,7 @@ function createConventionalRecommendedBumpOpts (parserOpts) {
       })
 
       return {
-        level: level,
+        level,
         reason: breakings === 1
           ? `There is ${breakings} BREAKING CHANGE and ${features} features`
           : `There are ${breakings} BREAKING CHANGES and ${features} features`

--- a/packages/conventional-changelog-atom/conventionalRecommendedBump.js
+++ b/packages/conventional-changelog-atom/conventionalRecommendedBump.js
@@ -22,7 +22,7 @@ function createConventionalRecommendedBumpOpts (parserOpts) {
       })
 
       return {
-        level: level,
+        level,
         reason: `There are ${breakings} BREAKING CHANGES and ${features} features`
       }
     }

--- a/packages/conventional-changelog-codemirror/conventionalRecommendedBump.js
+++ b/packages/conventional-changelog-codemirror/conventionalRecommendedBump.js
@@ -22,7 +22,7 @@ function createConventionalRecommendedBumpOpts (parserOpts) {
       })
 
       return {
-        level: level,
+        level,
         reason: `There are ${breakings} BREAKING CHANGES and ${features} features`
       }
     }

--- a/packages/conventional-changelog-ember/conventionalRecommendedBump.js
+++ b/packages/conventional-changelog-ember/conventionalRecommendedBump.js
@@ -22,7 +22,7 @@ function createConventionalRecommendedBumpOpts (parserOpts) {
       })
 
       return {
-        level: level,
+        level,
         reason: `There are ${breakings} BREAKING CHANGES and ${features} features`
       }
     }

--- a/packages/conventional-changelog-eslint/conventionalRecommendedBump.js
+++ b/packages/conventional-changelog-eslint/conventionalRecommendedBump.js
@@ -24,7 +24,7 @@ function createConventionalRecommendedBumpOpts (parserOpts) {
       })
 
       return {
-        level: level,
+        level,
         reason: `There are ${breakings} breaking changes and ${features} features`
       }
     }

--- a/packages/conventional-changelog-express/conventionalRecommendedBump.js
+++ b/packages/conventional-changelog-express/conventionalRecommendedBump.js
@@ -22,7 +22,7 @@ function createConventionalRecommendedBumpOpts (parserOpts) {
       })
 
       return {
-        level: level,
+        level,
         reason: `There are ${breakings} BREAKING CHANGES and ${features} features`
       }
     }

--- a/packages/conventional-changelog-jquery/conventionalRecommendedBump.js
+++ b/packages/conventional-changelog-jquery/conventionalRecommendedBump.js
@@ -22,7 +22,7 @@ function createConventionalRecommendedBumpOpts (parserOpts) {
       })
 
       return {
-        level: level,
+        level,
         reason: `There are ${breakings} BREAKING CHANGES and ${features} features`
       }
     }

--- a/packages/conventional-changelog-jshint/conventionalRecommendedBump.js
+++ b/packages/conventional-changelog-jshint/conventionalRecommendedBump.js
@@ -22,7 +22,7 @@ function createConventionalRecommendedBumpOpts (parserOpts) {
       })
 
       return {
-        level: level,
+        level,
         reason: `There are ${breakings} BREAKING CHANGES and ${features} features`
       }
     }

--- a/packages/conventional-changelog-writer/index.js
+++ b/packages/conventional-changelog-writer/index.js
@@ -100,7 +100,7 @@ function conventionalChangelogWriterParseStream (context, options) {
     async transform (chunk, _enc, cb) {
       try {
         let result
-        const commit = util.processCommit(chunk, options.transform, context)
+        const commit = await util.processCommit(chunk, options.transform, context)
         const keyCommit = commit || chunk
 
         // previous blocks of logs
@@ -194,7 +194,7 @@ conventionalChangelogWriterParseStream.parseArray = async (rawCommits, context, 
   }
   const entries = []
   for (const rawCommit of rawCommits) {
-    const commit = util.processCommit(rawCommit, await options.transform, context)
+    const commit = await util.processCommit(rawCommit, options.transform, context)
     const keyCommit = commit || rawCommit
     if (generateOn(keyCommit, commits, context, options)) {
       entries.push(await util.generate(options, commits, context, savedKeyCommit))

--- a/packages/conventional-changelog-writer/lib/util.js
+++ b/packages/conventional-changelog-writer/lib/util.js
@@ -81,8 +81,8 @@ function getCommitGroups (groupBy, commits, groupsSort, commitsSort) {
     }
 
     commitGroups.push({
-      title: title,
-      commits: commits
+      title,
+      commits
     })
   })
 
@@ -110,7 +110,7 @@ function getNoteGroups (notes, noteGroupsSort, notesSort) {
 
     if (!titleExists) {
       retGroups.push({
-        title: title,
+        title,
         notes: [note]
       })
     }
@@ -225,7 +225,7 @@ function getExtraContext (commits, notes, options) {
   return context
 }
 
-function generate (options, commits, context, keyCommit) {
+async function generate (options, commits, context, keyCommit) {
   const notes = []
   let filteredCommits
   const compiled = compileTemplates(options)
@@ -264,18 +264,18 @@ function generate (options, commits, context, keyCommit) {
     context.isPatch = context.isPatch || semver.patch(context.version) !== 0
   }
 
-  context = options.finalizeContext(context, options, filteredCommits, keyCommit, commits)
+  context = await options.finalizeContext(context, options, filteredCommits, keyCommit, commits)
   options.debug('Your final context is:\n' + stringify(context, null, 2))
 
   return compiled(context)
 }
 
 module.exports = {
-  compileTemplates: compileTemplates,
-  functionify: functionify,
-  getCommitGroups: getCommitGroups,
-  getNoteGroups: getNoteGroups,
-  processCommit: processCommit,
-  getExtraContext: getExtraContext,
-  generate: generate
+  compileTemplates,
+  functionify,
+  getCommitGroups,
+  getNoteGroups,
+  processCommit,
+  getExtraContext,
+  generate
 }

--- a/packages/conventional-changelog-writer/lib/util.js
+++ b/packages/conventional-changelog-writer/lib/util.js
@@ -175,7 +175,7 @@ function cloneCommit (commit) {
   return commitClone
 }
 
-function processCommit (chunk, transform, context) {
+async function processCommit (chunk, transform, context) {
   let commit
 
   try {
@@ -185,7 +185,7 @@ function processCommit (chunk, transform, context) {
   commit = cloneCommit(chunk)
 
   if (typeof transform === 'function') {
-    commit = transform(commit, context)
+    commit = await transform(commit, context)
 
     if (commit) {
       commit.raw = chunk

--- a/packages/conventional-changelog-writer/test/index.spec.js
+++ b/packages/conventional-changelog-writer/test/index.spec.js
@@ -1,7 +1,7 @@
 import dedent from 'dedent'
 import { describe, it, expect } from 'vitest'
 import { delay, throughObj } from '../../../tools/test-tools'
-import conventionalChangelogWriter from '../'
+import conventionalChangelogWriter, { parseArray } from '../'
 
 // sv-SEis used for yyyy-mm-dd format
 const dateFormatter = Intl.DateTimeFormat('sv-SE', {
@@ -99,7 +99,7 @@ describe('conventional-changelog-writer', () => {
         host: 'https://github.com',
         repository: 'a/b'
       }
-      const changelog = await conventionalChangelogWriter.parseArray(commits, context)
+      const changelog = await parseArray(commits, context)
 
       expect(changelog).toContain('https://github.com/a/b/commits/13f3160')
 
@@ -119,7 +119,7 @@ describe('conventional-changelog-writer', () => {
         title: 'this is a title',
         repoUrl: 'https://github.com/a/b'
       }
-      const changelog = await conventionalChangelogWriter.parseArray(commits, context)
+      const changelog = await parseArray(commits, context)
 
       expect(changelog).toContain('https://github.com/a/b/commits/13f3160')
 
@@ -134,7 +134,7 @@ describe('conventional-changelog-writer', () => {
 
     it('should not auto link', async () => {
       let i = 0
-      const changelog = await conventionalChangelogWriter.parseArray(commits, {})
+      const changelog = await parseArray(commits, {})
 
       expect(changelog).not.toContain('https://github.com/a/b/commits/13f3160')
 
@@ -156,7 +156,7 @@ describe('conventional-changelog-writer', () => {
         repository: 'a/b',
         linkReferences: false
       }
-      const changelog = await conventionalChangelogWriter.parseArray(commits, context)
+      const changelog = await parseArray(commits, context)
 
       expect(changelog).not.toContain('https://github.com/a/b/commits/13f3160')
 
@@ -175,7 +175,7 @@ describe('conventional-changelog-writer', () => {
       let i = 0
       let called = false
 
-      await conventionalChangelogWriter.parseArray(commits, {}, {
+      await parseArray(commits, {}, {
         transform (commit, context) {
           expect(context).toEqual({
             commit: 'commits',
@@ -208,7 +208,7 @@ describe('conventional-changelog-writer', () => {
 
     it('should leave the original commits objects unchanged', async () => {
       expect(commits[1].notes[0].title).toBe('BREAKING CHANGE')
-      await conventionalChangelogWriter.parseArray(commits, {}, {
+      await parseArray(commits, {}, {
         transform: {
           notes (notes) {
             notes.map((note) => {
@@ -229,7 +229,7 @@ describe('conventional-changelog-writer', () => {
 
     it('should merge with the provided transform object', async () => {
       let i = 0
-      const changelog = await conventionalChangelogWriter.parseArray(commits, {}, {
+      const changelog = await parseArray(commits, {}, {
         transform: {
           notes (notes) {
             notes.map((note) => {
@@ -277,7 +277,7 @@ describe('conventional-changelog-writer', () => {
 
     it('should ignore the commit if tranform returns `null`', async () => {
       let i = 0
-      const changelog = await conventionalChangelogWriter.parseArray(commits, {}, {
+      const changelog = await parseArray(commits, {}, {
         transform () {
           return false
         }
@@ -299,11 +299,11 @@ describe('conventional-changelog-writer', () => {
       expect(i).toBe(1)
     })
 
-    it('support tranform commits async', async () => {
-      const changelog = await conventionalChangelogWriter.parseArray(commits, {}, {
+    it('should support tranform commits async', async () => {
+      const changelog = await parseArray(commits, {}, {
         async transform () {
           await delay(100)
-          return [{
+          return {
             hash: '9b1aff905b638aa274a5fc8f88662df446d374bd',
             header: 'feat(scope): broadcast $destroy event on scope destruction',
             body: null,
@@ -311,7 +311,7 @@ describe('conventional-changelog-writer', () => {
               title: 'BREAKING CHANGE',
               text: 'some breaking change'
             }]
-          }]
+          }
         }
       })
 
@@ -368,7 +368,7 @@ describe('conventional-changelog-writer', () => {
 
     it('should generate on the transformed commit', async () => {
       let i = 0
-      const changelog = await conventionalChangelogWriter.parseArray(commits, {
+      const changelog = await parseArray(commits, {
         version: '1.0.0'
       }, {
         transform (commit) {
@@ -398,7 +398,7 @@ describe('conventional-changelog-writer', () => {
     describe('when commits are not reversed', () => {
       it('should generate on `\'version\'` if it\'s a valid semver', async () => {
         let i = 0
-        const changelog = await conventionalChangelogWriter.parseArray(commits)
+        const changelog = await parseArray(commits)
 
         expect(changelog).toContain('##  (' + today)
         expect(changelog).toContain('feat(scope): ')
@@ -479,7 +479,7 @@ describe('conventional-changelog-writer', () => {
 
         upstream.end()
 
-        const changelog = await conventionalChangelogWriter.parseArray(commits, {}, {
+        const changelog = await parseArray(commits, {}, {
           generateOn: 'version'
         })
 
@@ -561,7 +561,7 @@ describe('conventional-changelog-writer', () => {
       it('version should fall back on `context.version` and `context.date`', async () => {
         let i = 0
 
-        const changelog = await conventionalChangelogWriter.parseArray(commits, {
+        const changelog = await parseArray(commits, {
           version: '0.0.1',
           date: '2015-01-01'
         })
@@ -761,7 +761,7 @@ describe('conventional-changelog-writer', () => {
 
         upstream.end()
 
-        const changelog = await conventionalChangelogWriter.parseArray(commits, {}, {
+        const changelog = await parseArray(commits, {}, {
           reverse: true
         })
 

--- a/packages/conventional-changelog-writer/test/index.spec.js
+++ b/packages/conventional-changelog-writer/test/index.spec.js
@@ -229,7 +229,7 @@ describe('conventional-changelog-writer', () => {
 
     it('should merge with the provided transform object', async () => {
       let i = 0
-      const changelog = await await conventionalChangelogWriter.parseArray(commits, {}, {
+      const changelog = await conventionalChangelogWriter.parseArray(commits, {}, {
         transform: {
           notes (notes) {
             notes.map((note) => {
@@ -349,7 +349,7 @@ describe('conventional-changelog-writer', () => {
 
     it('should generate on the transformed commit', async () => {
       let i = 0
-      const changelog = await await conventionalChangelogWriter.parseArray(commits, {
+      const changelog = await conventionalChangelogWriter.parseArray(commits, {
         version: '1.0.0'
       }, {
         transform (commit) {
@@ -542,7 +542,7 @@ describe('conventional-changelog-writer', () => {
       it('version should fall back on `context.version` and `context.date`', async () => {
         let i = 0
 
-        const changelog = await await conventionalChangelogWriter.parseArray(commits, {
+        const changelog = await conventionalChangelogWriter.parseArray(commits, {
           version: '0.0.1',
           date: '2015-01-01'
         })

--- a/packages/conventional-changelog-writer/test/index.spec.js
+++ b/packages/conventional-changelog-writer/test/index.spec.js
@@ -99,7 +99,7 @@ describe('conventional-changelog-writer', () => {
         host: 'https://github.com',
         repository: 'a/b'
       }
-      const changelog = conventionalChangelogWriter.parseArray(commits, context)
+      const changelog = await conventionalChangelogWriter.parseArray(commits, context)
 
       expect(changelog).toContain('https://github.com/a/b/commits/13f3160')
 
@@ -119,7 +119,7 @@ describe('conventional-changelog-writer', () => {
         title: 'this is a title',
         repoUrl: 'https://github.com/a/b'
       }
-      const changelog = conventionalChangelogWriter.parseArray(commits, context)
+      const changelog = await conventionalChangelogWriter.parseArray(commits, context)
 
       expect(changelog).toContain('https://github.com/a/b/commits/13f3160')
 
@@ -134,7 +134,7 @@ describe('conventional-changelog-writer', () => {
 
     it('should not auto link', async () => {
       let i = 0
-      const changelog = conventionalChangelogWriter.parseArray(commits, {})
+      const changelog = await conventionalChangelogWriter.parseArray(commits, {})
 
       expect(changelog).not.toContain('https://github.com/a/b/commits/13f3160')
 
@@ -156,7 +156,7 @@ describe('conventional-changelog-writer', () => {
         repository: 'a/b',
         linkReferences: false
       }
-      const changelog = conventionalChangelogWriter.parseArray(commits, context)
+      const changelog = await conventionalChangelogWriter.parseArray(commits, context)
 
       expect(changelog).not.toContain('https://github.com/a/b/commits/13f3160')
 
@@ -175,7 +175,7 @@ describe('conventional-changelog-writer', () => {
       let i = 0
       let called = false
 
-      conventionalChangelogWriter.parseArray(commits, {}, {
+      await conventionalChangelogWriter.parseArray(commits, {}, {
         transform (commit, context) {
           expect(context).toEqual({
             commit: 'commits',
@@ -206,9 +206,9 @@ describe('conventional-changelog-writer', () => {
       expect(i).toBe(1)
     })
 
-    it('should leave the original commits objects unchanged', () => {
+    it('should leave the original commits objects unchanged', async () => {
       expect(commits[1].notes[0].title).toBe('BREAKING CHANGE')
-      conventionalChangelogWriter.parseArray(commits, {}, {
+      await conventionalChangelogWriter.parseArray(commits, {}, {
         transform: {
           notes (notes) {
             notes.map((note) => {
@@ -229,7 +229,7 @@ describe('conventional-changelog-writer', () => {
 
     it('should merge with the provided transform object', async () => {
       let i = 0
-      const changelog = conventionalChangelogWriter.parseArray(commits, {}, {
+      const changelog = await await conventionalChangelogWriter.parseArray(commits, {}, {
         transform: {
           notes (notes) {
             notes.map((note) => {
@@ -277,7 +277,7 @@ describe('conventional-changelog-writer', () => {
 
     it('should ignore the commit if tranform returns `null`', async () => {
       let i = 0
-      const changelog = conventionalChangelogWriter.parseArray(commits, {}, {
+      const changelog = await conventionalChangelogWriter.parseArray(commits, {}, {
         transform () {
           return false
         }
@@ -349,7 +349,7 @@ describe('conventional-changelog-writer', () => {
 
     it('should generate on the transformed commit', async () => {
       let i = 0
-      const changelog = conventionalChangelogWriter.parseArray(commits, {
+      const changelog = await await conventionalChangelogWriter.parseArray(commits, {
         version: '1.0.0'
       }, {
         transform (commit) {
@@ -379,7 +379,7 @@ describe('conventional-changelog-writer', () => {
     describe('when commits are not reversed', () => {
       it('should generate on `\'version\'` if it\'s a valid semver', async () => {
         let i = 0
-        const changelog = conventionalChangelogWriter.parseArray(commits)
+        const changelog = await conventionalChangelogWriter.parseArray(commits)
 
         expect(changelog).toContain('##  (' + today)
         expect(changelog).toContain('feat(scope): ')
@@ -460,7 +460,7 @@ describe('conventional-changelog-writer', () => {
 
         upstream.end()
 
-        const changelog = conventionalChangelogWriter.parseArray(commits, {}, {
+        const changelog = await conventionalChangelogWriter.parseArray(commits, {}, {
           generateOn: 'version'
         })
 
@@ -542,7 +542,7 @@ describe('conventional-changelog-writer', () => {
       it('version should fall back on `context.version` and `context.date`', async () => {
         let i = 0
 
-        const changelog = conventionalChangelogWriter.parseArray(commits, {
+        const changelog = await await conventionalChangelogWriter.parseArray(commits, {
           version: '0.0.1',
           date: '2015-01-01'
         })
@@ -742,7 +742,7 @@ describe('conventional-changelog-writer', () => {
 
         upstream.end()
 
-        const changelog = conventionalChangelogWriter.parseArray(commits, {}, {
+        const changelog = await conventionalChangelogWriter.parseArray(commits, {}, {
           reverse: true
         })
 

--- a/packages/conventional-changelog-writer/test/index.spec.js
+++ b/packages/conventional-changelog-writer/test/index.spec.js
@@ -310,7 +310,7 @@ describe('conventional-changelog-writer', () => {
             notes: [{
               title: 'BREAKING CHANGE',
               text: 'some breaking change'
-            }],
+            }]
           }]
         }
       })

--- a/packages/conventional-changelog-writer/test/index.spec.js
+++ b/packages/conventional-changelog-writer/test/index.spec.js
@@ -1,6 +1,6 @@
 import dedent from 'dedent'
 import { describe, it, expect } from 'vitest'
-import { throughObj } from '../../../tools/test-tools'
+import { delay, throughObj } from '../../../tools/test-tools'
 import conventionalChangelogWriter from '../'
 
 // sv-SEis used for yyyy-mm-dd format
@@ -297,6 +297,25 @@ describe('conventional-changelog-writer', () => {
       }
 
       expect(i).toBe(1)
+    })
+
+    it('support tranform commits async', async () => {
+      const changelog = await conventionalChangelogWriter.parseArray(commits, {}, {
+        async transform () {
+          await delay(100)
+          return [{
+            hash: '9b1aff905b638aa274a5fc8f88662df446d374bd',
+            header: 'feat(scope): broadcast $destroy event on scope destruction',
+            body: null,
+            notes: [{
+              title: 'BREAKING CHANGE',
+              text: 'some breaking change'
+            }],
+          }]
+        }
+      })
+
+      expect(changelog).toContain('broadcast $destroy event on scope destruction')
     })
   })
 

--- a/packages/conventional-changelog-writer/test/util.spec.js
+++ b/packages/conventional-changelog-writer/test/util.spec.js
@@ -369,8 +369,8 @@ describe('conventional-changelog-writer', () => {
         doNothing: 'nothing'
       }
 
-      it('should process object commit', () => {
-        const processed = util.processCommit(commit)
+      it('should process object commit', async () => {
+        const processed = await util.processCommit(commit)
 
         expect(processed).toEqual({
           hash: '456789uhghi',
@@ -386,8 +386,8 @@ describe('conventional-changelog-writer', () => {
         })
       })
 
-      it('should process json commit', () => {
-        const processed = util.processCommit(JSON.stringify(commit))
+      it('should process json commit', async () => {
+        const processed = await util.processCommit(JSON.stringify(commit))
 
         expect(processed).toEqual({
           hash: '456789uhghi',
@@ -403,8 +403,8 @@ describe('conventional-changelog-writer', () => {
         })
       })
 
-      it('should transform by a function', () => {
-        const processed = util.processCommit(commit, (commit) => {
+      it('should transform by a function', async () => {
+        const processed = await util.processCommit(commit, (commit) => {
           commit.hash = commit.hash.substring(0, 4)
           commit.subject = commit.subject.substring(0, 5)
           commit.replaceThis = 'replaced'
@@ -425,8 +425,8 @@ describe('conventional-changelog-writer', () => {
         })
       })
 
-      it('should transform by an object', () => {
-        const processed = util.processCommit(commit, {
+      it('should transform by an object', async () => {
+        const processed = await util.processCommit(commit, {
           hash: (hash) => {
             return hash.substring(0, 4)
           },
@@ -450,8 +450,8 @@ describe('conventional-changelog-writer', () => {
         })
       })
 
-      it('should transform by an object using dot path', () => {
-        const processed = util.processCommit({
+      it('should transform by an object using dot path', async () => {
+        const processed = await util.processCommit({
           header: {
             subject: 'my subject'
           }

--- a/packages/conventional-changelog-writer/test/util.spec.js
+++ b/packages/conventional-changelog-writer/test/util.spec.js
@@ -773,6 +773,22 @@ describe('conventional-changelog-writer', () => {
         expect(log).toBe('`a` oh')
       })
 
+      it('support finalize the context async', async () => {
+        const log = await util.generate({
+          mainTemplate: '{{whatever}} {{somethingExtra}}',
+          finalizeContext: async (context) => {
+            await new Promise((resolve) => setTimeout(resolve, 100))
+            context.somethingExtra = 'oh'
+            return context
+          },
+          debug: () => {}
+        }, [], [], {
+          whatever: '`a`'
+        })
+
+        expect(log).toBe('`a` oh')
+      })
+
       it('should finalize context', async () => {
         const log = await util.generate({
           mainTemplate: '{{whatever}} {{somethingExtra}} {{opt}} {{commitsLen}} {{whatever}}',

--- a/packages/conventional-changelog-writer/test/util.spec.js
+++ b/packages/conventional-changelog-writer/test/util.spec.js
@@ -618,8 +618,8 @@ describe('conventional-changelog-writer', () => {
     })
 
     describe('generate', () => {
-      it('should merge with the key commit', () => {
-        const log = util.generate({
+      it('should merge with the key commit', async () => {
+        const log = await util.generate({
           mainTemplate: '{{whatever}}',
           finalizeContext: (context) => {
             return context
@@ -634,8 +634,8 @@ describe('conventional-changelog-writer', () => {
         expect(log).toBe('b')
       })
 
-      it('should attach a copy of the commit to note', () => {
-        const log = util.generate({
+      it('should attach a copy of the commit to note', async () => {
+        const log = await util.generate({
           mainTemplate: '{{#each noteGroups}}{{#each notes}}{{commit.header}}{{/each}}{{/each}}',
           ignoreReverted: true,
           finalizeContext: (context) => {
@@ -673,8 +673,8 @@ describe('conventional-changelog-writer', () => {
         expect(log).toContain('chore: first commit')
       })
 
-      it('should not html escape any content', () => {
-        const log = util.generate({
+      it('should not html escape any content', async () => {
+        const log = await util.generate({
           mainTemplate: '{{whatever}}',
           finalizeContext: (context) => {
             return context
@@ -687,8 +687,8 @@ describe('conventional-changelog-writer', () => {
         expect(log).toBe('`a`')
       })
 
-      it('should ignore a reverted commit', () => {
-        const log = util.generate({
+      it('should ignore a reverted commit', async () => {
+        const log = await util.generate({
           mainTemplate: '{{#each commitGroups}}{{commits.length}}{{#each commits}}{{header}}{{/each}}{{/each}}{{#each noteGroups}}{{title}}{{#each notes}}{{text}}{{/each}}{{/each}}',
           ignoreReverted: true,
           finalizeContext: (context) => {
@@ -758,8 +758,8 @@ describe('conventional-changelog-writer', () => {
         expect(log).not.toContain('breaking change')
       })
 
-      it('should finalize context', () => {
-        const log = util.generate({
+      it('should finalize context', async () => {
+        const log = await util.generate({
           mainTemplate: '{{whatever}} {{somethingExtra}}',
           finalizeContext: (context) => {
             context.somethingExtra = 'oh'
@@ -773,8 +773,8 @@ describe('conventional-changelog-writer', () => {
         expect(log).toBe('`a` oh')
       })
 
-      it('should finalize context', () => {
-        const log = util.generate({
+      it('should finalize context', async () => {
+        const log = await util.generate({
           mainTemplate: '{{whatever}} {{somethingExtra}} {{opt}} {{commitsLen}} {{whatever}}',
           finalizeContext: (context, options, commits, keyCommit) => {
             context.somethingExtra = 'oh'
@@ -793,8 +793,8 @@ describe('conventional-changelog-writer', () => {
         expect(log).toBe('`a` oh opt 0 `a`')
       })
 
-      it('should pass the correct arguments', () => {
-        util.generate({
+      it('should pass the correct arguments', async () => {
+        await util.generate({
           mainTemplate: '{{#each noteGroups}}{{#each notes}}{{commit.header}}{{/each}}{{/each}}',
           ignoreReverted: true,
           finalizeContext: (context, options, filteredCommits, keyCommit, originalCommits) => {

--- a/packages/conventional-commits-parser/lib/parser.js
+++ b/packages/conventional-commits-parser/lib/parser.js
@@ -66,8 +66,8 @@ function getReferences (input, regex) {
       }
 
       const reference = {
-        action: action,
-        owner: owner,
+        action,
+        owner,
         repository: repository || null,
         issue: referenceMatch[3],
         raw: referenceMatch[0],
@@ -132,14 +132,14 @@ function parser (raw, options, regex) {
 
   if (lines.length === 0) {
     return {
-      body: body,
-      footer: footer,
-      header: header,
-      mentions: mentions,
-      merge: merge,
-      notes: notes,
-      references: references,
-      revert: revert,
+      body,
+      footer,
+      header,
+      mentions,
+      merge,
+      notes,
+      references,
+      revert,
       scope: null,
       subject: null,
       type: null
@@ -299,14 +299,14 @@ function parser (raw, options, regex) {
   const msg = {
     ...headerParts,
     ...mergeParts,
-    merge: merge,
-    header: header,
+    merge,
+    header,
     body: body ? trimOffNewlines(body) : null,
     footer: footer ? trimOffNewlines(footer) : null,
-    notes: notes,
-    references: references,
-    mentions: mentions,
-    revert: revert,
+    notes,
+    references,
+    mentions,
+    revert,
     ...otherFields
   }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -615,7 +615,7 @@ packages:
     engines: {node: '>=10.10.0'}
     dependencies:
       '@humanwhocodes/object-schema': 1.2.1
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
@@ -1586,7 +1586,7 @@ packages:
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.3
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       doctrine: 3.0.0
       enquirer: 2.4.1
       escape-string-regexp: 4.0.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -615,7 +615,7 @@ packages:
     engines: {node: '>=10.10.0'}
     dependencies:
       '@humanwhocodes/object-schema': 1.2.1
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
@@ -1586,7 +1586,7 @@ packages:
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.3
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       doctrine: 3.0.0
       enquirer: 2.4.1
       escape-string-regexp: 4.0.0


### PR DESCRIPTION
Now you can return promises in `transform` and `finalizeContenxt`:
```js
export default {
    async transform: (commit, context) => {
        return await ...
    },
    async finalizeContext: (context, options, commits) => {
        return await ...
    }
}
```
I didn't do complicated refactoring; I just changed most synchronous functions to support asynchronous and passed all tests.

Hope to see this feature in `v6.1.0`.

I'm suffering from adding contributors to [Master CSS releases](https://github.com/master-co/css/releases).