### PR TITLE
feat(conventional-commits-parser): set breaking as true when the parser find it is a breaking change commit

### DIFF
--- a/packages/conventional-commits-parser/src/CommitParser.ts
+++ b/packages/conventional-commits-parser/src/CommitParser.ts
@@ -333,6 +333,7 @@ export class CommitParser {
         title: 'BREAKING CHANGE',
         text: matches[3]
       })
+      commit.breaking = true
     }
   }
 

--- a/packages/conventional-commits-parser/src/types.ts
+++ b/packages/conventional-commits-parser/src/types.ts
@@ -100,6 +100,7 @@ export interface CommitBase {
   notes: CommitNote[]
   mentions: string[]
   references: CommitReference[]
+  breaking: boolean | null
 }
 
 export type Commit = CommitBase & CommitMeta


### PR DESCRIPTION
Add a breaking member variable to `CommitBase` interface and set it as true in `parseBreakingHeader()` when it is pushing a "BREAKING CHANGE" to `notes`. Then the default release rule `{ breaking: true, release: "major" }` defined in @semantic-release/commit-analyzer can take effect.