### PR TITLE
feat(conventional-changelog-conventionalcommits): add footer reference in template

### DIFF
--- a/packages/conventional-changelog-conventionalcommits/src/templates/template.hbs
+++ b/packages/conventional-changelog-conventionalcommits/src/templates/template.hbs
@@ -19,3 +19,5 @@
 {{> commit root=@root}}
 {{/each}}
 {{/each}}
+{{> footer}}
+


### PR DESCRIPTION
Add a footer reference to the main template.hbs file for the 'conventional-changelog-conventional-commits' preset. 

Currently, when a custom footer is defined, the main template.hbs file also needs to be updated because it contains no footer reference. 
This change means that the template.hbs now has a footer.hbs reference.  