### PR TITLE
fix(conventional-changelog-conventionalcommits): optional config

### DIFF
--- a/packages/conventional-changelog-conventionalcommits/conventionalRecommendedBump.js
+++ b/packages/conventional-changelog-conventionalcommits/conventionalRecommendedBump.js
@@ -27,7 +27,7 @@ function createConventionalRecommendedBumpOpts (config, parserOpts) {
         }
       })
 
-      if (config.preMajor && level < 2) {
+      if (config?.preMajor && level < 2) {
         level++
       }
 

--- a/packages/conventional-recommended-bump/test/index.spec.js
+++ b/packages/conventional-recommended-bump/test/index.spec.js
@@ -71,13 +71,24 @@ describe('conventional-recommended-bump', () => {
     await expect(() => conventionalRecommendedBump({ cwd: testTools.cwd }, {})).rejects.toThrow()
   })
 
+  it('should allow the string `conventionalcommits` as the preset option', async () => {
+    preparing(2)
+
+    await expect(() => conventionalRecommendedBump({
+      cwd: testTools.cwd,
+      preset: 'conventionalcommits'
+    }, {})).not.toThrowError()
+  })
+
   describe('conventionalcommits ! in isolation', () => {
     it('recommends major if ! is used in isolation', async () => {
       preparing(2)
 
       const recommendation = await conventionalRecommendedBump({
         cwd: testTools.cwd,
-        preset: 'conventionalcommits'
+        preset: {
+          name: 'conventionalcommits'
+        }
       }, {})
 
       expect(recommendation.reason).toContain('1 BREAKING')

--- a/packages/conventional-recommended-bump/test/index.spec.js
+++ b/packages/conventional-recommended-bump/test/index.spec.js
@@ -77,9 +77,7 @@ describe('conventional-recommended-bump', () => {
 
       const recommendation = await conventionalRecommendedBump({
         cwd: testTools.cwd,
-        preset: {
-          name: 'conventionalcommits'
-        }
+        preset: 'conventionalcommits'
       }, {})
 
       expect(recommendation.reason).toContain('1 BREAKING')


### PR DESCRIPTION
It throws error, when the preset option is set to the string `conventionalcommits`.

![image](https://github.com/conventional-changelog/conventional-changelog/assets/11309921/8ec3b823-610f-43f6-8447-d934db6ecdd4)
