### PR TITLE
feat(conventional-changelog-writer): add skip option for skipping commits when writing changelog

### DIFF
--- a/packages/conventional-changelog-writer/src/types/commit.ts
+++ b/packages/conventional-changelog-writer/src/types/commit.ts
@@ -8,6 +8,8 @@ export interface CommitKnownProps {
   committerDate?: string | null
   notes: CommitNote[]
   revert?: AnyObject | null
+  body?: string | null
+  footer?: string | null
 }
 
 export type TransformedCommit<Commit extends CommitKnownProps = CommitKnownProps> = Commit & {

--- a/packages/conventional-changelog-writer/src/types/options.ts
+++ b/packages/conventional-changelog-writer/src/types/options.ts
@@ -113,7 +113,13 @@ export interface Options<Commit extends CommitKnownProps = CommitKnownProps> ext
    * @param date - Date string or Date object.
    * @returns Final date string.
    */
-  formatDate?(date: string | Date): string
+  formatDate?(date: string | Date): string,
+  /**
+  * A function that will determine if a commit should be skipped by the writer
+  * @param commit - The commit in question
+  * @returns boolean. If true, don't write the current commit
+  */
+  skip?: (commit: Commit) => boolean
 }
 
 type RequiredOptions<Commit extends CommitKnownProps = CommitKnownProps> = Required<Options<Commit>>
@@ -129,6 +135,7 @@ export interface FinalOptions<Commit extends CommitKnownProps = CommitKnownProps
   commitGroupsSort?: Comparator<CommitGroup<Commit>>
   notesSort?: Comparator<CommitNote>
   noteGroupsSort?: Comparator<NoteGroup>
+  skip?: Options<Commit>['skip']
   mainTemplate: FinalTemplatesOptions['mainTemplate']
   headerPartial: FinalTemplatesOptions['headerPartial']
   commitPartial: FinalTemplatesOptions['commitPartial']

--- a/packages/conventional-changelog-writer/src/writers.spec.ts
+++ b/packages/conventional-changelog-writer/src/writers.spec.ts
@@ -6,6 +6,7 @@ import {
   writeChangelogStream,
   writeChangelogString
 } from './writers.js'
+import { Commit } from './types/commit.js'
 
 const todayUtc = formatDate(new Date())
 const commits = [
@@ -408,6 +409,26 @@ describe('conventional-changelog-writer', () => {
 
         expect(i).toBe(5)
       })
+
+      describe('when a commit should be skipped', () => {
+        const skippedCommit = {
+          header: 'fix(scope): remove duplicate emission of $destroy',
+          body: '[skip changelog]',
+          footer: null,
+          notes: [],
+          references: [],
+          committerDate: '2015-04-09 09:43:59 +1000'
+        }
+
+        it('should not appear in the generated changelog', async () => {
+          const changelogWithoutSkipCommit = await writeChangelogString(commits)
+          const skip = (commit: Commit) => {
+            return (commit.header + commit.body).includes('[skip changelog]')
+          }
+          const changelogWithSkip = await writeChangelogString([...commits, skippedCommit], undefined, {skip});
+          expect(changelogWithSkip).toEqual(changelogWithoutSkipCommit)
+        });
+      });
 
       describe('when commits are not reversed', () => {
         it('should generate on `\'version\'` if it\'s a valid semver', async () => {

--- a/packages/conventional-changelog-writer/src/writers.ts
+++ b/packages/conventional-changelog-writer/src/writers.ts
@@ -85,7 +85,8 @@ export function writeChangelog<Commit extends CommitKnownProps = CommitKnownProp
     const {
       transform,
       reverse,
-      doFlush
+      doFlush,
+      skip
     } = finalOptions
     let chunk: Commit
     let commit: TransformedCommit<Commit> | null
@@ -99,6 +100,10 @@ export function writeChangelog<Commit extends CommitKnownProps = CommitKnownProp
     for await (chunk of commits) {
       commit = await transformCommit(chunk, transform, finalContext, finalOptions)
       keyCommit = commit || chunk
+
+      if (skip && skip(keyCommit)) {
+        continue
+      }
 
       // previous blocks of logs
       if (reverse) {


### PR DESCRIPTION
This PR adds `skip` to `Option` which allows for skipping commits based on the return value of a function. This is particularly useful for when a single PR has multiple conventional commits but some of them should not be in user facing release notes/changelogs (i.e. a `fix` for a `feat` added in the same PR). 

Closes #1179
Closes #342