### PR TITLE
perf(git-semver-tags): use simpler CLI parser

### DIFF
--- a/packages/git-semver-tags/package.json
+++ b/packages/git-semver-tags/package.json
@@ -47,6 +47,6 @@
   },
   "dependencies": {
     "@conventional-changelog/git-client": "workspace:^",
-    "meow": "^13.0.0"
+    "sade": "^1.8.1"
   }
 }

--- a/packages/git-semver-tags/src/cli.js
+++ b/packages/git-semver-tags/src/cli.js
@@ -1,43 +1,26 @@
 #!/usr/bin/env node
-import meow from 'meow'
+import sade from 'sade'
 import { getSemverTags } from './index.js'
 
-const args = meow(`
-  Usage
-    git-semver-tags
-  Options
-    --cwd                  path to git repository to be searched
-    --lerna                parse lerna style git tags
-    --package <name>       when listing lerna style tags, filter by a package
-    --tag-prefix <prefix>  prefix to remove from the tags during their processing
-    --skip-unstable        if given, unstable tags will be skipped, e.g., x.x.x-alpha.1, x.x.x-rc.2`,
-{
-  importMeta: import.meta,
-  booleanDefault: undefined,
-  flags: {
-    cwd: {
-      type: 'string'
-    },
-    lerna: {
-      type: 'boolean'
-    },
-    package: {
-      type: 'string'
-    },
-    tagPrefix: {
-      type: 'string'
-    },
-    skipUnstable: {
-      type: 'boolean'
-    }
-  }
-})
-const tags = await getSemverTags({
-  lernaTags: args.flags.lerna,
-  package: args.flags.package,
-  tagPrefix: args.flags.tagPrefix,
-  skipUnstable: args.flags.skipUnstable
-})
+const cli = sade('git-semver-tags', true)
 
-// eslint-disable-next-line no-console
-console.log(tags.join('\n'))
+cli
+  .describe('Get all git semver tags of your repository in reverse chronological order.')
+  .version('stable')
+  .option('--cwd', 'path to git repository to be searched')
+  .option('--lerna', 'parse lerna style git tags')
+  .option('--package', 'when listing lerna style tags, filter by a package')
+  .option('--tag-prefix', 'prefix to remove from the tags during their processing')
+  .option('--skip-unstable', 'if given, unstable tags will be skipped, e.g., x.x.x-alpha.1, x.x.x-rc.2')
+  .action(async (args) => {
+    const tags = await getSemverTags({
+      lernaTags: args.lerna === true,
+      package: args.package,
+      tagPrefix: args['tag-prefix'],
+      skipUnstable: args['skip-unstable'] === true
+    })
+
+    // eslint-disable-next-line no-console
+    console.log(tags.join('\n'))
+  })
+  .parse(process.argv)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -244,9 +244,9 @@ importers:
       '@conventional-changelog/git-client':
         specifier: workspace:^
         version: link:../git-client
-      meow:
-        specifier: ^13.0.0
-        version: 13.2.0
+      sade:
+        specifier: ^1.8.1
+        version: 1.8.1
     publishDirectory: package
 
   packages/standard-changelog:
@@ -2432,6 +2432,10 @@ packages:
     resolution: {integrity: sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==}
     engines: {node: '>=16 || 14 >=14.17'}
 
+  mri@1.2.0:
+    resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
+    engines: {node: '>=4'}
+
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
@@ -2717,6 +2721,10 @@ packages:
 
   rxjs@7.8.2:
     resolution: {integrity: sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==}
+
+  sade@1.8.1:
+    resolution: {integrity: sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==}
+    engines: {node: '>=6'}
 
   safe-array-concat@1.1.3:
     resolution: {integrity: sha512-AURm5f0jYEOydBj7VQlVvDrjeFgthDdEF5H1dP+6mNpoXOMo1quQqJ4wvJDyRZ9+pO3kGWoOdmV08cSv2aJV6Q==}
@@ -5514,6 +5522,8 @@ snapshots:
 
   minipass@7.1.2: {}
 
+  mri@1.2.0: {}
+
   ms@2.1.3: {}
 
   mute-stream@0.0.8: {}
@@ -5825,6 +5835,10 @@ snapshots:
   rxjs@7.8.2:
     dependencies:
       tslib: 2.8.1
+
+  sade@1.8.1:
+    dependencies:
+      mri: 1.2.0
 
   safe-array-concat@1.1.3:
     dependencies:


### PR DESCRIPTION
We don't actually need most of `meow`, so can use something much simpler
like `sade`.

`sade` is ~45KB to install, while `meow` is ~419KB.

We do use `meow` elsewhere in the monorepo, so i'm happy to do the same change there if this lands.
