### PR TITLE
fix(angular): revert pattern to not require a period

### DIFF
--- a/packages/conventional-changelog-angular/src/parser.js
+++ b/packages/conventional-changelog-angular/src/parser.js
@@ -7,7 +7,7 @@ export function createParserOpts () {
       'subject'
     ],
     noteKeywords: ['BREAKING CHANGE'],
-    revertPattern: /^(?:Revert|revert:)\s"?([\s\S]+?)"?\s*This reverts commit (\w*)\./i,
+    revertPattern: /^(?:Revert|revert:)\s"?([\s\S]+?)"?\s*This reverts commit (\w{7,40})\b/i,
     revertCorrespondence: ['header', 'hash']
   }
 }

--- a/packages/conventional-changelog-angular/test/index.spec.js
+++ b/packages/conventional-changelog-angular/test/index.spec.js
@@ -58,8 +58,8 @@ setups([
     testTools.gitCommit(['build(deps): bump @dummy/package from 7.1.2 to 8.0.0', 'BREAKING CHANGE: The Change is huge.'])
   },
   () => {
-    testTools.gitCommit(['Revert \\"feat: default revert format\\"', 'This reverts commit 1234.'])
-    testTools.gitCommit(['revert: feat: custom revert format', 'This reverts commit 5678.'])
+    testTools.gitCommit(['Revert \\"feat: default revert format\\"', 'This reverts commit 1234567.'])
+    testTools.gitCommit(['revert: feat: custom revert format', 'This reverts commit 5678910.'])
   }
 ])
 
@@ -324,8 +324,8 @@ describe('conventional-changelog-angular', () => {
     })) {
       chunk = chunk.toString()
 
-      expect(chunk).toMatch(/custom revert format/)
-      expect(chunk).toMatch(/default revert format/)
+      expect(chunk).toMatch('custom revert format')
+      expect(chunk).toMatch('default revert format')
       i++
     }
 


### PR DESCRIPTION
As per their spec, there is no period required at the end of the commit SHA:
https://github.com/angular/angular/blob/main/CONTRIBUTING.md#revert-commits

Also, as a fix, I set a minimum requirement of 7 characters for the SHA ([Git default](https://stackoverflow.com/a/18134919)) as currently you can pass in nothing and it would still work.