### PR TITLE
feat(git-raw-commits): add support for multiple paths

### DIFF
--- a/packages/git-raw-commits/README.md
+++ b/packages/git-raw-commits/README.md
@@ -59,9 +59,9 @@ A function to get debug information.
 
 ##### gitOpts.path
 
-Type: `string`
+Type: `string` or `array`
 
-Filter commits to the path provided.
+Filter commits to the path(s) provided.
 
 ##### execOpts
 

--- a/packages/git-raw-commits/index.js
+++ b/packages/git-raw-commits/index.js
@@ -30,10 +30,10 @@ async function getGitArgs (gitOpts) {
       excludes: ['debug', 'from', 'to', 'format', 'path', 'ignore']
     }))
 
-  // allow commits to focus on a single directory
+  // allow commits to focus on specific directories.
   // this is useful for monorepos.
   if (gitOpts.path) {
-    gitArgs.push('--', gitOpts.path)
+    gitArgs.push('--', ...Array.isArray(gitOpts.path) ? gitOpts.path : [gitOpts.path])
   }
 
   return gitArgs

--- a/packages/git-raw-commits/test/index.spec.js
+++ b/packages/git-raw-commits/test/index.spec.js
@@ -168,6 +168,27 @@ describe('git-raw-commits', () => {
     expect(output).not.toMatch(/Second commit/)
   })
 
+  it('should allow commits to be scoped to a list of directories', async () => {
+    let i = 0
+    let output = ''
+
+    for await (let chunk of gitRawCommits({
+      path: ['./packages/foo', './test2']
+    }, {
+      cwd: testTools.cwd
+    })) {
+      chunk = chunk.toString()
+
+      output += chunk
+      i++
+    }
+
+    expect(i).toBe(2)
+    expect(output).toMatch(/First commit/)
+    expect(output).toMatch(/Second commit/)
+    expect(output).not.toMatch(/Third commit/)
+  })
+
   it('should show your git-log command', async () => {
     let cmd = ''
 


### PR DESCRIPTION
We have a use case for creating changelogs for a bundled application where the source code is spread across multiple directories and libs inside a monorepo e.g. `apps/my-app` and `libs/my-app-external-api`, and we'd like to include changes from `libs/my-app-external-api` inside of the changelog for `apps/my-app`. Currently we have patched `git-raw-commits` to allow this, but I think that others may find this useful.