### PR TITLE
ci: no need to just run in master branch

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,7 +1,7 @@
 on:
   push:
     branches:
-      - master
+      - '**'
   pull_request:
     types: [ assigned, opened, synchronize, reopened, labeled ]
 name: ci


### PR DESCRIPTION
When a contributor wants to create a PR for this repo, the normal thing for her to do first is fork the repo and create a branch with a different name than master. Then, if she pushes her commits, she should be able to see the CI status of her fixes before opening a PR.