### PR TITLE
Update README.md - fix links, example json

### DIFF
--- a/packages/conventional-changelog-conventionalcommits/README.md
+++ b/packages/conventional-changelog-conventionalcommits/README.md
@@ -44,11 +44,11 @@ npm i -D conventional-changelog-conventionalcommits
 
 ## Indirect Usage (as preset)
 
-Use the [Conventional Changelog CLI Quick Start](https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-cli#quick-start) with the `-p conventionalcommits` option.
+Use the [Conventional Changelog CLI Usage](https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog#usage) with the `-p conventionalcommits` option.
 
 ## Direct Usage (as a base preset so you can customize it)
 
-If you want to use this package directly and pass options, you can use the [Conventional Changelog CLI Quick Start](https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-cli#quick-start) and with the `--config` or `-n` parameter, pass a js config that looks like this:
+If you want to use this package directly and pass options, you can use the [Conventional Changelog CLI Usage](https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog#usage) and with the `--config` or `-n` parameter, pass a js config that looks like this:
 
 ```js
 import createPreset from 'conventional-changelog-conventionalcommits'
@@ -67,7 +67,7 @@ or json config like that:
 {
   "options": {
     "preset": {
-      "name": "conventionalchangelog",
+      "name": "conventional-changelog-conventionalcommits",
       "issuePrefixes": ["TEST-"],
       "issueUrlFormat": "https://myBugTracker.com/{{prefix}}{{id}}"
     }

--- a/packages/conventional-changelog-conventionalcommits/README.md
+++ b/packages/conventional-changelog-conventionalcommits/README.md
@@ -67,7 +67,7 @@ or json config like that:
 {
   "options": {
     "preset": {
-      "name": "conventional-changelog-conventionalcommits",
+      "name": "conventionalcommits",
       "issuePrefixes": ["TEST-"],
       "issueUrlFormat": "https://myBugTracker.com/{{prefix}}{{id}}"
     }


### PR DESCRIPTION
I was getting onboarded to conventional-changelog and had a confusing time trying to get customization working

Turns out that the `name` for `preset` needs to match the `npm` package name? `conventional-changelog-conventionalcommits` instead of `conventionalchangelog`

Also updating some outdated 404 links