### PR TITLE
feat(conventional-commits-parser): add bodyLines to commit object

### DIFF
--- a/packages/conventional-changelog-writer/README.md
+++ b/packages/conventional-changelog-writer/README.md
@@ -27,6 +27,7 @@ It expects an object mode upstream that looks something like this:
   scope: 'scope',
   subject: 'broadcast $destroy event on scope destruction',
   body: null,
+  bodyLines: [],
   footer: 'Closes #1',
   notes: [],
   references: [ { action: 'Closes', owner: null, repository: null, issue: '1', raw: '#1' } ] }
@@ -36,6 +37,7 @@ It expects an object mode upstream that looks something like this:
   scope: 'ng-list',
   subject: 'Allow custom separator',
   body: 'bla bla bla',
+  bodyLines: ['bla bla bla'],
   footer: 'BREAKING CHANGE: some breaking change',
   notes: [ { title: 'BREAKING CHANGE', text: 'some breaking change' } ],
   references: [] }

--- a/packages/conventional-commits-parser/README.md
+++ b/packages/conventional-commits-parser/README.md
@@ -69,6 +69,7 @@ It will return parsed commit object. Examples:
   merge: null,
   header: 'feat(scope): broadcast $destroy event on scope destruction',
   body: null,
+  bodyLines: [],
   footer: 'Closes #1',
   notes: [],
   references:
@@ -90,6 +91,7 @@ It will return parsed commit object. Examples:
   merge: null,
   header: 'feat(ng-list): Allow custom separator',
   body: 'bla bla bla',
+  bodyLines: ['bla bla bla'],
   footer: 'BREAKING CHANGE: some breaking change.\nThanks @stevemao',
   notes:
    [{
@@ -324,7 +326,7 @@ You will enter an interactive shell. To show your parsed output enter "return" t
 > fix(title): a title is fixed
 
 
-{"type":"fix","scope":"title","subject":"a title is fixed","header":"fix(title): a title is fixed","body":null,"footer":null,"notes":[],"references":[],"revert":null}
+{"type":"fix","scope":"title","subject":"a title is fixed","header":"fix(title): a title is fixed","body":null,","bodyLines":[],"footer":null,"notes":[],"references":[],"revert":null}
 ```
 
 You can also use cli to parse messages from files.
@@ -354,7 +356,7 @@ An array of json will be printed to stdout.
 
 ```sh
 [
-{"type":"feat","scope":"ngMessages","subject":"provide support for dynamic message resolution","header":"feat(ngMessages): provide support for dynamic message resolution","body":"Prior to this fix it was impossible to apply a binding to a the ngMessage directive to represent the name of the error.","footer":"BREAKING CHANGE: The `ngMessagesInclude` attribute is now its own directive and that must be placed as a **child** element within the element with the ngMessages directive.\nCloses #10036\nCloses #9338","notes":[{"title":"BREAKING CHANGE","text":"The `ngMessagesInclude` attribute is now its own directive and that must be placed as a **child** element within the element with the ngMessages directive."}],"references":[{"action":"Closes","owner":null,"repository":null,"issue":"10036","raw":"#10036"},{"action":"Closes","owner":null,"repository":null,"issue":"9338","raw":"#9338"}],"revert":null}
+{"type":"feat","scope":"ngMessages","subject":"provide support for dynamic message resolution","header":"feat(ngMessages): provide support for dynamic message resolution","body":"Prior to this fix it was impossible to apply a binding to a the ngMessage directive to represent the name of the error.","bodyLines":["Prior to this fix it was impossible to apply a binding to a the ngMessage directive to represent the name of the error."],"footer":"BREAKING CHANGE: The `ngMessagesInclude` attribute is now its own directive and that must be placed as a **child** element within the element with the ngMessages directive.\nCloses #10036\nCloses #9338","notes":[{"title":"BREAKING CHANGE","text":"The `ngMessagesInclude` attribute is now its own directive and that must be placed as a **child** element within the element with the ngMessages directive."}],"references":[{"action":"Closes","owner":null,"repository":null,"issue":"10036","raw":"#10036"},{"action":"Closes","owner":null,"repository":null,"issue":"9338","raw":"#9338"}],"revert":null}
 ]
 ```
 
@@ -380,9 +382,9 @@ $ conventional-commits-parser log2.txt '==='
 
 ```sh
 [
-{"type":"docs","scope":"ngMessageExp","subject":"split ngMessage docs up to show its alias more clearly","header":"docs(ngMessageExp): split ngMessage docs up to show its alias more clearly","body":null,"footer":null,"notes":[],"references":[],"revert":null}
+{"type":"docs","scope":"ngMessageExp","subject":"split ngMessage docs up to show its alias more clearly","header":"docs(ngMessageExp): split ngMessage docs up to show its alias more clearly","body":null,"bodyLines":[],"footer":null,"notes":[],"references":[],"revert":null}
 ,
-{"type":"fix","scope":"$animate","subject":"applyStyles from options on leave","header":"fix($animate): applyStyles from options on leave","body":null,"footer":"Closes #10068","notes":[],"references":[{"action":"Closes","owner":null,"repository":null,"issue":"10068","raw":"#10068"}],"revert":null}
+{"type":"fix","scope":"$animate","subject":"applyStyles from options on leave","header":"fix($animate): applyStyles from options on leave","body":null,"bodyLines":[],"footer":"Closes #10068","notes":[],"references":[{"action":"Closes","owner":null,"repository":null,"issue":"10068","raw":"#10068"}],"revert":null}
 ]
 ```
 

--- a/packages/conventional-commits-parser/src/CommitParser.spec.ts
+++ b/packages/conventional-commits-parser/src/CommitParser.spec.ts
@@ -37,6 +37,8 @@ describe('conventional-commits-parser', () => {
         const result = parser.parse(commit)
 
         expect(result.header).toBe('feat(ng-list): Allow custom separator')
+        expect(result.body).toBe('bla bla bla')
+        expect(result.bodyLines).toEqual(['bla bla bla'])
         expect(result.footer).toBe('Closes #123\nCloses #25\nFixes #33')
         expect(result.references).toEqual([
           {
@@ -90,6 +92,24 @@ describe('conventional-commits-parser', () => {
         expect(result.scope).toBe('hello/world')
         expect(result.subject).toBe('message')
       })
+
+      it('should parse multiple body lines from body', () => {
+        const commit = 'feat(conventional-commits-parser): add bodyLines to commit object\n\n'
+          + 'Adds the new property bodyLines to the commit object\n'
+          + 'Second body line after one new line\n\n'
+          + 'Third body line after two new lines\n'
+          + 'BREAKING CHANGE: Non-body line\n\n'
+          + 'Closes #1166.'
+        const result = parser.parse(commit)
+
+        expect(result.header).toBe('feat(conventional-commits-parser): add bodyLines to commit object')
+        expect(result.body).toBe('Adds the new property bodyLines to the commit object\nSecond body line after one new line\n\nThird body line after two new lines')
+        expect(result.bodyLines).toEqual([
+          'Adds the new property bodyLines to the commit object',
+          'Second body line after one new line',
+          'Third body line after two new lines'
+        ])
+      })
     })
 
     describe('custom options', () => {
@@ -116,6 +136,7 @@ describe('conventional-commits-parser', () => {
           subject: 'broadcast $destroy event on scope destruction',
           type: 'feat',
           body: 'perf testing shows that in chrome this change adds 5-15% overhead\n\n\n\nwhen destroying 10k nested scopes where each scope has a $destroy listener',
+          bodyLines: ['perf testing shows that in chrome this change adds 5-15% overhead', 'when destroying 10k nested scopes where each scope has a $destroy listener'],
           footer: 'BREAKING AMEND: some breaking change\n\n\n\n\nBREAKING AMEND: An awesome breaking change\n\n\n```\ncode here\n```\n\nKills #1\n\n\n\nkilled #25',
           notes: [
             {
@@ -162,6 +183,7 @@ describe('conventional-commits-parser', () => {
           merge: null,
           header: ' feat(scope): broadcast $destroy event on scope destruction ',
           body: ' perf testing shows that in chrome this change adds 5-15% overhead \n\n when destroying 10k nested scopes where each scope has a $destroy listener ',
+          bodyLines: [' perf testing shows that in chrome this change adds 5-15% overhead ', ' when destroying 10k nested scopes where each scope has a $destroy listener '],
           footer: '         BREAKING AMEND: some breaking change         \n\n   BREAKING AMEND: An awesome breaking change\n\n\n```\ncode here\n```\n\n    Kills   #1',
           notes: [
             {
@@ -205,6 +227,7 @@ describe('conventional-commits-parser', () => {
           subject: 'broadcast $destroy event on scope destruction',
           type: 'feat',
           body: 'perf testing shows that in chrome this change adds 5-15% overhead\nwhen destroying 10k nested scopes where each scope has a $destroy listener',
+          bodyLines: ['perf testing shows that in chrome this change adds 5-15% overhead', 'when destroying 10k nested scopes where each scope has a $destroy listener'],
           footer: 'BREAKING AMEND: some breaking change\nKills #1',
           notes: [
             {
@@ -270,6 +293,7 @@ describe('conventional-commits-parser', () => {
           merge: null,
           header: null,
           body: null,
+          bodyLines: [],
           footer: null,
           notes: [],
           references: [],
@@ -281,6 +305,7 @@ describe('conventional-commits-parser', () => {
           merge: null,
           header: ' # non-comment',
           body: null,
+          bodyLines: [],
           footer: null,
           notes: [],
           references: [],
@@ -292,6 +317,7 @@ describe('conventional-commits-parser', () => {
           merge: null,
           header: 'header',
           body: 'body',
+          bodyLines: ['body'],
           footer: null,
           notes: [],
           references: [],
@@ -310,6 +336,7 @@ describe('conventional-commits-parser', () => {
           merge: null,
           header: null,
           body: null,
+          bodyLines: [],
           footer: null,
           notes: [],
           references: [],
@@ -321,6 +348,7 @@ describe('conventional-commits-parser', () => {
           merge: null,
           header: '# non-comment',
           body: null,
+          bodyLines: [],
           footer: null,
           notes: [],
           references: [],
@@ -332,6 +360,7 @@ describe('conventional-commits-parser', () => {
           merge: null,
           header: ' * non-comment',
           body: null,
+          bodyLines: [],
           footer: null,
           notes: [],
           references: [],
@@ -343,6 +372,7 @@ describe('conventional-commits-parser', () => {
           merge: null,
           header: 'header',
           body: 'body',
+          bodyLines: ['body'],
           footer: null,
           notes: [],
           references: [],

--- a/packages/conventional-commits-parser/src/CommitParser.ts
+++ b/packages/conventional-commits-parser/src/CommitParser.ts
@@ -28,6 +28,7 @@ export function createCommitObject(initialData: Partial<Commit> = {}): Commit {
     revert: null,
     header: null,
     body: null,
+    bodyLines: [],
     footer: null,
     notes: [],
     mentions: [],
@@ -296,7 +297,13 @@ export class CommitParser {
     const isStillBody = !references.length && isBody
 
     if (isStillBody) {
-      commit.body = appendLine(commit.body, this.currentLine())
+      const currentLine = this.currentLine()
+
+      commit.body = appendLine(commit.body, currentLine)
+
+      if (currentLine !== '') {
+        commit.bodyLines.push(currentLine)
+      }
     } else {
       commit.references.push(...references)
       commit.footer = appendLine(commit.footer, this.currentLine())
@@ -370,6 +377,8 @@ export class CommitParser {
     if (commit.body) {
       commit.body = trimNewLines(commit.body)
     }
+
+    commit.bodyLines.map(bodyLine => trimNewLines(bodyLine))
 
     if (commit.footer) {
       commit.footer = trimNewLines(commit.footer)

--- a/packages/conventional-commits-parser/src/types.ts
+++ b/packages/conventional-commits-parser/src/types.ts
@@ -95,6 +95,7 @@ export interface CommitBase {
   revert: CommitMeta | null
   header: string | null
   body: string | null
+  bodyLines: string[]
   footer: string | null
   notes: CommitNote[]
   mentions: string[]


### PR DESCRIPTION
Adds the new property `bodyLines` as a line-by-line representation of `body` to the commit object.

Closes #1166.