### PR TITLE
fix(parser): parser escape special chars in footer tokens

### DIFF
--- a/packages/conventional-commits-parser/src/regex.spec.ts
+++ b/packages/conventional-commits-parser/src/regex.spec.ts
@@ -77,6 +77,32 @@ describe('conventional-commits-parser', () => {
 
           expect(match).toBe(null)
         })
+
+        it('should match RegEx special chars when used inside `noteKeywords`', () => {
+          const noteKeywordsSpecialChars = [
+            '[1]',
+            '(2)',
+            '{3}',
+            '.4',
+            '*5',
+            '+6',
+            '?7',
+            '^8',
+            '$9'
+          ]
+          const { notes } = getParserRegexes({
+            noteKeywords: noteKeywordsSpecialChars,
+            issuePrefixes: ['#']
+          })
+
+          noteKeywordsSpecialChars.forEach((keyword) => {
+            const textToMatch = `${keyword}: footer`
+            const match = textToMatch.match(notes)
+
+            expect(Array.isArray(match)).toBe(true)
+            expect(match?.[1]).toBe(keyword)
+          })
+        })
       })
 
       describe('references', () => {

--- a/packages/conventional-commits-parser/src/regex.spec.ts
+++ b/packages/conventional-commits-parser/src/regex.spec.ts
@@ -78,7 +78,7 @@ describe('conventional-commits-parser', () => {
           expect(match).toBe(null)
         })
 
-        it('should match RegEx special chars when used inside `noteKeywords`', () => {
+        it('should escape regex special chars when used inside `noteKeywords`', () => {
           const noteKeywordsSpecialChars = [
             '[1]',
             '(2)',
@@ -96,11 +96,13 @@ describe('conventional-commits-parser', () => {
           })
 
           noteKeywordsSpecialChars.forEach((keyword) => {
-            const textToMatch = `${keyword}: footer`
-            const match = textToMatch.match(notes)
+            const match = `${keyword}: footer`.match(notes)
 
-            expect(Array.isArray(match)).toBe(true)
-            expect(match?.[1]).toBe(keyword)
+            expect(match).toMatchObject({
+              0: `${keyword}: footer`,
+              1: keyword,
+              2: 'footer'
+            })
           })
         })
       })
@@ -223,6 +225,32 @@ describe('conventional-commits-parser', () => {
             'amends #2, ',
             'fixes #3'
           ])
+        })
+
+        it('should escape regex special chars when used inside `referenceActions`', () => {
+          const referenceActionsSpecialChars = [
+            '[close]',
+            '(fix)',
+            '{resolve}',
+            '.closes',
+            '*merge',
+            '+amend',
+            '?fix',
+            '^resolve',
+            '$close'
+          ]
+          const { references } = getParserRegexes({
+            referenceActions: referenceActionsSpecialChars,
+            issuePrefixes: ['#']
+          })
+
+          referenceActionsSpecialChars.forEach((action) => {
+            const match = `${action} #1`.match(references)
+
+            expect(match).toMatchObject({
+              0: `${action} #1`
+            })
+          })
         })
       })
 
@@ -369,6 +397,31 @@ describe('conventional-commits-parser', () => {
           const match = referenceParts.exec(body)
 
           expect(match).toBe(null)
+        })
+
+        it('should escape regex special chars when used inside `issuePrefixes`', () => {
+          const issuePrefixesSpecialChars = [
+            '[#]',
+            '(#)',
+            '{#}',
+            '.#',
+            '*#',
+            '+#',
+            '?#',
+            '^#',
+            '$'
+          ]
+          const { referenceParts } = getParserRegexes({
+            issuePrefixes: issuePrefixesSpecialChars
+          })
+
+          issuePrefixesSpecialChars.forEach((prefix) => {
+            const match = `${prefix}1`.match(referenceParts)
+
+            expect(match).toMatchObject({
+              0: `${prefix}1`
+            })
+          })
         })
       })
 

--- a/packages/conventional-commits-parser/src/regex.ts
+++ b/packages/conventional-commits-parser/src/regex.ts
@@ -12,6 +12,16 @@ function join(parts: string[], joiner: string) {
     .join(joiner)
 }
 
+/**
+ * Escapes all RegEx special characters: `.*+?^$ {} () [] | \` by
+ * prefixing them with a backslash.
+ * @param string
+ * @returns string
+ */
+function escapeRegExpSpecialChars(string: string) {
+  return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
 function getNotesRegex(
   noteKeywords: string[] | undefined,
   notesPattern: ((text: string) => RegExp) | undefined
@@ -20,7 +30,8 @@ function getNotesRegex(
     return nomatchRegex
   }
 
-  const noteKeywordsSelection = join(noteKeywords, '|')
+  const regexSafeKeywords = noteKeywords.map(escapeRegExpSpecialChars)
+  const noteKeywordsSelection = join(regexSafeKeywords, '|')
 
   if (!notesPattern) {
     return new RegExp(`^[\\s|*]*(${noteKeywordsSelection})[:\\s]+(.*)`, 'i')

--- a/packages/conventional-commits-parser/src/regex.ts
+++ b/packages/conventional-commits-parser/src/regex.ts
@@ -5,21 +5,15 @@ import type {
 
 const nomatchRegex = /(?!.*)/
 
-function join(parts: string[], joiner: string) {
-  return parts
-    .map(val => val.trim())
-    .filter(Boolean)
-    .join(joiner)
+function escape(string: string) {
+  return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
 }
 
-/**
- * Escapes all RegEx special characters: `.*+?^$ {} () [] | \` by
- * prefixing them with a backslash.
- * @param string
- * @returns string
- */
-function escapeRegExpSpecialChars(string: string) {
-  return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+function join(parts: string[], joiner: string) {
+  return parts
+    .map(val => escape(val.trim()))
+    .filter(Boolean)
+    .join(joiner)
 }
 
 function getNotesRegex(
@@ -30,8 +24,7 @@ function getNotesRegex(
     return nomatchRegex
   }
 
-  const regexSafeKeywords = noteKeywords.map(escapeRegExpSpecialChars)
-  const noteKeywordsSelection = join(regexSafeKeywords, '|')
+  const noteKeywordsSelection = join(noteKeywords, '|')
 
   if (!notesPattern) {
     return new RegExp(`^[\\s|*]*(${noteKeywordsSelection})[:\\s]+(.*)`, 'i')


### PR DESCRIPTION
Fixes https://github.com/conventional-changelog/commitlint/issues/4560#issuecomment-3530732995.

Previously footers with RegEx related special characters would not be escaped which limited what characters could be used to denote footers when users supplied a custom `noteKeywords` array.

(edit)
**Note to maintainers**

I think we might need to delve a bit deeper on expected behaviours here and whether or not this should be considered a breaking change.

If consumers have defined footers that contain RegEx special chars, so long as it parses fine, there's all sorts of edge cases here since previously they weren't being escaped and thus parsed and treated as special chars. What that means is a small subset of users may actually be relying on the existing behaviour, had they clocked this quirk.

I'm also a bit suss on this `filter(Boolean)` line in the existing join function.

Some reproducible examples:

```js
/**
 * @param {string[]} parts
 * @param {string} joiner
 * @returns string that has been trimmed and joined by the joiner
 */
function join(parts, joiner) {
  return parts
    .map(val => val.trim())
    .filter(Boolean)
    .join(joiner)
}

/**
 * @param {string} noteSequence
 * @returns string with all regex characters escaped
 */
function escapeRegExpSpecialChars(noteSequence) {
  return noteSequence.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
}

/**
 * @param {string} noteKeywordsSelection
 * @returns a RegExp pattern with a capture group that houses all note keywords
 */
function defaultNotesPattern(noteKeywordsSelection) {
  return new RegExp(`^[\\s|*]*(${noteKeywordsSelection})[:\\s]+(.*)`, 'i')
}

/**
 * @param {string} data
 * @param {RegExp} matcher
 */
function test(data, matcher) {
  console.log(`
    Footer: "${data}"
    RegEx: ${matcher.source}
    `)
  console.log(data.match(matcher) ?? 'No match')
}

// array of notes, must escape backlash so that it's not discarded by Node or V8 engines
const noteKeywords = ['\\[\\d\\]', 'Note.']
const escapedEdgeCaseKeywords = noteKeywords.map(escapeRegExpSpecialChars)
// joined footer tokens
const joinedEdgeCaseNotes = join(noteKeywords, '|')
const joinedEscapedEdgeCaseNotes = join(escapedEdgeCaseKeywords, '|')
// regex patterns
const regexJoinedEdgeCaseNotes = defaultNotesPattern(joinedEdgeCaseNotes)
const regexJoinedEscapedEdgeCaseNotes = defaultNotesPattern(
  joinedEscapedEdgeCaseNotes
)
// test data
const testDataWithDot = 'Note!: dream big'
const testDataWithBrackets = '[1]: dream big'

test(testDataWithDot, regexJoinedEdgeCaseNotes)
test(testDataWithDot, regexJoinedEscapedEdgeCaseNotes)
test(testDataWithBrackets, regexJoinedEdgeCaseNotes)
test(testDataWithBrackets, regexJoinedEscapedEdgeCaseNotes)
```

The above test functions output:

```
    Footer: "Note!: dream big"
    RegEx: ^[\s|*]*(\[\d\]|Note.)[:\s]+(.*)
    
[
  'Note!: dream big',
  'Note!',
  'dream big',
  index: 0,
  input: 'Note!: dream big',
  groups: undefined
]

    Footer: "Note!: dream big"
    RegEx: ^[\s|*]*(\\\[\\d\\\]|Note\.)[:\s]+(.*)
    
No match

    Footer: "[1]: dream big"
    RegEx: ^[\s|*]*(\[\d\]|Note.)[:\s]+(.*)
    
[
  '[1]: dream big',
  '[1]',
  'dream big',
  index: 0,
  input: '[1]: dream big',
  groups: undefined
]

    Footer: "[1]: dream big"
    RegEx: ^[\s|*]*(\\\[\\d\\\]|Note\.)[:\s]+(.*)
    
No match
```

What we see here is that if a RegEx char is already being manually escaped, it escaping it again changes the match to expect a leading and trailing `\`.

This is just the edge case off of the top of my head. For the `Note!` match, the special char `.` in the original form would match one of any character but now that the full stop is being escaped, it matches a literal dot.

Happy to discuss further with y'all just wanted to flag this before it gets merged upstream.