### PR TITLE
feat(conventional-commits-filter)!: align methods with other packages

### DIFF
--- a/packages/conventional-commits-filter/README.md
+++ b/packages/conventional-commits-filter/README.md
@@ -46,9 +46,12 @@ npm i -D conventional-commits-filter
 
 ```js
 import {
+  filterRevertedCommitsSync,
   filterRevertedCommits,
-  filterRevertedCommitsSync
+  filterRevertedCommitsStream
 } from 'conventional-commits-filter'
+import { pipeline } from 'stream/promises'
+import { Readable } from 'stream'
 
 const commits = [{
   type: 'revert',
@@ -152,14 +155,26 @@ const commits = [{
   }
 }];
 
-// for sync input data
+// to filter reverted commits syncronously:
 for (const commit of filterRevertedCommitsSync(commits)) {
   console.log(commit)
 }
-// for async iterable or stream input data
-for await (const commit of filterRevertedCommits(commits)) {
-  console.log(commit)
-}
+
+// to filter reverted commits in async iterables:
+await pipeline(
+  commits,
+  filterRevertedCommits,
+  async function* (filteredCommits) {
+    for await (const commit of filteredCommits) {
+      console.log(commit)
+    }
+  }
+)
+
+// to filter reverted commits in streams:
+Readable.from(commits)
+  .pipe(filterRevertedCommitsStream())
+  .on('data', commit => console.log(commit))
 ```
 
 Output:

--- a/packages/conventional-commits-filter/src/filters.ts
+++ b/packages/conventional-commits-filter/src/filters.ts
@@ -1,10 +1,11 @@
+import { Transform } from 'stream'
 import type { Commit } from './types.js'
 import { RevertedCommitsFilter } from './RevertedCommitsFilter.js'
 
 /**
- * Filter reverted commits
+ * Filter reverted commits.
  * @param commits
- * @yields Commits without reverted commits
+ * @yields Commits without reverted commits.
  */
 export async function* filterRevertedCommits<
   T extends Commit = Commit
@@ -21,9 +22,9 @@ export async function* filterRevertedCommits<
 }
 
 /**
- * Filter reverted commits synchronously
+ * Filter reverted commits synchronously.
  * @param commits
- * @yields Commits without reverted commits
+ * @yields Commits without reverted commits.
  */
 export function* filterRevertedCommitsSync<
   T extends Commit = Commit
@@ -37,4 +38,12 @@ export function* filterRevertedCommitsSync<
   }
 
   yield* filter.flush()
+}
+
+/**
+ * Filter reverted commits stream.
+ * @returns Reverted commits filter stream.
+ */
+export function filterRevertedCommitsStream() {
+  return Transform.from(filterRevertedCommits)
 }


### PR DESCRIPTION
BREAKING CHANGES: Now package exports filterRevertedCommits method. filterRevertedCommitsStream and filterRevertedCommitsSync methods are exported for backward compatability.