### PR TITLE
revert(conventional-changelog-cli): contenxt supports both json and js file types at the same time

### DIFF
--- a/packages/conventional-changelog-cli/cli.js
+++ b/packages/conventional-changelog-cli/cli.js
@@ -163,7 +163,7 @@ let outStream
 
 try {
   if (flags.context) {
-    templateContext = JSON.parse(await readFile(relativeResolve(flags.context), 'utf8'))
+    templateContext = require(resolve(process.cwd(), flags.context))
   }
 
   if (flags.config) {


### PR DESCRIPTION

close: #1153