### PR TITLE
feat(conventional-commits-parser): add flag to enable/disable multiple-scopes (default: enabled)

### DIFF
--- a/packages/conventional-commits-parser/src/CommitParser.spec.ts
+++ b/packages/conventional-commits-parser/src/CommitParser.spec.ts
@@ -90,6 +90,37 @@ describe('conventional-commits-parser', () => {
         expect(result.scope).toBe('hello/world')
         expect(result.subject).toBe('message')
       })
+
+      it('should parse scopes with delimiters when default isEnableMultipleScopes and scopeDelimitersPattern option', () => {
+        const parser = new CommitParser({
+          headerPattern: /^(\w*)(?:\((.*)\))?: (.*)$/ // TODO default headerPattern do not match scopeDelimiters
+        })
+        const commitsWithScopeDelimiters = [
+          {
+            commit: 'feat(hello/world): message',
+            parsedScore: 'hello/world'
+          },
+          {
+            commit: 'feat(hello\\world): message',
+            parsedScore: 'hello\\world'
+          },
+          {
+            commit: 'feat(hello,world): message',
+            parsedScore: 'hello,world'
+          },
+          {
+            commit: 'feat(hello, world): message',
+            parsedScore: 'hello, world'
+          }
+        ]
+
+        Object.values(commitsWithScopeDelimiters).forEach(({ commit, parsedScore }) => {
+          const result = parser.parse(commit)
+
+          expect(result.scope).toBe(parsedScore)
+          expect(result.scopes).toEqual(['hello', 'world'])
+        })
+      })
     })
 
     describe('custom options', () => {
@@ -256,6 +287,38 @@ describe('conventional-commits-parser', () => {
         )
 
         expect(commit.body).toBe('this is some body before a scissors-line')
+      })
+
+      it('should not parse scopes with delimiters when isEnableMultipleScopes is false', () => {
+        const parser = new CommitParser({
+          isEnableMultipleScopes: false,
+          headerPattern: /^(\w*)(?:\((.*)\))?: (.*)$/ // TODO default headerPattern do not match scopeDelimiters
+        })
+        const commitsWithScopeDelimiters = [
+          {
+            commit: 'feat(hello/world): message',
+            parsedScore: 'hello/world'
+          },
+          {
+            commit: 'feat(hello\\world): message',
+            parsedScore: 'hello\\world'
+          },
+          {
+            commit: 'feat(hello,world): message',
+            parsedScore: 'hello,world'
+          },
+          {
+            commit: 'feat(hello, world): message',
+            parsedScore: 'hello, world'
+          }
+        ]
+
+        Object.values(commitsWithScopeDelimiters).forEach(({ commit, parsedScore }) => {
+          const result = parser.parse(commit)
+
+          expect(result.scope).toBe(parsedScore)
+          expect(result.scopes).toBeUndefined()
+        })
       })
     })
 

--- a/packages/conventional-commits-parser/src/CommitParser.spec.ts
+++ b/packages/conventional-commits-parser/src/CommitParser.spec.ts
@@ -92,9 +92,6 @@ describe('conventional-commits-parser', () => {
       })
 
       it('should parse scopes with delimiters when default isEnableMultipleScopes and scopeDelimitersPattern option', () => {
-        const parser = new CommitParser({
-          headerPattern: /^(\w*)(?:\((.*)\))?: (.*)$/ // TODO default headerPattern do not match scopeDelimiters
-        })
         const commitsWithScopeDelimiters = [
           {
             commit: 'feat(hello/world): message',
@@ -291,8 +288,7 @@ describe('conventional-commits-parser', () => {
 
       it('should not parse scopes with delimiters when isEnableMultipleScopes is false', () => {
         const parser = new CommitParser({
-          isEnableMultipleScopes: false,
-          headerPattern: /^(\w*)(?:\((.*)\))?: (.*)$/ // TODO default headerPattern do not match scopeDelimiters
+          isEnableMultipleScopes: false
         })
         const commitsWithScopeDelimiters = [
           {

--- a/packages/conventional-commits-parser/src/CommitParser.ts
+++ b/packages/conventional-commits-parser/src/CommitParser.ts
@@ -388,6 +388,20 @@ export class CommitParser {
     })
   }
 
+  private parseScopes() {
+    const { commit, options: { isEnableMultipleScopes, scopeDelimitersPattern } } = this
+
+    if (!isEnableMultipleScopes || !scopeDelimitersPattern || !commit.scope) {
+      return
+    }
+
+    const messageScopes = commit.scope.split(scopeDelimitersPattern)
+
+    if (messageScopes.length > 1) {
+      commit.scopes = messageScopes
+    }
+  }
+
   /**
    * Parse commit message string into an object.
    * @param input - Commit message string.
@@ -432,6 +446,7 @@ export class CommitParser {
     this.parseBreakingHeader()
     this.parseMentions(input)
     this.parseRevert(input)
+    this.parseScopes()
     this.cleanupCommit()
 
     return commit

--- a/packages/conventional-commits-parser/src/options.ts
+++ b/packages/conventional-commits-parser/src/options.ts
@@ -14,7 +14,7 @@ export const defaultOptions: ParserOptions = {
     'resolves',
     'resolved'
   ],
-  headerPattern: /^(\w*)(?:\(([\w$.\-*/ ]*)\))?: (.*)$/,
+  headerPattern: /^(\w*)(?:\(([\w$.\-*/\\, ]*)\))?: (.*)$/,
   headerCorrespondence: [
     'type',
     'scope',

--- a/packages/conventional-commits-parser/src/options.ts
+++ b/packages/conventional-commits-parser/src/options.ts
@@ -22,5 +22,7 @@ export const defaultOptions: ParserOptions = {
   ],
   revertPattern: /^Revert\s"([\s\S]*)"\s*This reverts commit (\w*)\./,
   revertCorrespondence: ['header', 'hash'],
-  fieldPattern: /^-(.*?)-$/
+  fieldPattern: /^-(.*?)-$/,
+  isEnableMultipleScopes: true,
+  scopeDelimitersPattern: /\/|\\|, ?/g
 }

--- a/packages/conventional-commits-parser/src/types.ts
+++ b/packages/conventional-commits-parser/src/types.ts
@@ -58,6 +58,16 @@ export interface ParserOptions {
    * Keywords to reference an issue. This value is case **insensitive**.
    */
   referenceActions?: string[]
+  /**
+   * Used to determine whether to separate scopes by slash or comma delimiters contain in scope.
+   * The default value of isEnableMultipleScopes is true.
+   */
+  isEnableMultipleScopes?: boolean
+  /**
+   * RegExp used to separate scopes.
+   * The default value of scopeDelimitersPattern is `/\/|\\|, ?/g`.
+   */
+  scopeDelimitersPattern?: RegExp
 }
 
 export interface ParserStreamOptions extends ParserOptions {
@@ -72,6 +82,7 @@ export interface ParserRegexes {
   referenceParts: RegExp
   references: RegExp
   mentions: RegExp
+  scopeDelimiters: RegExp
 }
 
 export interface CommitReference {
@@ -99,6 +110,7 @@ export interface CommitBase {
   notes: CommitNote[]
   mentions: string[]
   references: CommitReference[]
+  scopes: string[]
 }
 
 export type Commit = CommitBase & CommitMeta

--- a/packages/conventional-commits-parser/src/types.ts
+++ b/packages/conventional-commits-parser/src/types.ts
@@ -82,7 +82,6 @@ export interface ParserRegexes {
   referenceParts: RegExp
   references: RegExp
   mentions: RegExp
-  scopeDelimiters: RegExp
 }
 
 export interface CommitReference {


### PR DESCRIPTION
This PR close to [issue 4015](https://github.com/conventional-changelog/commitlint/issues/4015)

migrate separating scopes logic code from `@commitlint/rules/src/scope-enum.ts`.


to Implement the feature add `isEnableMultipleScopes` and `scopeDelimitersPattern` parserOptions:

 - `isEnableMultipleScopes` used to determine whether to separate scopes by slash or comma delimiters contain in scope.

 - `scopeDelimitersPattern` used to separate scopes if `isEnableMultipleScopes` value is true.

the two default parserOptions values of two parserOptions refer to [@commitlint/rules/src/scope-enum.ts](https://github.com/conventional-changelog/commitlint/blob/aa4df36b1d07e56230ff569aec5af727f1144aae/%40commitlint/rules/src/scope-enum.ts#L16), this pr make it configurable, and work as before if not config

