### PR TITLE
feat(angular): support ignoreCommits option

### DIFF
--- a/packages/conventional-changelog-angular/README.md
+++ b/packages/conventional-changelog-angular/README.md
@@ -132,3 +132,9 @@ reference GitHub issues that this commit **Closes**.
 **Breaking Changes** should start with the word `BREAKING CHANGE:` with a space or two newlines. The rest of the commit message is then used for this.
 
 A detailed explanation can be found in this [document](#commit-message-format).
+
+## Specific Options
+
+| Option | Description |
+|--------|-------------|
+| ignoreCommits | Regular expression to match and exclude commits from the changelog. Commits matching this pattern will be ignored. |

--- a/packages/conventional-changelog-angular/src/index.js
+++ b/packages/conventional-changelog-angular/src/index.js
@@ -2,8 +2,12 @@ import { createParserOpts } from './parser.js'
 import { createWriterOpts } from './writer.js'
 import { whatBump } from './whatBump.js'
 
-export default async function createPreset() {
+export default async function createPreset(config) {
   return {
+    commits: {
+      ignore: config?.ignoreCommits,
+      merges: false
+    },
     parser: createParserOpts(),
     writer: await createWriterOpts(),
     whatBump


### PR DESCRIPTION
Extend options for angular to support ignoreCommits as in https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-conventionalcommits#specific-options