### PR TITLE
fix: define `skip-unstable` in opts so they are passed down to `gitSemverTags`

### DIFF
--- a/packages/conventional-recommended-bump/cli.mjs
+++ b/packages/conventional-recommended-bump/cli.mjs
@@ -64,6 +64,9 @@ const cli = meow(`
     },
     tagPrefix: {
       shortFlag: 't'
+    },
+    skipUnstable: {
+      type: 'boolean'
     }
   }
 })

--- a/packages/git-semver-tags/cli.mjs
+++ b/packages/git-semver-tags/cli.mjs
@@ -10,7 +10,7 @@ const args = meow(`
     --lerna                parse lerna style git tags
     --package <name>       when listing lerna style tags, filter by a package
     --tag-prefix <prefix>  prefix to remove from the tags during their processing
-`,
+    --skip-unstable                If given, unstable tags will be skipped, e.g., x.x.x-alpha.1, x.x.x-rc.2`,
 {
   importMeta: import.meta,
   booleanDefault: undefined,
@@ -26,6 +26,9 @@ const args = meow(`
     },
     tagPrefix: {
       type: 'string'
+    },
+    skipUnstable: {
+      type: 'boolean'
     }
   }
 })
@@ -33,7 +36,8 @@ const args = meow(`
 gitSemverTags({
   lernaTags: args.flags.lerna,
   package: args.flags.package,
-  tagPrefix: args.flags.tagPrefix
+  tagPrefix: args.flags.tagPrefix,
+  skipUnstable: args.flags.skipUnstable
 }, (err, tags) => {
   if (err) {
     console.error(err.toString())

--- a/packages/git-semver-tags/cli.mjs
+++ b/packages/git-semver-tags/cli.mjs
@@ -10,7 +10,7 @@ const args = meow(`
     --lerna                parse lerna style git tags
     --package <name>       when listing lerna style tags, filter by a package
     --tag-prefix <prefix>  prefix to remove from the tags during their processing
-    --skip-unstable                If given, unstable tags will be skipped, e.g., x.x.x-alpha.1, x.x.x-rc.2`,
+    --skip-unstable        if given, unstable tags will be skipped, e.g., x.x.x-alpha.1, x.x.x-rc.2`,
 {
   importMeta: import.meta,
   booleanDefault: undefined,


### PR DESCRIPTION
Option definition for `skip-unstable` are missing in `cli.js` both for `git-semver-tags` and `conventional-recommended-bump`. So when running from command line the `--skip-unstable` opt is not passed to the actual `gitSemverTags` method.

I could not manage to validate the issue with `conventional-recommended-bump` but since it is defined in the `options` object, I've added it to the `meow` definition there too for consistency.

Likely addresses #754 and #675.

## Validation

Example when running in this very repo:

<details><summary>Before</summary>

```
$ node packages/git-semver-tags/cli.js
v1.1.0
v1.0.2
v1.0.1
v1.0.0
v0.5.3
v0.5.2
v0.5.1
v0.5.0
v0.4.3
v0.4.2
v0.4.1
v0.4.0
v0.3.2
v0.3.1
v0.3.0
v0.2.1
v0.2.0
v0.1.3
v0.1.2
v0.1.1
v0.1.0
v0.1.0-beta.3
v0.1.0-beta.2
v0.1.0-beta.1
v0.1.0-alpha.3
v0.1.0-alpha.2
v0.1.0-alpha.1
v0.0.17
v0.0.16
v0.0.15
v0.0.14
v0.0.13
v0.0.11
v0.0.10
v0.0.9
v0.0.8
v0.0.7
v0.0.6
v0.0.4
```

</details>


<details><summary>After</summary>


```
$ node packages/git-semver-tags/cli.js
v1.1.0
v1.0.2
v1.0.1
v1.0.0
v0.5.3
v0.5.2
v0.5.1
v0.5.0
v0.4.3
v0.4.2
v0.4.1
v0.4.0
v0.3.2
v0.3.1
v0.3.0
v0.2.1
v0.2.0
v0.1.3
v0.1.2
v0.1.1
v0.1.0
v0.0.17
v0.0.16
v0.0.15
v0.0.14
v0.0.13
v0.0.11
v0.0.10
v0.0.9
v0.0.8
v0.0.7
v0.0.6
v0.0.4
```

</details>

