### PR TITLE
fix: added Bitbucket correct "commit" link

### DIFF
--- a/packages/conventional-changelog-conventionalcommits/src/writer.js
+++ b/packages/conventional-changelog-conventionalcommits/src/writer.js
@@ -13,12 +13,13 @@ const releaseAsRegex = /release-as:\s*\w*@?([0-9]+\.[0-9]+\.[0-9a-z]+(-[0-9a-z.]
 const owner = '{{#if this.owner}}{{~this.owner}}{{else}}{{~@root.owner}}{{/if}}'
 const host = '{{~@root.host}}'
 const repository = '{{#if this.repository}}{{~this.repository}}{{else}}{{~@root.repository}}{{/if}}'
+const commitRemoteUrl = host.includes('bitbucket.org') ? 'commits' : 'commit'
 
 export async function createWriterOpts (config) {
   const finalConfig = {
     types: DEFAULT_COMMIT_TYPES,
     issueUrlFormat: '{{host}}/{{owner}}/{{repository}}/issues/{{id}}',
-    commitUrlFormat: '{{host}}/{{owner}}/{{repository}}/commit/{{hash}}',
+    commitUrlFormat: '{{host}}/{{owner}}/{{repository}}/{{commitRemoteUrl}}/{{hash}}',
     compareUrlFormat: '{{host}}/{{owner}}/{{repository}}/compare/{{previousTag}}...{{currentTag}}',
     userUrlFormat: '{{host}}/{{user}}',
     issuePrefixes: ['#'],


### PR DESCRIPTION
This PR closes the issue #780.

The error was due to Bitbucket using the URL path of the commit with "commits" instead of "commit", being different from here on GitHub.

This PR implements a validation for that, verifying whether the repo is from GitHub or Bitbucket. If it's from Bitbucket, use "commits" on the path; if it's from GitHub, use "commit" on the path.

It's a straightforward validation, checked on Node versions from v8 to v20.