### PR TITLE
feat(conventional-changelog-conventionalcommits): filter duplicate commit references

### DIFF
--- a/packages/conventional-changelog-conventionalcommits/src/writer.js
+++ b/packages/conventional-changelog-conventionalcommits/src/writer.js
@@ -147,9 +147,7 @@ function getWriterOpts(config) {
       }
 
       // remove references that already appear in the subject
-      const references = commit.references
-        .filter(reference => !issues.includes(reference.prefix + reference.issue))
-        .filter((item, pos, arr) => arr.indexOf(item) === pos)
+      const references = commit.references.filter(reference => !issues.includes(reference.prefix + reference.issue))
 
       return {
         notes,

--- a/packages/conventional-commits-parser/src/CommitParser.spec.ts
+++ b/packages/conventional-commits-parser/src/CommitParser.spec.ts
@@ -83,6 +83,31 @@ describe('conventional-commits-parser', () => {
         ])
       })
 
+      it('should deduplicate references when the same issue appears multiple times', () => {
+        const commit = 'feat(ng-list): Allow custom separator\n'
+          + 'Closes #123\nCloses #123\nFixes #123\n'
+        const result = parser.parse(commit)
+
+        expect(result.references).toEqual([
+          {
+            action: 'Closes',
+            issue: '123',
+            owner: null,
+            prefix: '#',
+            raw: '#123',
+            repository: null
+          },
+          {
+            action: 'Fixes',
+            issue: '123',
+            owner: null,
+            prefix: '#',
+            raw: '#123',
+            repository: null
+          }
+        ])
+      })
+
       it('should parse slash in the header with default headerPattern option', () => {
         const commit = 'feat(hello/world): message'
         const result = parser.parse(commit)

--- a/packages/conventional-commits-parser/src/CommitParser.ts
+++ b/packages/conventional-commits-parser/src/CommitParser.ts
@@ -383,6 +383,19 @@ export class CommitParser {
     commit.notes.forEach((note) => {
       note.text = trimNewLines(note.text)
     })
+
+    const referencesSet = new Set<string>()
+
+    commit.references = commit.references.filter((reference) => {
+      const uid = `${reference.action} ${reference.raw}`.toLocaleLowerCase()
+      const ok = !referencesSet.has(uid)
+
+      if (ok) {
+        referencesSet.add(uid)
+      }
+
+      return ok
+    })
   }
 
   /**


### PR DESCRIPTION
Currently, when I generate a changelog that contains duplicate issue references in the commit, the issue is referenced multiple times: 
<img width="643" height="78" alt="image" src="https://github.com/user-attachments/assets/d3d3422c-72ea-459b-b9fa-bb59c72e46d2" />

I added a filter to the references to stop the same element appearing twice in the array. 