### PR TITLE
fix(conventional-changelog-conventionalcommits): avoid double empty lines

### DIFF
--- a/packages/conventional-changelog-conventionalcommits/src/templates/template.hbs
+++ b/packages/conventional-changelog-conventionalcommits/src/templates/template.hbs
@@ -1,5 +1,4 @@
 {{> header}}
-
 {{#if noteGroups}}
 {{#each noteGroups}}
 
@@ -19,5 +18,4 @@
 {{#each commits}}
 {{> commit root=@root}}
 {{/each}}
-
 {{/each}}


### PR DESCRIPTION
fixes #1188