### PR TITLE
refactor(conventional-commits-parser): use Transform instead of JSONStream

### DIFF
--- a/packages/conventional-commits-parser/package.json
+++ b/packages/conventional-commits-parser/package.json
@@ -33,7 +33,6 @@
     "logs"
   ],
   "dependencies": {
-    "JSONStream": "^1.3.5",
     "is-text-path": "^2.0.0",
     "meow": "^12.0.1",
     "split2": "^4.0.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -224,9 +224,6 @@ importers:
 
   packages/conventional-commits-parser:
     dependencies:
-      JSONStream:
-        specifier: ^1.3.5
-        version: 1.3.5
       is-text-path:
         specifier: ^2.0.0
         version: 2.0.0
@@ -768,14 +765,6 @@ packages:
       loupe: 2.3.6
       pretty-format: 29.6.3
     dev: true
-
-  /JSONStream@1.3.5:
-    resolution: {integrity: sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==}
-    hasBin: true
-    dependencies:
-      jsonparse: 1.3.1
-      through: 2.3.8
-    dev: false
 
   /acorn-jsx@5.3.2(acorn@8.10.0):
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
@@ -2113,11 +2102,6 @@ packages:
     resolution: {integrity: sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==}
     dev: true
 
-  /jsonparse@1.3.1:
-    resolution: {integrity: sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg==}
-    engines: {'0': node >= 0.2.0}
-    dev: false
-
   /keyv@4.5.3:
     resolution: {integrity: sha512-QCiSav9WaX1PgETJ+SpNnx2PRRapJ/oRSXM4VO5OGYGSjrxbKPVFVhB3l2OCbLCk329N8qyAtsJjSjvVBWzEug==}
     dependencies:
@@ -2840,10 +2824,6 @@ packages:
   /text-table@0.2.0:
     resolution: {integrity: sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==}
     dev: true
-
-  /through@2.3.8:
-    resolution: {integrity: sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==}
-    dev: false
 
   /tinybench@2.5.0:
     resolution: {integrity: sha512-kRwSG8Zx4tjF9ZiyH4bhaebu+EDz1BOx9hOigYHlUW4xxI/wKIUQUqo018UlU4ar6ATPBsaMrdbKZ+tmPdohFA==}


### PR DESCRIPTION
follow up for #971

Use simple stream transform instead of JSONStream library,

- [JSONStream](https://github.com/dominictarr/JSONStream) is archived and no longer maintained.
- [through](https://github.com/dominictarr/through) is no longer included in dependency tree