### PR TITLE
feat(conventional-changelog-writer): writerOpts supports timeZone

### DIFF
--- a/packages/conventional-changelog-writer/README.md
+++ b/packages/conventional-changelog-writer/README.md
@@ -137,7 +137,7 @@ Issue or pull request keyword in the url if `context.linkReferences === true`.
 
 ##### date
 
-Type: `string` Default: formatted (`'yyyy-mm-dd'`) today's date in timezone set by [`timeZone`](#timezone) option.
+Type: `string` Default: formatted (`'yyyy-mm-dd'`) today's date in timezone set by [`timeZone`](#timeZone) option.
 
 If `version` is found in the last commit, `committerDate` will overwrite this.
 

--- a/packages/conventional-changelog-writer/README.md
+++ b/packages/conventional-changelog-writer/README.md
@@ -137,7 +137,7 @@ Issue or pull request keyword in the url if `context.linkReferences === true`.
 
 ##### date
 
-Type: `string` Default: formatted (`'yyyy-mm-dd'`) today's date in timezone set by timeZone option.
+Type: `string` Default: formatted (`'yyyy-mm-dd'`) today's date in timezone set by [`timeZone`](#timezone) option.
 
 If `version` is found in the last commit, `committerDate` will overwrite this.
 
@@ -300,7 +300,7 @@ Partials that used in the main template, if any. The key should be the partial n
 
 ##### timeZone
 
-Type: `string` Default: `UTC`
+Type: `string` Default: `'UTC'`
 
 The timezone to use. The date in the changelog is generated based on timezone.
 

--- a/packages/conventional-changelog-writer/README.md
+++ b/packages/conventional-changelog-writer/README.md
@@ -298,6 +298,11 @@ Type: `object`
 
 Partials that used in the main template, if any. The key should be the partial name and the value should be handlebars template strings. If you are using handlebars template files, read files by yourself.
 
+##### timeZone
+
+Type: `string` Default: `UTC`
+
+The time zone to use. The date in the changelog is generated based on time zone.
 
 ## Customization Guide
 

--- a/packages/conventional-changelog-writer/README.md
+++ b/packages/conventional-changelog-writer/README.md
@@ -137,7 +137,7 @@ Issue or pull request keyword in the url if `context.linkReferences === true`.
 
 ##### date
 
-Type: `string` Default: formatted (`'yyyy-mm-dd'`) today's date in UTC timezone
+Type: `string` Default: formatted (`'yyyy-mm-dd'`) today's date in timezone set by timeZone option.
 
 If `version` is found in the last commit, `committerDate` will overwrite this.
 
@@ -302,7 +302,7 @@ Partials that used in the main template, if any. The key should be the partial n
 
 Type: `string` Default: `UTC`
 
-The time zone to use. The date in the changelog is generated based on time zone.
+The timezone to use. The date in the changelog is generated based on timezone.
 
 ## Customization Guide
 

--- a/packages/conventional-changelog-writer/index.js
+++ b/packages/conventional-changelog-writer/index.js
@@ -11,8 +11,8 @@ import {
 
 const dirname = fileURLToPath(new URL('.', import.meta.url))
 
-// sv-SE is used for yyyy-mm-dd format
 function formatDate(date, timeZone = 'UTC') {
+  // sv-SE is used for yyyy-mm-dd format
   return Intl.DateTimeFormat('sv-SE', {
     timeZone
   }).format(date)

--- a/packages/conventional-changelog-writer/index.js
+++ b/packages/conventional-changelog-writer/index.js
@@ -11,7 +11,7 @@ import {
 
 const dirname = fileURLToPath(new URL('.', import.meta.url))
 
-function formatDate(date, timeZone = 'UTC') {
+function formatDate (date, timeZone = 'UTC') {
   // sv-SE is used for yyyy-mm-dd format
   return Intl.DateTimeFormat('sv-SE', {
     timeZone

--- a/packages/conventional-changelog-writer/index.js
+++ b/packages/conventional-changelog-writer/index.js
@@ -12,10 +12,10 @@ import {
 const dirname = fileURLToPath(new URL('.', import.meta.url))
 
 // sv-SE is used for yyyy-mm-dd format
-function dateFormatter(timeZone) {
+function formatDate(date, timeZone = 'UTC') {
   return Intl.DateTimeFormat('sv-SE', {
     timeZone
-  })
+  }).format(date)
 }
 
 function immediate () {
@@ -26,7 +26,7 @@ async function conventionalChangelogWriterInit (context, options) {
   context = {
     commit: 'commits',
     issue: 'issues',
-    date: dateFormatter(options?.timeZone ?? 'UTC').format(new Date()),
+    date: formatDate(new Date(), options?.timeZone),
     ...context
   }
 
@@ -80,7 +80,7 @@ async function conventionalChangelogWriterInit (context, options) {
           return
         }
 
-        return dateFormatter(options?.timeZone ?? 'UTC').format(new Date(date))
+        return formatDate(new Date(date), options?.timeZone)
       },
       ...options.transform
     }

--- a/packages/conventional-changelog-writer/index.js
+++ b/packages/conventional-changelog-writer/index.js
@@ -12,9 +12,11 @@ import {
 const dirname = fileURLToPath(new URL('.', import.meta.url))
 
 // sv-SE is used for yyyy-mm-dd format
-const dateFormatter = Intl.DateTimeFormat('sv-SE', {
-  timeZone: 'UTC'
-})
+function dateFormatter(timeZone) {
+  return Intl.DateTimeFormat('sv-SE', {
+    timeZone
+  })
+}
 
 function immediate () {
   return new Promise(resolve => setImmediate(resolve))
@@ -24,7 +26,7 @@ async function conventionalChangelogWriterInit (context, options) {
   context = {
     commit: 'commits',
     issue: 'issues',
-    date: dateFormatter.format(new Date()),
+    date: dateFormatter(options?.timeZone ?? 'UTC').format(new Date()),
     ...context
   }
 
@@ -78,7 +80,7 @@ async function conventionalChangelogWriterInit (context, options) {
           return
         }
 
-        return dateFormatter.format(new Date(date))
+        return dateFormatter(options?.timeZone ?? 'UTC').format(new Date(date))
       },
       ...options.transform
     }

--- a/packages/conventional-changelog-writer/test/index.spec.js
+++ b/packages/conventional-changelog-writer/test/index.spec.js
@@ -10,8 +10,8 @@ function formatDate(date, timeZone = 'UTC') {
   }).format(date)
 }
 
-function getTodayDate(timezone) {
-  return formatDate(new Date(), timezone)
+function getTodayDate(timeZone) {
+  return formatDate(new Date(), timeZone)
 }
 
 const todayUtc = getTodayDate()
@@ -847,7 +847,7 @@ describe('conventional-changelog-writer', () => {
         expect(i).toBe(2)
       });
 
-      it('should generated date from timezone of the option', async () => {
+      it('should generated date from timeZone of the option', async () => {
         let i = 0
 
         for await (const chunk of getStream().pipe(conventionalChangelogWriter({}, {

--- a/packages/conventional-changelog-writer/test/index.spec.js
+++ b/packages/conventional-changelog-writer/test/index.spec.js
@@ -3,8 +3,8 @@ import { describe, it, expect } from 'vitest'
 import { delay, throughObj } from '../../../tools/test-tools.js'
 import conventionalChangelogWriter, { parseArray } from '../index.js'
 
-// sv-SEis used for yyyy-mm-dd format
 function formatDate(date, timeZone = 'UTC') {
+  // sv-SE is used for yyyy-mm-dd format
   return Intl.DateTimeFormat('sv-SE', {
     timeZone
   }).format(date)

--- a/packages/conventional-changelog-writer/test/index.spec.js
+++ b/packages/conventional-changelog-writer/test/index.spec.js
@@ -4,10 +4,12 @@ import { delay, throughObj } from '../../../tools/test-tools.js'
 import conventionalChangelogWriter, { parseArray } from '../index.js'
 
 // sv-SEis used for yyyy-mm-dd format
-const dateFormatter = Intl.DateTimeFormat('sv-SE', {
-  timeZone: 'UTC'
-})
-const today = dateFormatter.format(new Date())
+function dateFormatter(timeZone) {
+  return Intl.DateTimeFormat('sv-SE', {
+    timeZone
+  })
+}
+const today = (timeZone = 'UTC') => dateFormatter(timeZone).format(new Date())
 const commits = [
   {
     hash: '9b1aff905b638aa274a5fc8f88662df446d374bd',
@@ -82,7 +84,7 @@ describe('conventional-changelog-writer', () => {
 
       for await (let chunk of upstream.pipe(conventionalChangelogWriter())) {
         chunk = chunk.toString()
-        expect(chunk).toBe('##  (' + today + ')\n\n\n\n\n')
+        expect(chunk).toBe('##  (' + today() + ')\n\n\n\n\n')
         i++
       }
 
@@ -180,7 +182,7 @@ describe('conventional-changelog-writer', () => {
           expect(context).toEqual({
             commit: 'commits',
             issue: 'issues',
-            date: today
+            date: today()
           })
           called = true
           return commit
@@ -193,7 +195,7 @@ describe('conventional-changelog-writer', () => {
           expect(context).toEqual({
             commit: 'commits',
             issue: 'issues',
-            date: today
+            date: today()
           })
 
           return commit
@@ -283,7 +285,7 @@ describe('conventional-changelog-writer', () => {
         }
       })
 
-      expect(changelog).toBe('##  (' + today + ')\n\n\n\n\n')
+      expect(changelog).toBe('##  (' + today() + ')\n\n\n\n\n')
 
       for await (let chunk of getStream().pipe(conventionalChangelogWriter({}, {
         transform () {
@@ -291,7 +293,7 @@ describe('conventional-changelog-writer', () => {
         }
       }))) {
         chunk = chunk.toString()
-        expect(chunk).toBe('##  (' + today + ')\n\n\n\n\n')
+        expect(chunk).toBe('##  (' + today() + ')\n\n\n\n\n')
 
         i++
       }
@@ -400,7 +402,7 @@ describe('conventional-changelog-writer', () => {
         let i = 0
         const changelog = await parseArray(commits)
 
-        expect(changelog).toContain('##  (' + today)
+        expect(changelog).toContain('##  (' + today())
         expect(changelog).toContain('feat(scope): ')
         expect(changelog).toContain('## <small>1.0.1 (2015-04-07)</small>')
         expect(changelog).toContain('fix(ng-list): ')
@@ -411,7 +413,7 @@ describe('conventional-changelog-writer', () => {
           chunk = chunk.toString()
 
           if (i === 0) {
-            expect(chunk).toContain('##  (' + today)
+            expect(chunk).toContain('##  (' + today())
             expect(chunk).toContain('feat(scope): ')
 
             expect(chunk).not.toContain('fix(ng-list): ')
@@ -483,7 +485,7 @@ describe('conventional-changelog-writer', () => {
           generateOn: 'version'
         })
 
-        expect(changelog).toContain('##  (' + today)
+        expect(changelog).toContain('##  (' + today())
         expect(changelog).toContain('feat(scope): broadcast $destroy event on scope destruction')
         expect(changelog).not.toContain('<a name=""></a>')
         expect(changelog).toContain('fix(ng-list): Allow custom separator')
@@ -497,7 +499,7 @@ describe('conventional-changelog-writer', () => {
           chunk = chunk.toString()
 
           if (i === 0) {
-            expect(chunk).toContain('##  (' + today)
+            expect(chunk).toContain('##  (' + today())
 
             expect(chunk).not.toContain('## 1.0.1 (2015-04-07)')
           } else if (i === 1) {
@@ -532,7 +534,7 @@ describe('conventional-changelog-writer', () => {
           chunk = chunk.toString()
 
           if (i === 0) {
-            expect(chunk).toContain('##  (' + today)
+            expect(chunk).toContain('##  (' + today())
             expect(chunk).not.toContain('## 1.0.1 (2015-04-07)')
           }
 
@@ -550,7 +552,7 @@ describe('conventional-changelog-writer', () => {
         }))) {
           chunk = chunk.toString()
 
-          expect(chunk).toContain('##  (' + today)
+          expect(chunk).toContain('##  (' + today())
 
           i++
         }
@@ -598,7 +600,7 @@ describe('conventional-changelog-writer', () => {
           chunk = chunk.toString()
 
           if (i === 0) {
-            expect(chunk).toBe('##  (' + today + ')\n\n\n\n\n')
+            expect(chunk).toBe('##  (' + today() + ')\n\n\n\n\n')
           } else {
             expect(chunk).toBe('## <small>1.0.1 (2015-04-07 15:00:44 +1000)</small>\n\n\n\n\n')
           }
@@ -616,7 +618,7 @@ describe('conventional-changelog-writer', () => {
           includeDetails: true
         }))) {
           if (i === 0) {
-            expect(chunk.log).toContain('##  (' + today + ')\n\n')
+            expect(chunk.log).toContain('##  (' + today() + ')\n\n')
             expect(chunk.log).toContain('feat(scope): broadcast $destroy event on scope destruction')
             expect(chunk.keyCommit).toBe()
           } else {
@@ -784,7 +786,7 @@ describe('conventional-changelog-writer', () => {
 
 
 
-        ##  (xxxx-xx-xx)`).replace('xxxx-xx-xx', today))
+        ##  (xxxx-xx-xx)`).replace('xxxx-xx-xx', today()))
 
         for await (let chunk of upstream.pipe(conventionalChangelogWriter({}, {
           reverse: true
@@ -807,7 +809,7 @@ describe('conventional-changelog-writer', () => {
             expect(chunk).toContain('perf(template): ')
             expect(chunk).toContain('refactor(name): ')
           } else if (i === 3) {
-            expect(chunk).toContain('##  (' + today)
+            expect(chunk).toContain('##  (' + today())
           }
 
           i++
@@ -830,9 +832,27 @@ describe('conventional-changelog-writer', () => {
           if (i === 0) {
             expect(chunk).toBe('## <small>1.0.1 (2015-04-07 15:00:44 +1000)</small>\n\n\n\n\n')
           } else {
-            expect(chunk).toBe('##  (' + today + ')\n\n\n\n\n')
+            expect(chunk).toBe('##  (' + today() + ')\n\n\n\n\n')
           }
 
+          i++
+        }
+
+        expect(i).toBe(2)
+      });
+
+      it('should generated date from timezone of the option', async () => {
+        let i = 0
+
+        for await (const chunk of getStream().pipe(conventionalChangelogWriter({}, {
+          timeZone: 'America/New_York',
+          transform () {
+            return false
+          }
+        }))) {
+          if(i === 0) {
+            expect(chunk).toBe('##  (' + today('America/New_York') + ')\n\n\n\n\n')
+          }
           i++
         }
 
@@ -853,7 +873,7 @@ describe('conventional-changelog-writer', () => {
             expect(chunk.keyCommit.version).toBe('1.0.1')
             expect(chunk.keyCommit.committerDate).toBe('2015-04-07')
           } else {
-            expect(chunk.log).toContain('##  (' + today + ')\n\n')
+            expect(chunk.log).toContain('##  (' + today() + ')\n\n')
             expect(chunk.log).toContain('perf(template): tweak')
             expect(chunk.log).toContain('refactor(name): rename this module to conventional-changelog-writer')
             expect(chunk.keyCommit).toBe()
@@ -960,7 +980,7 @@ describe('conventional-changelog-writer', () => {
     upstream.end()
 
     for await (const chunk of upstream.pipe(conventionalChangelogWriter())) {
-      expect(chunk.toString()).toBe('##  (' + today + ')\n\n* bla\n\n\n\n')
+      expect(chunk.toString()).toBe('##  (' + today() + ')\n\n* bla\n\n\n\n')
       i++
     }
 

--- a/packages/conventional-changelog-writer/test/index.spec.js
+++ b/packages/conventional-changelog-writer/test/index.spec.js
@@ -90,7 +90,7 @@ describe('conventional-changelog-writer', () => {
 
       for await (let chunk of upstream.pipe(conventionalChangelogWriter())) {
         chunk = chunk.toString()
-        expect(chunk).toBe('##  (' + todayUtc  + ')\n\n\n\n\n')
+        expect(chunk).toBe('##  (' + todayUtc + ')\n\n\n\n\n')
         i++
       }
 
@@ -188,7 +188,7 @@ describe('conventional-changelog-writer', () => {
           expect(context).toEqual({
             commit: 'commits',
             issue: 'issues',
-            date: todayUtc 
+            date: todayUtc
           })
           called = true
           return commit
@@ -201,7 +201,7 @@ describe('conventional-changelog-writer', () => {
           expect(context).toEqual({
             commit: 'commits',
             issue: 'issues',
-            date: todayUtc 
+            date: todayUtc
           })
 
           return commit
@@ -291,7 +291,7 @@ describe('conventional-changelog-writer', () => {
         }
       })
 
-      expect(changelog).toBe('##  (' + todayUtc  + ')\n\n\n\n\n')
+      expect(changelog).toBe('##  (' + todayUtc + ')\n\n\n\n\n')
 
       for await (let chunk of getStream().pipe(conventionalChangelogWriter({}, {
         transform () {
@@ -299,7 +299,7 @@ describe('conventional-changelog-writer', () => {
         }
       }))) {
         chunk = chunk.toString()
-        expect(chunk).toBe('##  (' + todayUtc  + ')\n\n\n\n\n')
+        expect(chunk).toBe('##  (' + todayUtc + ')\n\n\n\n\n')
 
         i++
       }
@@ -408,7 +408,7 @@ describe('conventional-changelog-writer', () => {
         let i = 0
         const changelog = await parseArray(commits)
 
-        expect(changelog).toContain('##  (' + todayUtc )
+        expect(changelog).toContain('##  (' + todayUtc)
         expect(changelog).toContain('feat(scope): ')
         expect(changelog).toContain('## <small>1.0.1 (2015-04-07)</small>')
         expect(changelog).toContain('fix(ng-list): ')
@@ -419,7 +419,7 @@ describe('conventional-changelog-writer', () => {
           chunk = chunk.toString()
 
           if (i === 0) {
-            expect(chunk).toContain('##  (' + todayUtc )
+            expect(chunk).toContain('##  (' + todayUtc)
             expect(chunk).toContain('feat(scope): ')
 
             expect(chunk).not.toContain('fix(ng-list): ')
@@ -491,7 +491,7 @@ describe('conventional-changelog-writer', () => {
           generateOn: 'version'
         })
 
-        expect(changelog).toContain('##  (' + todayUtc )
+        expect(changelog).toContain('##  (' + todayUtc)
         expect(changelog).toContain('feat(scope): broadcast $destroy event on scope destruction')
         expect(changelog).not.toContain('<a name=""></a>')
         expect(changelog).toContain('fix(ng-list): Allow custom separator')
@@ -505,7 +505,7 @@ describe('conventional-changelog-writer', () => {
           chunk = chunk.toString()
 
           if (i === 0) {
-            expect(chunk).toContain('##  (' + todayUtc )
+            expect(chunk).toContain('##  (' + todayUtc)
 
             expect(chunk).not.toContain('## 1.0.1 (2015-04-07)')
           } else if (i === 1) {
@@ -540,7 +540,7 @@ describe('conventional-changelog-writer', () => {
           chunk = chunk.toString()
 
           if (i === 0) {
-            expect(chunk).toContain('##  (' + todayUtc )
+            expect(chunk).toContain('##  (' + todayUtc)
             expect(chunk).not.toContain('## 1.0.1 (2015-04-07)')
           }
 
@@ -558,7 +558,7 @@ describe('conventional-changelog-writer', () => {
         }))) {
           chunk = chunk.toString()
 
-          expect(chunk).toContain('##  (' + todayUtc )
+          expect(chunk).toContain('##  (' + todayUtc)
 
           i++
         }
@@ -606,7 +606,7 @@ describe('conventional-changelog-writer', () => {
           chunk = chunk.toString()
 
           if (i === 0) {
-            expect(chunk).toBe('##  (' + todayUtc  + ')\n\n\n\n\n')
+            expect(chunk).toBe('##  (' + todayUtc + ')\n\n\n\n\n')
           } else {
             expect(chunk).toBe('## <small>1.0.1 (2015-04-07 15:00:44 +1000)</small>\n\n\n\n\n')
           }
@@ -624,7 +624,7 @@ describe('conventional-changelog-writer', () => {
           includeDetails: true
         }))) {
           if (i === 0) {
-            expect(chunk.log).toContain('##  (' + todayUtc  + ')\n\n')
+            expect(chunk.log).toContain('##  (' + todayUtc + ')\n\n')
             expect(chunk.log).toContain('feat(scope): broadcast $destroy event on scope destruction')
             expect(chunk.keyCommit).toBe()
           } else {
@@ -792,7 +792,7 @@ describe('conventional-changelog-writer', () => {
 
 
 
-        ##  (xxxx-xx-xx)`).replace('xxxx-xx-xx', todayUtc ))
+        ##  (xxxx-xx-xx)`).replace('xxxx-xx-xx', todayUtc))
 
         for await (let chunk of upstream.pipe(conventionalChangelogWriter({}, {
           reverse: true
@@ -815,7 +815,7 @@ describe('conventional-changelog-writer', () => {
             expect(chunk).toContain('perf(template): ')
             expect(chunk).toContain('refactor(name): ')
           } else if (i === 3) {
-            expect(chunk).toContain('##  (' + todayUtc )
+            expect(chunk).toContain('##  (' + todayUtc)
           }
 
           i++
@@ -838,7 +838,7 @@ describe('conventional-changelog-writer', () => {
           if (i === 0) {
             expect(chunk).toBe('## <small>1.0.1 (2015-04-07 15:00:44 +1000)</small>\n\n\n\n\n')
           } else {
-            expect(chunk).toBe('##  (' + todayUtc  + ')\n\n\n\n\n')
+            expect(chunk).toBe('##  (' + todayUtc + ')\n\n\n\n\n')
           }
 
           i++
@@ -879,7 +879,7 @@ describe('conventional-changelog-writer', () => {
             expect(chunk.keyCommit.version).toBe('1.0.1')
             expect(chunk.keyCommit.committerDate).toBe('2015-04-07')
           } else {
-            expect(chunk.log).toContain('##  (' + todayUtc  + ')\n\n')
+            expect(chunk.log).toContain('##  (' + todayUtc + ')\n\n')
             expect(chunk.log).toContain('perf(template): tweak')
             expect(chunk.log).toContain('refactor(name): rename this module to conventional-changelog-writer')
             expect(chunk.keyCommit).toBe()
@@ -986,7 +986,7 @@ describe('conventional-changelog-writer', () => {
     upstream.end()
 
     for await (const chunk of upstream.pipe(conventionalChangelogWriter())) {
-      expect(chunk.toString()).toBe('##  (' + todayUtc  + ')\n\n* bla\n\n\n\n')
+      expect(chunk.toString()).toBe('##  (' + todayUtc + ')\n\n* bla\n\n\n\n')
       i++
     }
 

--- a/packages/conventional-changelog-writer/test/index.spec.js
+++ b/packages/conventional-changelog-writer/test/index.spec.js
@@ -3,14 +3,14 @@ import { describe, it, expect } from 'vitest'
 import { delay, throughObj } from '../../../tools/test-tools.js'
 import conventionalChangelogWriter, { parseArray } from '../index.js'
 
-function formatDate(date, timeZone = 'UTC') {
+function formatDate (date, timeZone = 'UTC') {
   // sv-SE is used for yyyy-mm-dd format
   return Intl.DateTimeFormat('sv-SE', {
     timeZone
   }).format(date)
 }
 
-function getTodayDate(timeZone) {
+function getTodayDate (timeZone) {
   return formatDate(new Date(), timeZone)
 }
 
@@ -845,7 +845,7 @@ describe('conventional-changelog-writer', () => {
         }
 
         expect(i).toBe(2)
-      });
+      })
 
       it('should generated date from timeZone of the option', async () => {
         let i = 0
@@ -856,7 +856,7 @@ describe('conventional-changelog-writer', () => {
             return false
           }
         }))) {
-          if(i === 0) {
+          if (i === 0) {
             expect(chunk).toBe('##  (' + getTodayDate('America/New_York') + ')\n\n\n\n\n')
           }
           i++

--- a/packages/conventional-changelog-writer/test/index.spec.js
+++ b/packages/conventional-changelog-writer/test/index.spec.js
@@ -4,12 +4,18 @@ import { delay, throughObj } from '../../../tools/test-tools.js'
 import conventionalChangelogWriter, { parseArray } from '../index.js'
 
 // sv-SEis used for yyyy-mm-dd format
-function dateFormatter(timeZone) {
+function formatDate(date, timeZone = 'UTC') {
   return Intl.DateTimeFormat('sv-SE', {
     timeZone
-  })
+  }).format(date)
 }
-const today = (timeZone = 'UTC') => dateFormatter(timeZone).format(new Date())
+
+function getTodayDate(timezone) {
+  return formatDate(new Date(), timezone)
+}
+
+const todayUtc = getTodayDate()
+
 const commits = [
   {
     hash: '9b1aff905b638aa274a5fc8f88662df446d374bd',
@@ -84,7 +90,7 @@ describe('conventional-changelog-writer', () => {
 
       for await (let chunk of upstream.pipe(conventionalChangelogWriter())) {
         chunk = chunk.toString()
-        expect(chunk).toBe('##  (' + today() + ')\n\n\n\n\n')
+        expect(chunk).toBe('##  (' + todayUtc  + ')\n\n\n\n\n')
         i++
       }
 
@@ -182,7 +188,7 @@ describe('conventional-changelog-writer', () => {
           expect(context).toEqual({
             commit: 'commits',
             issue: 'issues',
-            date: today()
+            date: todayUtc 
           })
           called = true
           return commit
@@ -195,7 +201,7 @@ describe('conventional-changelog-writer', () => {
           expect(context).toEqual({
             commit: 'commits',
             issue: 'issues',
-            date: today()
+            date: todayUtc 
           })
 
           return commit
@@ -285,7 +291,7 @@ describe('conventional-changelog-writer', () => {
         }
       })
 
-      expect(changelog).toBe('##  (' + today() + ')\n\n\n\n\n')
+      expect(changelog).toBe('##  (' + todayUtc  + ')\n\n\n\n\n')
 
       for await (let chunk of getStream().pipe(conventionalChangelogWriter({}, {
         transform () {
@@ -293,7 +299,7 @@ describe('conventional-changelog-writer', () => {
         }
       }))) {
         chunk = chunk.toString()
-        expect(chunk).toBe('##  (' + today() + ')\n\n\n\n\n')
+        expect(chunk).toBe('##  (' + todayUtc  + ')\n\n\n\n\n')
 
         i++
       }
@@ -402,7 +408,7 @@ describe('conventional-changelog-writer', () => {
         let i = 0
         const changelog = await parseArray(commits)
 
-        expect(changelog).toContain('##  (' + today())
+        expect(changelog).toContain('##  (' + todayUtc )
         expect(changelog).toContain('feat(scope): ')
         expect(changelog).toContain('## <small>1.0.1 (2015-04-07)</small>')
         expect(changelog).toContain('fix(ng-list): ')
@@ -413,7 +419,7 @@ describe('conventional-changelog-writer', () => {
           chunk = chunk.toString()
 
           if (i === 0) {
-            expect(chunk).toContain('##  (' + today())
+            expect(chunk).toContain('##  (' + todayUtc )
             expect(chunk).toContain('feat(scope): ')
 
             expect(chunk).not.toContain('fix(ng-list): ')
@@ -485,7 +491,7 @@ describe('conventional-changelog-writer', () => {
           generateOn: 'version'
         })
 
-        expect(changelog).toContain('##  (' + today())
+        expect(changelog).toContain('##  (' + todayUtc )
         expect(changelog).toContain('feat(scope): broadcast $destroy event on scope destruction')
         expect(changelog).not.toContain('<a name=""></a>')
         expect(changelog).toContain('fix(ng-list): Allow custom separator')
@@ -499,7 +505,7 @@ describe('conventional-changelog-writer', () => {
           chunk = chunk.toString()
 
           if (i === 0) {
-            expect(chunk).toContain('##  (' + today())
+            expect(chunk).toContain('##  (' + todayUtc )
 
             expect(chunk).not.toContain('## 1.0.1 (2015-04-07)')
           } else if (i === 1) {
@@ -534,7 +540,7 @@ describe('conventional-changelog-writer', () => {
           chunk = chunk.toString()
 
           if (i === 0) {
-            expect(chunk).toContain('##  (' + today())
+            expect(chunk).toContain('##  (' + todayUtc )
             expect(chunk).not.toContain('## 1.0.1 (2015-04-07)')
           }
 
@@ -552,7 +558,7 @@ describe('conventional-changelog-writer', () => {
         }))) {
           chunk = chunk.toString()
 
-          expect(chunk).toContain('##  (' + today())
+          expect(chunk).toContain('##  (' + todayUtc )
 
           i++
         }
@@ -600,7 +606,7 @@ describe('conventional-changelog-writer', () => {
           chunk = chunk.toString()
 
           if (i === 0) {
-            expect(chunk).toBe('##  (' + today() + ')\n\n\n\n\n')
+            expect(chunk).toBe('##  (' + todayUtc  + ')\n\n\n\n\n')
           } else {
             expect(chunk).toBe('## <small>1.0.1 (2015-04-07 15:00:44 +1000)</small>\n\n\n\n\n')
           }
@@ -618,7 +624,7 @@ describe('conventional-changelog-writer', () => {
           includeDetails: true
         }))) {
           if (i === 0) {
-            expect(chunk.log).toContain('##  (' + today() + ')\n\n')
+            expect(chunk.log).toContain('##  (' + todayUtc  + ')\n\n')
             expect(chunk.log).toContain('feat(scope): broadcast $destroy event on scope destruction')
             expect(chunk.keyCommit).toBe()
           } else {
@@ -786,7 +792,7 @@ describe('conventional-changelog-writer', () => {
 
 
 
-        ##  (xxxx-xx-xx)`).replace('xxxx-xx-xx', today()))
+        ##  (xxxx-xx-xx)`).replace('xxxx-xx-xx', todayUtc ))
 
         for await (let chunk of upstream.pipe(conventionalChangelogWriter({}, {
           reverse: true
@@ -809,7 +815,7 @@ describe('conventional-changelog-writer', () => {
             expect(chunk).toContain('perf(template): ')
             expect(chunk).toContain('refactor(name): ')
           } else if (i === 3) {
-            expect(chunk).toContain('##  (' + today())
+            expect(chunk).toContain('##  (' + todayUtc )
           }
 
           i++
@@ -832,7 +838,7 @@ describe('conventional-changelog-writer', () => {
           if (i === 0) {
             expect(chunk).toBe('## <small>1.0.1 (2015-04-07 15:00:44 +1000)</small>\n\n\n\n\n')
           } else {
-            expect(chunk).toBe('##  (' + today() + ')\n\n\n\n\n')
+            expect(chunk).toBe('##  (' + todayUtc  + ')\n\n\n\n\n')
           }
 
           i++
@@ -851,7 +857,7 @@ describe('conventional-changelog-writer', () => {
           }
         }))) {
           if(i === 0) {
-            expect(chunk).toBe('##  (' + today('America/New_York') + ')\n\n\n\n\n')
+            expect(chunk).toBe('##  (' + getTodayDate('America/New_York') + ')\n\n\n\n\n')
           }
           i++
         }
@@ -873,7 +879,7 @@ describe('conventional-changelog-writer', () => {
             expect(chunk.keyCommit.version).toBe('1.0.1')
             expect(chunk.keyCommit.committerDate).toBe('2015-04-07')
           } else {
-            expect(chunk.log).toContain('##  (' + today() + ')\n\n')
+            expect(chunk.log).toContain('##  (' + todayUtc  + ')\n\n')
             expect(chunk.log).toContain('perf(template): tweak')
             expect(chunk.log).toContain('refactor(name): rename this module to conventional-changelog-writer')
             expect(chunk.keyCommit).toBe()
@@ -980,7 +986,7 @@ describe('conventional-changelog-writer', () => {
     upstream.end()
 
     for await (const chunk of upstream.pipe(conventionalChangelogWriter())) {
-      expect(chunk.toString()).toBe('##  (' + today() + ')\n\n* bla\n\n\n\n')
+      expect(chunk.toString()).toBe('##  (' + todayUtc  + ')\n\n* bla\n\n\n\n')
       i++
     }
 


### PR DESCRIPTION
Hi there. I'm a user of this project.
Sorry... I use deepl because I am not good at English. 

I've faced a problem that same as #594. 

I created the PR because I thought it would be better to be able to set timeZone in writerOpts.

## summary
add timezone option to writerOpts(https://github.com/conventional-changelog/conventional-changelog/issues/594#issuecomment-587168242)

The default value is 'UTC' to avoid breaking changes in the conventional-changelog-writer.

### Usage
```js
// option.js
export default {
    writerOpts: {
        timeZone: "Ameraica/Los_Angeles"
    }
}
```

```
$ conventional-changelog -p angular -i CHANGELOG.md -s  -n option.js
```

### When a non-existent timezone is specified
When a non-existent timezone is specified, I get an error like the following.
Or should I catch the error?
```js
// option.js
export default {
    writerOpts: {
        timeZone: "not_found"
    }
}
```

```
$ conventional-changelog -p angular -i CHANGELOG.md -s  -n option.js
RangeError: Invalid time zone specified: not_found
    at Intl.DateTimeFormat (<anonymous>)
    at dateFormatter...
```

If you like it, could you please review and merge this PR?
If further  additional code or test is needed, we will accommodate.