### PR TITLE
fix(conventionalcommits): make commit types matching case sensitively

### DIFF
--- a/packages/conventional-changelog-conventionalcommits/src/writer.js
+++ b/packages/conventional-changelog-conventionalcommits/src/writer.js
@@ -174,7 +174,7 @@ function getWriterOpts(config) {
 }
 
 function findTypeEntry(types, commit) {
-  const typeKey = (commit.revert ? 'revert' : commit.type || '')
+  const typeKey = commit.revert ? 'revert' : commit.type || ''
 
   return types.find((entry) => {
     if (entry.type !== typeKey) {

--- a/packages/conventional-changelog-conventionalcommits/src/writer.js
+++ b/packages/conventional-changelog-conventionalcommits/src/writer.js
@@ -174,7 +174,7 @@ function getWriterOpts(config) {
 }
 
 function findTypeEntry(types, commit) {
-  const typeKey = (commit.revert ? 'revert' : commit.type || '').toLowerCase()
+  const typeKey = (commit.revert ? 'revert' : commit.type || '')
 
   return types.find((entry) => {
     if (entry.type !== typeKey) {


### PR DESCRIPTION
I have an issue with my custom configuration providing uppercased commit types (`FEAT`, `FIX`, ...).

Current version of `conventionalcommit` implementation produces an empty output in case of custom types provided using any non-lowercased letters. For example, see [repro] repository, namely _index.js_ and _README.md_.

```shell
git clone https://github.com/unennhexium/conventional-changelog-conventionalcommits-repro.git repro
cd repro
npm install
npm start # check output and index.js script
```

<details><summary><b>Output</b></summary>

- __Current version__

  ```text
  [Lowercased] (all types matched):
  
  ##  (2025-06-22)
  
  ### Features
  
  * some feature 5886f09
  * Some feature. 5886f09
  
  [Uppercased] (no types matched):
  
  ##  (2025-06-22)
  ```

- __Fixed version__

  ```text 
  [Lowercased] (lowercased types matched):
  
  ##  (2025-06-22)
  
  ### Features
  
  * some feature 5886f09
  
  [Uppercased] (uppercased types matched):
  
  ##  (2025-06-22)
  
  ### Features
  
  * Some feature. 5886f09
  ```

</details>

This PR changes one line of code and resolves the problem.

[repro]: https://github.com/unennhexium/conventional-changelog-conventionalcommits-repro