### PR TITLE
fix: align split/2 package between packages

### DIFF
--- a/packages/conventional-changelog-writer/cli.mjs
+++ b/packages/conventional-changelog-writer/cli.mjs
@@ -3,7 +3,7 @@ import { resolve } from 'path'
 import { pathToFileURL } from 'url'
 import { createReadStream } from 'fs'
 import { readFile } from 'fs/promises'
-import split from 'split'
+import split from 'split2'
 import meow from 'meow'
 import conventionalChangelogWriter from './index.js'
 

--- a/packages/conventional-changelog-writer/package.json
+++ b/packages/conventional-changelog-writer/package.json
@@ -41,7 +41,7 @@
     "json-stringify-safe": "^5.0.1",
     "meow": "^12.0.1",
     "semver": "^7.5.2",
-    "split": "^1.0.1"
+    "split2": "^4.0.0"
   },
   "bin": {
     "conventional-changelog-writer": "cli.mjs"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -209,9 +209,9 @@ importers:
       semver:
         specifier: ^7.5.2
         version: 7.5.2
-      split:
-        specifier: ^1.0.1
-        version: 1.0.1
+      split2:
+        specifier: ^4.0.0
+        version: 4.0.0
     devDependencies:
       dedent:
         specifier: ^1.0.0
@@ -2832,12 +2832,6 @@ packages:
 
   /split2@4.0.0:
     resolution: {integrity: sha512-gjmavJzvQCAZzaEHWoJBOwqIUAiEvUOlguQ6uO0+0LTS1tlLa2YetTLWCrm049ouvLOa1l6SOGm3XaiRiCg9SQ==}
-    dev: false
-
-  /split@1.0.1:
-    resolution: {integrity: sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==}
-    dependencies:
-      through: 2.3.8
     dev: false
 
   /sprintf-js@1.1.2:


### PR DESCRIPTION
split package is no longer maintained and has been marked as archived,

split2 package is used across repo for same purpose and API of those packages is "same"

https://github.com/conventional-changelog/conventional-changelog/commit/1941c374381688aff57ad2f4c20e6bd8e971bf01#diff-1e6d561d19491fb83fea724e4ac3e5d9ab82e58872a2ff9adbdbc8f08372a0c0R10
https://github.com/conventional-changelog/conventional-changelog/commit/8feb26c5230ed6ddfaebdb8a0d043fc66f6df0b4#diff-45ad27325f1ec4b7be159dc4117df057a9581ae50622def12aed26c0799cdc85R26

https://github.com/dominictarr/split
https://github.com/mcollina/split2

https://github.com/conventional-changelog/conventional-changelog/blob/208494eaff3bb7ab25a89e1151e7538d0806ddd6/packages/conventional-commits-parser/package.json#L39