### PR TITLE
feat(conventional-changelog-writer)!: align methods with other packages

### DIFF
--- a/packages/conventional-changelog-core/index.js
+++ b/packages/conventional-changelog-core/index.js
@@ -3,7 +3,7 @@ import { execFileSync } from 'child_process'
 import addStream from 'add-stream'
 import gitRawCommits from 'git-raw-commits'
 import { parseCommitsStream } from 'conventional-commits-parser'
-import { createChangelogWriterStream } from 'conventional-changelog-writer'
+import { writeChangelogStream } from 'conventional-changelog-writer'
 import mergeConfig from './lib/merge-config.js'
 
 export default function conventionalChangelog (options, context, gitRawCommitsOpts, parserOpts, writerOpts, gitRawExecOpts) {
@@ -117,7 +117,7 @@ export default function conventionalChangelog (options, context, gitRawCommitsOp
           err.message = 'Error in options.transform: ' + err.message
           setImmediate(readable.emit.bind(readable), 'error', err)
         })
-        .pipe(createChangelogWriterStream(context, writerOpts, writerOpts.includeDetails))
+        .pipe(writeChangelogStream(context, writerOpts, writerOpts.includeDetails))
         .on('error', function (err) {
           err.message = 'Error in conventional-changelog-writer: ' + err.message
           setImmediate(readable.emit.bind(readable), 'error', err)

--- a/packages/conventional-changelog-writer/README.md
+++ b/packages/conventional-changelog-writer/README.md
@@ -59,23 +59,30 @@ npm i -D conventional-changelog-writer
 
 ```js
 import {
-  createChangelogAsyncGeneratorFromCommits,
-  createChangelogWriterStream,
-  createChangelogFromCommits
+  writeChangelogString,
+  writeChangelog,
+  writeChangelogStream
 } from 'conventional-changelog-writer'
+import { pipeline } from 'stream/promises'
 
-// Create logs Async Generator from commits
-for await (let log of createChangelogAsyncGeneratorFromCommits(commits, context, options)) {
-  console.log(log)
-}
+// to write changelog from commits to string:
+console.log(await writeChangelogString(commits, context, options))
 
-// Create logs stream from commits
+// to write changelog from commits to async iterable:
+await pipeline(
+  commits,
+  writeChangelog(context, options),
+  async function* (changelog) {
+    for await (const chunk of changelog) {
+      console.log(chunk)
+    }
+  }
+)
+
+// to write changelog from commits to stream:
 commitsStream
-  .pipe(createChangelogWriterStream(context, options))
+  .pipe(writeChangelogStream(context, options))
   .pipe(process.stdout)
-
-// Create changelog string from commits
-console.log(await createChangelogFromCommits(commits, context, options))
 ```
 
 Commits it an async iterable of commit objects that looks like this:
@@ -122,19 +129,19 @@ The output log might look something like this:
 
 ## API
 
-### createChangelogAsyncGeneratorFromCommits(commits: Iterable<Commit> | AsyncIterable<Commit>, context?: Context, options?: Options, includeDetails?: boolean): AsyncGenerator<string | Details, void>
+### writeChangelog(context?: Context, options?: Options, includeDetails?: boolean)
 
-Creates an async generator of changelog entries from commits.
+Creates an async generator function to generate changelog entries from commits.
 
 If `includeDetails` is `true`, instead of emitting strings of changelog, it emits objects containing the details the block.
 
-### createChangelogWriterStream(context?: Context, options?: Options, includeDetails?: boolean): Transform
+### writeChangelogStream(context?: Context, options?: Options, includeDetails?: boolean): Transform
 
 Creates a transform stream which takes commits and outputs changelog entries.
 
 If `includeDetails` is `true`, instead of emitting strings of changelog, it emits objects containing the details the block.
 
-### createChangelogFromCommits(commits: Iterable<Commit> | AsyncIterable<Commit>, context?: Context, options?: Options): Promise<string>
+### writeChangelogString(commits: Iterable<Commit> | AsyncIterable<Commit>, context?: Context, options?: Options): Promise<string>
 
 Create a changelog from commits.
 


### PR DESCRIPTION
BREAKING CHANGES: Now package exports `writeChangelog` method. `writeChangelogStream` and `writeChangelogString` methods are exported for backward compatibility.