### PR TITLE
refactor: replace `fd-package-json` with `empathic`

### DIFF
--- a/packages/conventional-changelog/package.json
+++ b/packages/conventional-changelog/package.json
@@ -69,7 +69,7 @@
     "conventional-changelog-preset-loader": "workspace:^",
     "conventional-changelog-writer": "workspace:^",
     "conventional-commits-parser": "workspace:^",
-    "fd-package-json": "^2.0.0",
+    "empathic": "^2.0.0",
     "meow": "^13.0.0",
     "normalize-package-data": "^7.0.0"
   },

--- a/packages/conventional-changelog/src/ConventionalChangelog.ts
+++ b/packages/conventional-changelog/src/ConventionalChangelog.ts
@@ -26,7 +26,7 @@ import {
   loadPreset as defaultLoadPreset
 } from 'conventional-changelog-preset-loader'
 import normalizePackageData from 'normalize-package-data'
-import { findPackage } from 'fd-package-json'
+import { up } from 'empathic/package'
 import { parseHostedGitUrl } from './hostedGitInfo.js'
 import type {
   HostedGitInfo,
@@ -339,15 +339,11 @@ export class ConventionalChangelog {
     }
   }
 
-  private async getPackageJson(pkgPath?: string, transform?: PackageTransform) {
+  private async getPackageJson(pkgPath: string | undefined = up({
+    cwd: this.gitClient.cwd
+  }), transform?: PackageTransform) {
     const { gitClient } = this
-    let pkg: Package
-
-    if (pkgPath) {
-      pkg = JSON.parse(await fs.readFile(pkgPath, 'utf-8')) as Package
-    } else {
-      pkg = (await findPackage(gitClient.cwd) || {}) as Package
-    }
+    let pkg = (pkgPath ? JSON.parse(await fs.readFile(pkgPath, 'utf-8')) : {}) as Package
 
     normalizePackageData(pkg)
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -89,7 +89,7 @@ importers:
       conventional-commits-parser:
         specifier: workspace:^
         version: link:../conventional-commits-parser
-      fd-package-json:
+      empathic:
         specifier: ^2.0.0
         version: 2.0.0
       meow:
@@ -1480,6 +1480,10 @@ packages:
   emoji-regex@9.2.2:
     resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
 
+  empathic@2.0.0:
+    resolution: {integrity: sha512-i6UzDscO/XfAcNYD75CfICkmfLedpyPDdozrLMmQc5ORaQcdMoc21OnlEylMIqI7U8eniKrPMxxtj8k0vhmJhA==}
+    engines: {node: '>=14'}
+
   env-paths@2.2.1:
     resolution: {integrity: sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==}
     engines: {node: '>=6'}
@@ -1820,9 +1824,6 @@ packages:
 
   fastq@1.19.1:
     resolution: {integrity: sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==}
-
-  fd-package-json@2.0.0:
-    resolution: {integrity: sha512-jKmm9YtsNXN789RS/0mSzOC1NUq9mkVd65vbSSVsKdjGvYXBuE4oWe2QOEoFeRmJg+lPuZxpmrfFclNhoRMneQ==}
 
   fdir@6.4.6:
     resolution: {integrity: sha512-hiFoqpyZcfNm1yc4u8oWCf9A2c4D3QjCrks3zmoVKVxpQRzmPNar1hUJcBG2RQHvEVGDN+Jm81ZheVLAQMK6+w==}
@@ -3110,10 +3111,6 @@ packages:
         optional: true
       jsdom:
         optional: true
-
-  walk-up-path@4.0.0:
-    resolution: {integrity: sha512-3hu+tD8YzSLGuFYtPRb48vdhKMi0KQV5sn+uWr8+7dMEq/2G/dtLrdDinkLjqq5TIbIBjYJ4Ax/n3YiaW7QM8A==}
-    engines: {node: 20 || >=22}
 
   wcwidth@1.0.1:
     resolution: {integrity: sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==}
@@ -4452,6 +4449,8 @@ snapshots:
 
   emoji-regex@9.2.2: {}
 
+  empathic@2.0.0: {}
+
   env-paths@2.2.1: {}
 
   error-ex@1.3.2:
@@ -4899,10 +4898,6 @@ snapshots:
   fastq@1.19.1:
     dependencies:
       reusify: 1.1.0
-
-  fd-package-json@2.0.0:
-    dependencies:
-      walk-up-path: 4.0.0
 
   fdir@6.4.6(picomatch@4.0.2):
     optionalDependencies:
@@ -6253,8 +6248,6 @@ snapshots:
       - terser
       - tsx
       - yaml
-
-  walk-up-path@4.0.0: {}
 
   wcwidth@1.0.1:
     dependencies:


### PR DESCRIPTION
Remember #1289? It turns out that since then, a more definitive package has emerged for these types of usages, and it has [zero](https://npmgraph.js.org/?q=empathic) subdependencies instead of [one](https://npmgraph.js.org/?q=fd-package-json). Small difference but it's one less! :tada: