### PR TITLE
Support ClickUp-style issue IDs ending with letters

### DIFF
--- a/packages/conventional-commits-parser/src/regex.spec.ts
+++ b/packages/conventional-commits-parser/src/regex.spec.ts
@@ -259,6 +259,15 @@ describe('conventional-commits-parser', () => {
           expect(match?.[3]).toBe('JIRA-123')
         })
 
+        it('should match ClickUp-style reference parts ending with letters', () => {
+          const match = referenceParts.exec('#CU-123abc')
+
+          expect(match?.[0]).toBe('#CU-123abc')
+          expect(match?.[1]).toBe(undefined)
+          expect(match?.[2]).toBe('#')
+          expect(match?.[3]).toBe('CU-123abc')
+        })
+
         it('should not match MY-€#%#&-123 mixed symbol reference parts', () => {
           const match = referenceParts.exec('#MY-€#%#&-123')
 

--- a/packages/conventional-commits-parser/src/regex.ts
+++ b/packages/conventional-commits-parser/src/regex.ts
@@ -39,7 +39,7 @@ function getReferencePartsRegex(
 
   const flags = issuePrefixesCaseSensitive ? 'g' : 'gi'
 
-  return new RegExp(`(?:.*?)??\\s*([\\w-\\.\\/]*?)??(${join(issuePrefixes, '|')})([\\w-]*\\d+)`, flags)
+  return new RegExp(`(?:.*?)??\\s*([\\w-\\.\\/]*?)??(${join(issuePrefixes, '|')})([\\w-]+)(?=\\s|$|[,;)\\]])`, flags)
 }
 
 function getReferencesRegex(


### PR DESCRIPTION
The reference parts regex was requiring issue IDs to end with at least one number, which caused ClickUp-style IDs like '#CU-123abc' to be truncated at the last number. This prevented proper parsing of issue references that include letters at the end.

Added a lookahead assertion to ensure issue IDs are followed by valid delimiters (whitespace, end of string, or punctuation like ,;)]). This allows the regex to properly match the entire reference including trailing letters.

closes #1312 #1279 