### PR TITLE
fix(conventional-commits-parser): default gitlab revert message does not use a final dot in commit message.

### DIFF
--- a/packages/conventional-commits-parser/README.md
+++ b/packages/conventional-commits-parser/README.md
@@ -301,7 +301,7 @@ Pattern to match other fields.
 #### revertPattern
 
 Type: `RegExp`,
-Default: `/^Revert\s"([\s\S]*)"\s*This reverts commit (\w*)\./`
+Default: `/^Revert\s"([\s\S]*)"\s*This reverts commit (\w*)\.?/`
 
 Pattern to match what this commit reverts.
 

--- a/packages/conventional-commits-parser/src/options.ts
+++ b/packages/conventional-commits-parser/src/options.ts
@@ -20,7 +20,7 @@ export const defaultOptions: ParserOptions = {
     'scope',
     'subject'
   ],
-  revertPattern: /^Revert\s"([\s\S]*)"\s*This reverts commit (\w*)\./,
+  revertPattern: /^Revert\s"([\s\S]*)"\s*This reverts commit (\w*)\.?/,
   revertCorrespondence: ['header', 'hash'],
   fieldPattern: /^-(.*?)-$/
 }

--- a/packages/conventional-commits-parser/src/stream.spec.ts
+++ b/packages/conventional-commits-parser/src/stream.spec.ts
@@ -221,7 +221,7 @@ describe('conventional-commits-parser', () => {
           issuePrefixes: ['#'],
           noteKeywords: ['BREAKING CHANGES'],
           referenceActions: ['fix'],
-          revertPattern: /^Revert\s"([\s\S]*)"\s*This reverts commit (\w*)\./,
+          revertPattern: /^Revert\s"([\s\S]*)"\s*This reverts commit (\w*)\.?/,
           mergePattern: /^Merge pull request #(\d+) from (.*)$/,
           revertCorrespondence: ['header']
         }))) {


### PR DESCRIPTION
gitlab.com and gitlab self hosted does not use a final dot in default revert commit message, and the actual revertPattern does not match. 

This is an example of a revert commit message generated by gitlab : 
```
Revert "example commit to revert"
This reverts commit 92384291
```

This MR just make the last dot optional :-)