### PR TITLE
feat!(git-semver-tags,conventional-recommended-bump): refactoring to use promises instead of callbacks

### DIFF
--- a/packages/conventional-recommended-bump/README.md
+++ b/packages/conventional-recommended-bump/README.md
@@ -38,11 +38,11 @@ npm install conventional-recommended-bump
 ```javascript
 const conventionalRecommendedBump = require(`conventional-recommended-bump`);
 
-conventionalRecommendedBump({
+const recommendation = await conventionalRecommendedBump({
   preset: `angular`
-}, (error, recommendation) => {
-  console.log(recommendation.releaseType); // 'major'
 });
+
+console.log(recommendation.releaseType); // 'major'
 ```
 
 ```bash

--- a/packages/conventional-recommended-bump/cli.mjs
+++ b/packages/conventional-recommended-bump/cli.mjs
@@ -93,17 +93,12 @@ if (flags.verbose) {
   options.warn = console.warn.bind(console)
 }
 
-conventionalRecommendedBump(options, flags, (err, data) => {
-  if (err) {
-    console.error(err.toString())
-    process.exit(1)
-  }
+const data = await conventionalRecommendedBump(options, flags)
 
-  if (data.releaseType) {
-    console.log(data.releaseType)
-  }
+if (data.releaseType) {
+  console.log(data.releaseType)
+}
 
-  if (flags.verbose && data.reason) {
-    console.log(`Reason: ${data.reason}`)
-  }
-})
+if (flags.verbose && data.reason) {
+  console.log(`Reason: ${data.reason}`)
+}

--- a/packages/conventional-recommended-bump/package.json
+++ b/packages/conventional-recommended-bump/package.json
@@ -30,7 +30,6 @@
     "bump"
   ],
   "dependencies": {
-    "concat-stream": "^2.0.0",
     "conventional-changelog-preset-loader": "workspace:^",
     "conventional-commits-filter": "workspace:^",
     "conventional-commits-parser": "workspace:^",

--- a/packages/conventional-recommended-bump/test/index.spec.js
+++ b/packages/conventional-recommended-bump/test/index.spec.js
@@ -43,360 +43,278 @@ tearsWithJoy(() => {
 
 describe('conventional-recommended-bump', () => {
   describe('options object', () => {
-    it('should throw an error if an \'options\' object is not provided', () => {
-      expect(() => conventionalRecommendedBump()).toThrow()
-      expect(() => conventionalRecommendedBump('invalid options object')).toThrow()
+    it('should throw an error if an \'options\' object is not provided', async () => {
+      await expect(() => conventionalRecommendedBump()).rejects.toThrow()
+      await expect(() => conventionalRecommendedBump('invalid options object')).rejects.toThrow()
     })
   })
 
   describe('callback', () => {
-    it('should throw an error if no, or an invalid, callback function is provided', () => {
-      expect(() => conventionalRecommendedBump({ cwd: testTools.cwd })).toThrow()
-      expect(() => conventionalRecommendedBump({ cwd: testTools.cwd }, {})).toThrow()
-      expect(() => conventionalRecommendedBump({ cwd: testTools.cwd }, {}, {})).toThrow()
-    })
-
-    it('should allow callback function in the \'parserOpts\' argument spot', () => {
+    it('should throw an error if no, or an invalid, callback function is provided', async () => {
       preparing(1)
 
-      return new Promise((resolve) => {
-        conventionalRecommendedBump({ cwd: testTools.cwd }, (err) => {
-          expect(err).toBeTruthy()
-          resolve()
-        })
-      })
+      await expect(() => conventionalRecommendedBump({ cwd: testTools.cwd })).rejects.toThrow()
+      await expect(() => conventionalRecommendedBump({ cwd: testTools.cwd }, {})).rejects.toThrow()
+      await expect(() => conventionalRecommendedBump({ cwd: testTools.cwd }, {}, {})).rejects.toThrow()
+    })
+
+    it('should allow callback function in the \'parserOpts\' argument spot', async () => {
+      preparing(1)
+
+      await expect(() => conventionalRecommendedBump({ cwd: testTools.cwd })).rejects.toThrow()
     })
   })
 
-  it('should return an error if there are no commits in the repository', () => {
+  it('should return an error if there are no commits in the repository', async () => {
     preparing(1)
 
-    return new Promise((resolve) => {
-      conventionalRecommendedBump({
-        cwd: testTools.cwd
-      }, {}, (err) => {
-        expect(err).toBeTruthy()
-        resolve()
-      })
-    })
+    await expect(() => conventionalRecommendedBump({ cwd: testTools.cwd }, {})).rejects.toThrow()
   })
 
   describe('conventionalcommits ! in isolation', () => {
-    it('recommends major if ! is used in isolation', () => {
+    it('recommends major if ! is used in isolation', async () => {
       preparing(2)
 
-      return new Promise((resolve, reject) => {
-        conventionalRecommendedBump({
-          cwd: testTools.cwd,
-          preset: {
-            name: 'conventionalcommits'
-          }
-        }, {}, (err, recommendation) => {
-          if (err) reject(err)
-          expect(recommendation.reason).toContain('1 BREAKING')
-          expect(recommendation.releaseType).toBe('major')
-          resolve()
-        })
-      })
+      const recommendation = await conventionalRecommendedBump({
+        cwd: testTools.cwd,
+        preset: {
+          name: 'conventionalcommits'
+        }
+      }, {})
+
+      expect(recommendation.reason).toContain('1 BREAKING')
+      expect(recommendation.releaseType).toBe('major')
     })
   })
 
   describe('optional \'whatBump\'', () => {
-    it('should throw an error if \'whatBump\' is defined but not a function', () => {
+    it('should throw an error if \'whatBump\' is defined but not a function', async () => {
       preparing(2)
 
-      return new Promise((resolve) => {
-        conventionalRecommendedBump({
-          cwd: testTools.cwd,
-          whatBump: 'invalid'
-        }, {}, (err) => {
-          expect(err).toBeTruthy()
-          expect(err.message).toBe('whatBump must be a function')
-          resolve()
-        })
-      })
+      await expect(() => conventionalRecommendedBump({
+        cwd: testTools.cwd,
+        whatBump: 'invalid'
+      }, {})).rejects.toThrow('whatBump must be a function')
     })
 
-    it('should return \'{}\' if no \'whatBump\'', () => {
+    it('should return \'{}\' if no \'whatBump\'', async () => {
       preparing(2)
 
-      return new Promise((resolve, reject) => {
-        conventionalRecommendedBump({
-          cwd: testTools.cwd
-        }, {}, (err, recommendation) => {
-          if (err) reject(err)
-          expect(recommendation).toEqual({})
-          resolve()
-        })
-      })
+      const recommendation = await conventionalRecommendedBump({
+        cwd: testTools.cwd
+      }, {})
+
+      expect(recommendation).toEqual({})
     })
 
-    it('should return \'{}\' if \'whatBump\' returns \'null\'', () => {
+    it('should return \'{}\' if \'whatBump\' returns \'null\'', async () => {
       preparing(2)
 
-      return new Promise((resolve, reject) => {
-        conventionalRecommendedBump({
-          cwd: testTools.cwd,
-          whatBump: () => null
-        }, (err, recommendation) => {
-          if (err) reject(err)
-          expect(recommendation).toEqual({})
-          resolve()
-        })
+      const recommendation = await conventionalRecommendedBump({
+        cwd: testTools.cwd,
+        whatBump: () => null
       })
+
+      expect(recommendation).toEqual({})
     })
 
-    it('should return \'{}\' if \'whatBump\' returns \'undefined\'', () => {
+    it('should return \'{}\' if \'whatBump\' returns \'undefined\'', async () => {
       preparing(2)
 
-      return new Promise((resolve, reject) => {
-        conventionalRecommendedBump({
-          cwd: testTools.cwd,
-          whatBump: () => undefined
-        }, (err, recommendation) => {
-          if (err) reject(err)
-          expect(recommendation).toEqual({})
-          resolve()
-        })
+      const recommendation = await conventionalRecommendedBump({
+        cwd: testTools.cwd,
+        whatBump: () => undefined
       })
+
+      expect(recommendation).toEqual({})
     })
 
-    it('should return what is returned by \'whatBump\'', () => {
+    it('should return what is returned by \'whatBump\'', async () => {
       preparing(2)
 
-      return new Promise((resolve, reject) => {
-        conventionalRecommendedBump({
-          cwd: testTools.cwd,
-          whatBump: () => ({ test: 'test' })
-        }, (err, recommendation) => {
-          if (err) reject(err)
-          expect(recommendation).toEqual({ test: 'test' })
-          resolve()
-        })
+      const recommendation = await conventionalRecommendedBump({
+        cwd: testTools.cwd,
+        whatBump: () => ({ test: 'test' })
       })
+
+      expect(recommendation).toEqual({ test: 'test' })
     })
 
-    it('should send options to \'whatBump\'', () => {
+    it('should send options to \'whatBump\'', async () => {
       preparing(2)
 
-      return new Promise((resolve, reject) => {
-        conventionalRecommendedBump({
-          cwd: testTools.cwd,
-          lernaPackage: 'test',
-          whatBump: (commits, options) => options.lernaPackage
-        }, (err, recommendation) => {
-          if (err) reject(err)
-          expect(recommendation).toBe('test')
-          resolve()
-        })
+      const recommendation = await conventionalRecommendedBump({
+        cwd: testTools.cwd,
+        lernaPackage: 'test',
+        whatBump: (commits, options) => options.lernaPackage
       })
+
+      expect(recommendation).toBe('test')
     })
 
-    it('should return \'releaseType\' as undefined if \'level\' is not valid', () => {
+    it('should return \'releaseType\' as undefined if \'level\' is not valid', async () => {
       preparing(2)
 
-      return new Promise((resolve, reject) => {
-        conventionalRecommendedBump({
-          cwd: testTools.cwd,
-          whatBump: () => ({ level: 'test' })
-        }, (err, recommendation) => {
-          if (err) reject(err)
-          expect(recommendation).toEqual({ level: 'test', releaseType: undefined })
-          resolve()
-        })
+      const recommendation = await conventionalRecommendedBump({
+        cwd: testTools.cwd,
+        whatBump: () => ({ level: 'test' })
       })
+
+      expect(recommendation).toEqual({ level: 'test', releaseType: undefined })
     })
   })
 
   describe('warn logging', () => {
-    it('will ignore \'warn\' option if it\'s not a function', () => {
+    it('will ignore \'warn\' option if it\'s not a function', async () => {
       preparing(3)
 
-      return new Promise((resolve) => {
-        conventionalRecommendedBump({
-          cwd: testTools.cwd
-        }, { warn: 'invalid' }, resolve)
-      })
+      await conventionalRecommendedBump({
+        cwd: testTools.cwd
+      }, { warn: 'invalid' })
     })
 
-    it('should warn if there is no new commits since last release', () => {
+    it('should warn if there is no new commits since last release', async () => {
       preparing(3)
 
-      return new Promise((resolve) => {
-        conventionalRecommendedBump({
-          cwd: testTools.cwd
-        }, {
-          warn: warning => {
-            expect(warning).toBe('No commits since last release')
-            resolve()
-          }
-        }, () => {})
+      await conventionalRecommendedBump({
+        cwd: testTools.cwd
+      }, {
+        warn: warning => {
+          expect(warning).toBe('No commits since last release')
+        }
       })
     })
   })
 
   describe('loading a preset package', () => {
-    it('recommends a patch release for a feature when preMajor=true', () => {
+    it('recommends a patch release for a feature when preMajor=true', async () => {
       preparing(4)
 
-      return new Promise((resolve) => {
-        conventionalRecommendedBump({
-          cwd: testTools.cwd,
-          preset: {
-            name: 'conventionalcommits',
-            preMajor: true
-          }
-        }, {}, (_, recommendation) => {
-          expect(recommendation.reason).toContain('1 features')
-          expect(recommendation.releaseType).toBe('patch')
-          resolve()
-        })
-      })
+      const recommendation = await conventionalRecommendedBump({
+        cwd: testTools.cwd,
+        preset: {
+          name: 'conventionalcommits',
+          preMajor: true
+        }
+      }, {})
+
+      expect(recommendation.reason).toContain('1 features')
+      expect(recommendation.releaseType).toBe('patch')
     })
 
-    it('recommends a minor release for a feature when preMajor=false', () => {
+    it('recommends a minor release for a feature when preMajor=false', async () => {
       preparing(4)
 
-      return new Promise((resolve) => {
-        conventionalRecommendedBump({
-          cwd: testTools.cwd,
-          preset: {
-            name: 'conventionalcommits'
-          }
-        }, {}, (_, recommendation) => {
-          expect(recommendation.reason).toContain('1 features')
-          expect(recommendation.releaseType).toBe('minor')
-          resolve()
-        })
-      })
+      const recommendation = await conventionalRecommendedBump({
+        cwd: testTools.cwd,
+        preset: {
+          name: 'conventionalcommits'
+        }
+      }, {})
+
+      expect(recommendation.reason).toContain('1 features')
+      expect(recommendation.releaseType).toBe('minor')
     })
 
-    it('should ignore reverted commits', () => {
+    it('should ignore reverted commits', async () => {
       preparing(5)
 
-      return new Promise((resolve) => {
-        conventionalRecommendedBump({
-          cwd: testTools.cwd,
-          whatBump: commits => {
-            expect(commits.length).toBe(0)
-            resolve()
-          }
-        }, () => {})
+      await conventionalRecommendedBump({
+        cwd: testTools.cwd,
+        whatBump: commits => {
+          expect(commits.length).toBe(0)
+        }
       })
     })
 
-    it('should include reverted commits', () => {
+    it('should include reverted commits', async () => {
       preparing(5)
 
-      return new Promise((resolve) => {
-        conventionalRecommendedBump({
-          cwd: testTools.cwd,
-          ignoreReverted: false,
-          whatBump: commits => {
-            expect(commits.length).toBe(2)
-            resolve()
-          }
-        }, () => {})
+      await conventionalRecommendedBump({
+        cwd: testTools.cwd,
+        ignoreReverted: false,
+        whatBump: commits => {
+          expect(commits.length).toBe(2)
+        }
       })
     })
 
-    it('throws an error if unable to load a preset package', () => {
+    it('throws an error if unable to load a preset package', async () => {
       preparing(6)
 
-      return new Promise((resolve) => {
-        conventionalRecommendedBump({
-          cwd: testTools.cwd,
-          preset: 'does-not-exist'
-        }, {}, err => {
-          expect(err).toBeTruthy()
-          expect(err.message).toBe('Unable to load the "does-not-exist" preset. Please make sure it\'s installed.')
-          resolve()
-        })
-      })
+      await expect(() => conventionalRecommendedBump({
+        cwd: testTools.cwd,
+        preset: 'does-not-exist'
+      }, {})).rejects.toThrow('Unable to load the "does-not-exist" preset. Please make sure it\'s installed.')
     })
 
-    it('recommends a minor release for a breaking change when preMajor=true', () => {
+    it('recommends a minor release for a breaking change when preMajor=true', async () => {
       preparing(6)
 
-      return new Promise((resolve) => {
-        conventionalRecommendedBump({
-          cwd: testTools.cwd,
-          preset: {
-            name: 'conventionalcommits',
-            preMajor: true
-          }
-        }, {}, (_, recommendation) => {
-          expect(recommendation.reason).toContain('1 BREAKING')
-          expect(recommendation.releaseType).toBe('minor')
-          resolve()
-        })
-      })
+      const recommendation = await conventionalRecommendedBump({
+        cwd: testTools.cwd,
+        preset: {
+          name: 'conventionalcommits',
+          preMajor: true
+        }
+      }, {})
+
+      expect(recommendation.reason).toContain('1 BREAKING')
+      expect(recommendation.releaseType).toBe('minor')
     })
 
-    it('recommends a major release for a breaking change when preMajor=false', () => {
+    it('recommends a major release for a breaking change when preMajor=false', async () => {
       preparing(6)
 
-      return new Promise((resolve) => {
-        conventionalRecommendedBump({
-          cwd: testTools.cwd,
-          preset: {
-            name: 'conventionalcommits'
-          }
-        }, {}, (_, recommendation) => {
-          expect(recommendation.reason).toContain('1 BREAKING')
-          expect(recommendation.releaseType).toBe('major')
-          resolve()
-        })
-      })
+      const recommendation = await conventionalRecommendedBump({
+        cwd: testTools.cwd,
+        preset: {
+          name: 'conventionalcommits'
+        }
+      }, {})
+
+      expect(recommendation.reason).toContain('1 BREAKING')
+      expect(recommendation.releaseType).toBe('major')
     })
   })
 
   describe('repository with custom tag prefix', () => {
-    it('should recommends a minor release if appropriate', () => {
+    it('should recommends a minor release if appropriate', async () => {
       preparing(6)
 
-      return new Promise((resolve) => {
-        conventionalRecommendedBump({
-          cwd: testTools.cwd,
-          tagPrefix: 'ms/',
-          whatBump: commits => {
-            expect(commits.length).toBe(1)
-            expect(commits[0].type).toBe('feat')
-            resolve()
-          }
-        }, () => {})
+      await conventionalRecommendedBump({
+        cwd: testTools.cwd,
+        tagPrefix: 'ms/',
+        whatBump: commits => {
+          expect(commits.length).toBe(1)
+          expect(commits[0].type).toBe('feat')
+        }
       })
     })
   })
 
   describe('repository with lerna tags', () => {
-    it('should recommend \'major\' version bump when not using lerna tags', () => {
+    it('should recommend \'major\' version bump when not using lerna tags', async () => {
       preparing(7)
 
-      return new Promise((resolve) => {
-        conventionalRecommendedBump({
-          cwd: testTools.cwd,
-          whatBump: commits => {
-            expect(commits.length).toBe(3)
-            resolve()
-          }
-        }, () => {})
+      await conventionalRecommendedBump({
+        cwd: testTools.cwd,
+        whatBump: commits => {
+          expect(commits.length).toBe(3)
+        }
       })
     })
 
-    it('should recommend \'minor\' version bump when lerna tag option is enabled', () => {
+    it('should recommend \'minor\' version bump when lerna tag option is enabled', async () => {
       preparing(7)
 
-      return new Promise((resolve) => {
-        conventionalRecommendedBump({
-          cwd: testTools.cwd,
-          lernaPackage: 'my-package',
-          whatBump: commits => {
-            expect(commits.length).toBe(1)
-            expect(commits[0].type).toBe('feat')
-            resolve()
-          }
-        }, () => {})
+      await conventionalRecommendedBump({
+        cwd: testTools.cwd,
+        lernaPackage: 'my-package',
+        whatBump: commits => {
+          expect(commits.length).toBe(1)
+          expect(commits[0].type).toBe('feat')
+        }
       })
     })
   })

--- a/packages/git-semver-tags/README.md
+++ b/packages/git-semver-tags/README.md
@@ -16,12 +16,12 @@ $ npm install --save git-semver-tags
 ```js
 var gitSemverTags = require('git-semver-tags');
 
-// gitSemverTags([options,] callback)
+// gitSemverTags([options])
 
-gitSemverTags(function(err, tags) {
-  console.log(tags);
-  //=> [ 'v2.0.0', 'v1.0.0' ]
-});
+const tags = await gitSemverTags();
+
+console.log(tags);
+//=> [ 'v2.0.0', 'v1.0.0' ]
 ```
 
 ```sh

--- a/packages/git-semver-tags/cli.mjs
+++ b/packages/git-semver-tags/cli.mjs
@@ -33,16 +33,11 @@ const args = meow(`
   }
 })
 
-gitSemverTags({
+const tags = await gitSemverTags({
   lernaTags: args.flags.lerna,
   package: args.flags.package,
   tagPrefix: args.flags.tagPrefix,
   skipUnstable: args.flags.skipUnstable
-}, (err, tags) => {
-  if (err) {
-    console.error(err.toString())
-    process.exit(1)
-  }
-
-  console.log(tags.join('\n'))
 })
+
+console.log(tags.join('\n'))

--- a/packages/git-semver-tags/test/index.spec.js
+++ b/packages/git-semver-tags/test/index.spec.js
@@ -14,34 +14,25 @@ describe('git-semver-tags', () => {
     testTools?.cleanup()
   })
 
-  it('should error if no commits found', () => {
-    return new Promise((resolve) => {
-      gitSemverTags({
-        cwd: testTools.cwd
-      }, (err) => {
-        expect(err).toBeTruthy()
-        resolve()
-      })
-    })
+  it('should error if no commits found', async () => {
+    await expect(() => gitSemverTags({
+      cwd: testTools.cwd
+    })).rejects.toThrow()
   })
 
-  it('should get no semver tags', () => {
+  it('should get no semver tags', async () => {
     testTools.writeFileSync('test1', '')
     testTools.exec('git add --all && git commit -m"First commit"')
     testTools.exec('git tag foo')
 
-    return new Promise((resolve, reject) => {
-      gitSemverTags({
-        cwd: testTools.cwd
-      }, (err, tags) => {
-        if (err) return reject(err)
-        expect(tags).toEqual([])
-        resolve()
-      })
+    const tags = await gitSemverTags({
+      cwd: testTools.cwd
     })
+
+    expect(tags).toEqual([])
   })
 
-  it('should get the semver tag', () => {
+  it('should get the semver tag', async () => {
     testTools.writeFileSync('test2', '')
     testTools.exec('git add --all && git commit -m"Second commit"')
     testTools.exec('git tag v2.0.0')
@@ -49,90 +40,66 @@ describe('git-semver-tags', () => {
     testTools.exec('git add --all && git commit -m"Third commit"')
     testTools.exec('git tag va.b.c')
 
-    return new Promise((resolve, reject) => {
-      gitSemverTags({
-        cwd: testTools.cwd
-      }, (err, tags) => {
-        if (err) return reject(err)
-        expect(tags).toEqual(['v2.0.0'])
-        resolve()
-      })
+    const tags = await gitSemverTags({
+      cwd: testTools.cwd
     })
+
+    expect(tags).toEqual(['v2.0.0'])
   })
 
-  it('should get both semver tags', () => {
+  it('should get both semver tags', async () => {
     testTools.exec('git tag v3.0.0')
 
-    return new Promise((resolve, reject) => {
-      gitSemverTags({
-        cwd: testTools.cwd
-      }, (err, tags) => {
-        if (err) return reject(err)
-        expect(tags).toEqual(['v3.0.0', 'v2.0.0'])
-        resolve()
-      })
+    const tags = await gitSemverTags({
+      cwd: testTools.cwd
     })
+
+    expect(tags).toEqual(['v3.0.0', 'v2.0.0'])
   })
 
-  it('should get all semver tags if two tags on the same commit', () => {
+  it('should get all semver tags if two tags on the same commit', async () => {
     testTools.exec('git tag v4.0.0')
 
-    return new Promise((resolve, reject) => {
-      gitSemverTags({
-        cwd: testTools.cwd
-      }, (err, tags) => {
-        if (err) return reject(err)
-        expect(tags).toEqual(['v4.0.0', 'v3.0.0', 'v2.0.0'])
-        resolve()
-      })
+    const tags = await gitSemverTags({
+      cwd: testTools.cwd
     })
+
+    expect(tags).toEqual(['v4.0.0', 'v3.0.0', 'v2.0.0'])
   })
 
-  it('should still work if I run it again', () => {
-    return new Promise((resolve, reject) => {
-      gitSemverTags({
-        cwd: testTools.cwd
-      }, (err, tags) => {
-        if (err) return reject(err)
-        expect(tags).toEqual(['v4.0.0', 'v3.0.0', 'v2.0.0'])
-        resolve()
-      })
+  it('should still work if I run it again', async () => {
+    const tags = await gitSemverTags({
+      cwd: testTools.cwd
     })
+
+    expect(tags).toEqual(['v4.0.0', 'v3.0.0', 'v2.0.0'])
   })
 
-  it('should be in reverse chronological order', () => {
+  it('should be in reverse chronological order', async () => {
     testTools.writeFileSync('test4', '')
     testTools.exec('git add --all && git commit -m"Fourth commit"')
     testTools.exec('git tag v1.0.0')
 
-    return new Promise((resolve, reject) => {
-      gitSemverTags({
-        cwd: testTools.cwd
-      }, (err, tags) => {
-        if (err) return reject(err)
-        expect(tags).toEqual(['v1.0.0', 'v4.0.0', 'v3.0.0', 'v2.0.0'])
-        resolve()
-      })
+    const tags = await gitSemverTags({
+      cwd: testTools.cwd
     })
+
+    expect(tags).toEqual(['v1.0.0', 'v4.0.0', 'v3.0.0', 'v2.0.0'])
   })
 
-  it('should work with prerelease', () => {
+  it('should work with prerelease', async () => {
     testTools.writeFileSync('test5', '')
     testTools.exec('git add --all && git commit -m"Fifth commit"')
     testTools.exec('git tag 5.0.0-pre')
 
-    return new Promise((resolve, reject) => {
-      gitSemverTags({
-        cwd: testTools.cwd
-      }, (err, tags) => {
-        if (err) return reject(err)
-        expect(tags).toEqual(['5.0.0-pre', 'v1.0.0', 'v4.0.0', 'v3.0.0', 'v2.0.0'])
-        resolve()
-      })
+    const tags = await gitSemverTags({
+      cwd: testTools.cwd
     })
+
+    expect(tags).toEqual(['5.0.0-pre', 'v1.0.0', 'v4.0.0', 'v3.0.0', 'v2.0.0'])
   })
 
-  it('should work with empty commit', () => {
+  it('should work with empty commit', async () => {
     testTools?.cleanup()
     testTools = new TestTools()
 
@@ -143,18 +110,14 @@ describe('git-semver-tags', () => {
     testTools.gitDummyCommit('empty commit2')
     testTools.gitDummyCommit('empty commit3')
 
-    return new Promise((resolve, reject) => {
-      gitSemverTags({
-        cwd: testTools.cwd
-      }, (err, tags) => {
-        if (err) return reject(err)
-        expect(tags).toEqual(['v1.1.0'])
-        resolve()
-      })
+    const tags = await gitSemverTags({
+      cwd: testTools.cwd
     })
+
+    expect(tags).toEqual(['v1.1.0'])
   })
 
-  it('should work with lerna style tags', () => {
+  it('should work with lerna style tags', async () => {
     testTools.writeFileSync('test5', '2')
     testTools.exec('git add --all && git commit -m"sixth commit"')
     testTools.exec('git tag foo-project@4.0.0')
@@ -162,19 +125,15 @@ describe('git-semver-tags', () => {
     testTools.exec('git add --all && git commit -m"seventh commit"')
     testTools.exec('git tag foo-project@5.0.0')
 
-    return new Promise((resolve, reject) => {
-      gitSemverTags({
-        cwd: testTools.cwd,
-        lernaTags: true
-      }, (err, tags) => {
-        if (err) return reject(err)
-        expect(tags).toEqual(['foo-project@5.0.0', 'foo-project@4.0.0', 'blarg-project@1.0.0'])
-        resolve()
-      })
+    const tags = await gitSemverTags({
+      cwd: testTools.cwd,
+      lernaTags: true
     })
+
+    expect(tags).toEqual(['foo-project@5.0.0', 'foo-project@4.0.0', 'blarg-project@1.0.0'])
   })
 
-  it('should work with lerna style tags with multiple digits', () => {
+  it('should work with lerna style tags with multiple digits', async () => {
     testTools.writeFileSync('test5', '4')
     testTools.exec('git add --all && git commit -m"fifth commit"')
     testTools.exec('git tag foobar-project@0.0.10')
@@ -185,56 +144,43 @@ describe('git-semver-tags', () => {
     testTools.exec('git add --all && git commit -m"seventh commit"')
     testTools.exec('git tag foobar-project@10.0.0')
 
-    return new Promise((resolve, reject) => {
-      gitSemverTags({
-        cwd: testTools.cwd,
-        lernaTags: true
-      }, (err, tags) => {
-        if (err) return reject(err)
-        expect(tags).toEqual([
-          'foobar-project@10.0.0',
-          'foobar-project@0.10.0',
-          'foobar-project@0.0.10',
-          'foo-project@5.0.0',
-          'foo-project@4.0.0',
-          'blarg-project@1.0.0'
-        ])
-        resolve()
-      })
+    const tags = await gitSemverTags({
+      cwd: testTools.cwd,
+      lernaTags: true
     })
+
+    expect(tags).toEqual([
+      'foobar-project@10.0.0',
+      'foobar-project@0.10.0',
+      'foobar-project@0.0.10',
+      'foo-project@5.0.0',
+      'foo-project@4.0.0',
+      'blarg-project@1.0.0'
+    ])
   })
 
-  it('should allow lerna style tags to be filtered by package', () => {
+  it('should allow lerna style tags to be filtered by package', async () => {
     testTools.writeFileSync('test5', '')
     testTools.exec('git add --all && git commit -m"seventh commit"')
     testTools.exec('git tag bar-project@5.0.0')
 
-    return new Promise((resolve, reject) => {
-      gitSemverTags({
-        cwd: testTools.cwd,
-        lernaTags: true,
-        package: 'bar-project'
-      }, (err, tags) => {
-        if (err) return reject(err)
-        expect(tags).toEqual(['bar-project@5.0.0'])
-        resolve()
-      })
+    const tags = await gitSemverTags({
+      cwd: testTools.cwd,
+      lernaTags: true,
+      package: 'bar-project'
     })
+
+    expect(tags).toEqual(['bar-project@5.0.0'])
   })
 
-  it('should not allow package filter without lernaTags=true', () => {
-    return new Promise((resolve) => {
-      gitSemverTags({
-        cwd: testTools.cwd,
-        package: 'bar-project'
-      }, (err) => {
-        expect(err.message).toBe('opts.package should only be used when running in lerna mode')
-        resolve()
-      })
-    })
+  it('should not allow package filter without lernaTags=true', async () => {
+    await expect(() => gitSemverTags({
+      cwd: testTools.cwd,
+      package: 'bar-project'
+    })).rejects.toThrow('opts.package should only be used when running in lerna mode')
   })
 
-  it('should work with tag prefix option', () => {
+  it('should work with tag prefix option', async () => {
     testTools.writeFileSync('test6', '')
     testTools.exec('git add --all && git commit -m"eighth commit"')
     testTools.exec('git tag ms/6.0.0')
@@ -245,19 +191,15 @@ describe('git-semver-tags', () => {
     testTools.exec('git add --all && git commit -m"eleventh commit"')
     testTools.exec('git tag notms/7.0.0')
 
-    return new Promise((resolve, reject) => {
-      gitSemverTags({
-        cwd: testTools.cwd,
-        tagPrefix: 'ms/'
-      }, (err, tags) => {
-        if (err) return reject(err)
-        expect(tags).toEqual(['ms/7.0.0', 'ms/6.0.0'])
-        resolve()
-      })
+    const tags = await gitSemverTags({
+      cwd: testTools.cwd,
+      tagPrefix: 'ms/'
     })
+
+    expect(tags).toEqual(['ms/7.0.0', 'ms/6.0.0'])
   })
 
-  it('should handle regexp escaped characters in the tag prefix', () => {
+  it('should handle regexp escaped characters in the tag prefix', async () => {
     testTools.writeFileSync('test6', '')
     testTools.exec('git add --all && git commit -m"eighth commit"')
     testTools.exec('git tag ms+6.0.0')
@@ -268,19 +210,15 @@ describe('git-semver-tags', () => {
     testTools.exec('git add --all && git commit -m"eleventh commit"')
     testTools.exec('git tag notms+7.0.0')
 
-    return new Promise((resolve, reject) => {
-      gitSemverTags({
-        cwd: testTools.cwd,
-        tagPrefix: 'ms+'
-      }, (err, tags) => {
-        if (err) return reject(err)
-        expect(tags).toEqual(['ms+7.0.0', 'ms+6.0.0'])
-        resolve()
-      })
+    const tags = await gitSemverTags({
+      cwd: testTools.cwd,
+      tagPrefix: 'ms+'
     })
+
+    expect(tags).toEqual(['ms+7.0.0', 'ms+6.0.0'])
   })
 
-  it('should skip unstable tags', () => {
+  it('should skip unstable tags', async () => {
     testTools.writeFileSync('test7', '')
     testTools.exec('git add --all && git commit -m"twelfth commit"')
     testTools.exec('git tag skip/8.0.0')
@@ -294,16 +232,12 @@ describe('git-semver-tags', () => {
     testTools.exec('git add --all && git commit -m"fifteenth commit"')
     testTools.exec('git tag skip/9.0.0')
 
-    return new Promise((resolve, reject) => {
-      gitSemverTags({
-        cwd: testTools.cwd,
-        tagPrefix: 'skip/',
-        skipUnstable: true
-      }, (err, tags) => {
-        if (err) return reject(err)
-        expect(tags).toEqual(['skip/9.0.0', 'skip/8.0.0'])
-        resolve()
-      })
+    const tags = await gitSemverTags({
+      cwd: testTools.cwd,
+      tagPrefix: 'skip/',
+      skipUnstable: true
     })
+
+    expect(tags).toEqual(['skip/9.0.0', 'skip/8.0.0'])
   })
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -237,9 +237,6 @@ importers:
 
   packages/conventional-recommended-bump:
     dependencies:
-      concat-stream:
-        specifier: ^2.0.0
-        version: 2.0.0
       conventional-changelog-preset-loader:
         specifier: workspace:^
         version: link:../conventional-changelog-preset-loader


### PR DESCRIPTION
BREAKING CHANGE: gitSemverTags and conventionalRecommendedBump now return promises