### PR TITLE
Parse header if subject includes ! to indicate breaking change

### DIFF
--- a/packages/conventional-commits-parser/src/CommitParser.spec.ts
+++ b/packages/conventional-commits-parser/src/CommitParser.spec.ts
@@ -526,6 +526,19 @@ describe('conventional-commits-parser', () => {
         expect(commit.subject).not.toBeDefined()
       })
 
+      it('should parse header if the subject match breakingHeaderPattern', () => {
+        const parser = new CommitParser({
+          breakingHeaderPattern: /^(\w*)(?:\((.*)\))?!: (.*)$/
+        })
+
+        const commit = 'feat(hello/world)!: message'
+        const result = parser.parse(commit)
+
+        expect(result.type).toBe('feat')
+        expect(result.scope).toBe('hello/world')
+        expect(result.subject).toBe('message')
+      })
+
       it('should parse header', () => {
         const commit = customParser.parse(
           'feat(scope): broadcast $destroy event on scope destruction\n'

--- a/packages/conventional-commits-parser/src/CommitParser.spec.ts
+++ b/packages/conventional-commits-parser/src/CommitParser.spec.ts
@@ -530,7 +530,6 @@ describe('conventional-commits-parser', () => {
         const parser = new CommitParser({
           breakingHeaderPattern: /^(\w*)(?:\((.*)\))?!: (.*)$/
         })
-
         const commit = 'feat(hello/world)!: message'
         const result = parser.parse(commit)
 

--- a/packages/conventional-commits-parser/src/CommitParser.ts
+++ b/packages/conventional-commits-parser/src/CommitParser.ts
@@ -199,9 +199,7 @@ export class CommitParser {
 
     if (matches) {
       correspondence.forEach((key, index) => {
-        if (matches) {
-          commit[key] = matches[index + 1] || null
-        }
+        commit[key] = matches![index + 1] || null
       })
     }
   }

--- a/packages/conventional-commits-parser/src/CommitParser.ts
+++ b/packages/conventional-commits-parser/src/CommitParser.ts
@@ -199,7 +199,9 @@ export class CommitParser {
 
     if (matches) {
       correspondence.forEach((key, index) => {
-        commit[key] = matches[index + 1] || null
+        if (matches) {
+          commit[key] = matches[index + 1] || null
+        }
       })
     }
   }

--- a/packages/conventional-commits-parser/src/CommitParser.ts
+++ b/packages/conventional-commits-parser/src/CommitParser.ts
@@ -182,10 +182,12 @@ export class CommitParser {
     const correspondence = options.headerCorrespondence || []
     const header = this.nextLine()
     let matches: RegExpMatchArray | null = null
+
     if (header) {
       if (options.breakingHeaderPattern) {
         matches = header.match(options.breakingHeaderPattern)
       }
+
       if (!matches && options.headerPattern) {
         matches = header.match(options.headerPattern)
       }

--- a/packages/conventional-commits-parser/src/CommitParser.ts
+++ b/packages/conventional-commits-parser/src/CommitParser.ts
@@ -181,9 +181,15 @@ export class CommitParser {
     const { commit, options } = this
     const correspondence = options.headerCorrespondence || []
     const header = this.nextLine()
-    const matches = header && options.headerPattern
-      ? header.match(options.headerPattern)
-      : null
+    let matches: RegExpMatchArray | null = null
+    if (header) {
+      if (options.breakingHeaderPattern) {
+        matches = header.match(options.breakingHeaderPattern)
+      }
+      if (!matches && options.headerPattern) {
+        matches = header.match(options.headerPattern)
+      }
+    }
 
     if (header) {
       commit.header = header


### PR DESCRIPTION
At the moment `CommitParser.parse` does not set `type`, `scope`, or `subject` when the commit includes an exclamation mark to indicate a breaking change. E.g. `feat(hello/world)!: message`.

This pull request addresses that so that they are available to use post parsing for all commits.
