### PR TITLE
fix(conventional-recommended-bump): add missing await for config loading in cli.js

### DIFF
--- a/packages/conventional-recommended-bump/cli.js
+++ b/packages/conventional-recommended-bump/cli.js
@@ -85,7 +85,7 @@ if (preset) {
   options.preset = preset
   delete flags.preset
 } else if (config) {
-  options.config = (await import(relativeResolve(config))).default
+  options.config = await (await import(relativeResolve(config))).default
   delete flags.config
 }
 


### PR DESCRIPTION
The CLI currently ignores the passed config file, since it is a pending promise, not an actual options object. This PR fixes the config loading behavior.