### PR TITLE
chore(deps): replace del-cli with Node.js built-in fs.rmSync

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "node": ">=18"
   },
   "scripts": {
-    "clear": "pnpm -r --parallel --if-present clear && del ./coverage",
+    "clear": "pnpm -r --parallel --if-present clear && node tools/del.mjs ./coverage",
     "build": "pnpm -r --parallel --if-present build",
     "lint": "eslint --flag v10_config_lookup_from_file",
     "format": "pnpm lint --fix",
@@ -49,7 +49,6 @@
     "clean-publish": "^5.0.0",
     "commitizen": "^4.3.0",
     "conventional-changelog": "workspace:^",
-    "del-cli": "^7.0.0",
     "eslint": "^9.30.1",
     "inquirer": "^12.0.0",
     "nano-staged": "^0.8.0",

--- a/packages/conventional-changelog-angular/package.json
+++ b/packages/conventional-changelog-angular/package.json
@@ -31,7 +31,7 @@
     "src"
   ],
   "scripts": {
-    "clear": "del ./package",
+    "clear": "node ../../tools/del.mjs ./package",
     "prepublishOnly": "run clear clean-publish",
     "postpublish": "pnpm clear"
   },

--- a/packages/conventional-changelog-atom/package.json
+++ b/packages/conventional-changelog-atom/package.json
@@ -31,7 +31,7 @@
     "src"
   ],
   "scripts": {
-    "clear": "del ./package",
+    "clear": "node ../../tools/del.mjs ./package",
     "prepublishOnly": "run clear clean-publish",
     "postpublish": "pnpm clear"
   }

--- a/packages/conventional-changelog-codemirror/package.json
+++ b/packages/conventional-changelog-codemirror/package.json
@@ -31,7 +31,7 @@
     "src"
   ],
   "scripts": {
-    "clear": "del ./package",
+    "clear": "node ../../tools/del.mjs ./package",
     "prepublishOnly": "run clear clean-publish",
     "postpublish": "pnpm clear"
   }

--- a/packages/conventional-changelog-conventionalcommits/package.json
+++ b/packages/conventional-changelog-conventionalcommits/package.json
@@ -31,7 +31,7 @@
     "src"
   ],
   "scripts": {
-    "clear": "del ./package",
+    "clear": "node ../../tools/del.mjs ./package",
     "prepublishOnly": "run clear clean-publish",
     "postpublish": "pnpm clear"
   },

--- a/packages/conventional-changelog-ember/package.json
+++ b/packages/conventional-changelog-ember/package.json
@@ -31,7 +31,7 @@
     "src"
   ],
   "scripts": {
-    "clear": "del ./package",
+    "clear": "node ../../tools/del.mjs ./package",
     "prepublishOnly": "run clear clean-publish",
     "postpublish": "pnpm clear"
   }

--- a/packages/conventional-changelog-eslint/package.json
+++ b/packages/conventional-changelog-eslint/package.json
@@ -31,7 +31,7 @@
     "src"
   ],
   "scripts": {
-    "clear": "del ./package",
+    "clear": "node ../../tools/del.mjs ./package",
     "prepublishOnly": "run clear clean-publish",
     "postpublish": "pnpm clear"
   }

--- a/packages/conventional-changelog-express/package.json
+++ b/packages/conventional-changelog-express/package.json
@@ -31,7 +31,7 @@
     "src"
   ],
   "scripts": {
-    "clear": "del ./package",
+    "clear": "node ../../tools/del.mjs ./package",
     "prepublishOnly": "run clear clean-publish",
     "postpublish": "pnpm clear"
   }

--- a/packages/conventional-changelog-jquery/package.json
+++ b/packages/conventional-changelog-jquery/package.json
@@ -31,7 +31,7 @@
     "src"
   ],
   "scripts": {
-    "clear": "del ./package",
+    "clear": "node ../../tools/del.mjs ./package",
     "prepublishOnly": "run clear clean-publish",
     "postpublish": "pnpm clear"
   }

--- a/packages/conventional-changelog-jshint/package.json
+++ b/packages/conventional-changelog-jshint/package.json
@@ -31,7 +31,7 @@
     "src"
   ],
   "scripts": {
-    "clear": "del ./package",
+    "clear": "node ../../tools/del.mjs ./package",
     "prepublishOnly": "run clear clean-publish",
     "postpublish": "pnpm clear"
   },

--- a/packages/conventional-changelog-preset-loader/package.json
+++ b/packages/conventional-changelog-preset-loader/package.json
@@ -35,9 +35,9 @@
     "dist"
   ],
   "scripts": {
-    "clear:package": "del ./package",
-    "clear:dist": "del ./dist",
-    "clear": "del ./package ./dist",
+    "clear:package": "node ../../tools/del.mjs ./package",
+    "clear:dist": "node ../../tools/del.mjs ./dist",
+    "clear": "node ../../tools/del.mjs ./package ./dist",
     "prepublishOnly": "run build clear:package clean-publish",
     "postpublish": "pnpm clear:package",
     "build": "tsc -p tsconfig.build.json",

--- a/packages/conventional-changelog-writer/package.json
+++ b/packages/conventional-changelog-writer/package.json
@@ -48,9 +48,9 @@
     "templates/*.hbs"
   ],
   "scripts": {
-    "clear:package": "del ./package",
-    "clear:dist": "del ./dist",
-    "clear": "del ./package ./dist",
+    "clear:package": "node ../../tools/del.mjs ./package",
+    "clear:dist": "node ../../tools/del.mjs ./dist",
+    "clear": "node ../../tools/del.mjs ./package ./dist",
     "prepublishOnly": "run build clear:package clean-publish",
     "postpublish": "pnpm clear:package",
     "build": "tsc -p tsconfig.build.json",

--- a/packages/conventional-changelog/package.json
+++ b/packages/conventional-changelog/package.json
@@ -55,9 +55,9 @@
     "dist"
   ],
   "scripts": {
-    "clear:package": "del ./package",
-    "clear:dist": "del ./dist",
-    "clear": "del ./package ./dist",
+    "clear:package": "node ../../tools/del.mjs ./package",
+    "clear:dist": "node ../../tools/del.mjs ./dist",
+    "clear": "node ../../tools/del.mjs ./package ./dist",
     "prepublishOnly": "run build clear:package clean-publish",
     "postpublish": "pnpm clear:package",
     "build": "tsc -p tsconfig.build.json",

--- a/packages/conventional-commits-filter/package.json
+++ b/packages/conventional-commits-filter/package.json
@@ -40,9 +40,9 @@
     "dist"
   ],
   "scripts": {
-    "clear:package": "del ./package",
-    "clear:dist": "del ./dist",
-    "clear": "del ./package ./dist",
+    "clear:package": "node ../../tools/del.mjs ./package",
+    "clear:dist": "node ../../tools/del.mjs ./dist",
+    "clear": "node ../../tools/del.mjs ./package ./dist",
     "prepublishOnly": "run build clear:package clean-publish",
     "postpublish": "pnpm clear:package",
     "build": "tsc -p tsconfig.build.json",

--- a/packages/conventional-commits-parser/package.json
+++ b/packages/conventional-commits-parser/package.json
@@ -45,9 +45,9 @@
     "dist"
   ],
   "scripts": {
-    "clear:package": "del ./package",
-    "clear:dist": "del ./dist",
-    "clear": "del ./package ./dist",
+    "clear:package": "node ../../tools/del.mjs ./package",
+    "clear:dist": "node ../../tools/del.mjs ./dist",
+    "clear": "node ../../tools/del.mjs ./package ./dist",
     "prepublishOnly": "run build clear:package clean-publish",
     "postpublish": "pnpm clear:package",
     "build": "tsc -p tsconfig.build.json",

--- a/packages/conventional-recommended-bump/package.json
+++ b/packages/conventional-recommended-bump/package.json
@@ -43,9 +43,9 @@
     "dist"
   ],
   "scripts": {
-    "clear:package": "del ./package",
-    "clear:dist": "del ./dist",
-    "clear": "del ./package ./dist",
+    "clear:package": "node ../../tools/del.mjs ./package",
+    "clear:dist": "node ../../tools/del.mjs ./dist",
+    "clear": "node ../../tools/del.mjs ./package ./dist",
     "prepublishOnly": "run build clear:package clean-publish",
     "postpublish": "pnpm clear:package",
     "build": "tsc -p tsconfig.build.json",

--- a/packages/git-client/package.json
+++ b/packages/git-client/package.json
@@ -40,9 +40,9 @@
     "dist"
   ],
   "scripts": {
-    "clear:package": "del ./package",
-    "clear:dist": "del ./dist",
-    "clear": "del ./package ./dist",
+    "clear:package": "node ../../tools/del.mjs ./package",
+    "clear:dist": "node ../../tools/del.mjs ./dist",
+    "clear": "node ../../tools/del.mjs ./package ./dist",
     "prepublishOnly": "run build clear:package clean-publish",
     "postpublish": "pnpm clear:package",
     "build": "tsc -p tsconfig.build.json",

--- a/packages/git-raw-commits/package.json
+++ b/packages/git-raw-commits/package.json
@@ -42,7 +42,7 @@
     "src"
   ],
   "scripts": {
-    "clear": "del ./package",
+    "clear": "node ../../tools/del.mjs ./package",
     "prepublishOnly": "run clear clean-publish",
     "postpublish": "pnpm clear"
   },

--- a/packages/git-semver-tags/package.json
+++ b/packages/git-semver-tags/package.json
@@ -41,7 +41,7 @@
     "src"
   ],
   "scripts": {
-    "clear": "del ./package",
+    "clear": "node ../../tools/del.mjs ./package",
     "prepublishOnly": "run clear clean-publish",
     "postpublish": "pnpm clear"
   },

--- a/packages/standard-changelog/package.json
+++ b/packages/standard-changelog/package.json
@@ -40,9 +40,9 @@
     "dist"
   ],
   "scripts": {
-    "clear:package": "del ./package",
-    "clear:dist": "del ./dist",
-    "clear": "del ./package ./dist",
+    "clear:package": "node ../../tools/del.mjs ./package",
+    "clear:dist": "node ../../tools/del.mjs ./dist",
+    "clear": "node ../../tools/del.mjs ./package ./dist",
     "prepublishOnly": "run build clear:package clean-publish",
     "postpublish": "pnpm clear:package",
     "build": "tsc -p tsconfig.build.json",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,9 +44,6 @@ importers:
       conventional-changelog:
         specifier: workspace:^
         version: link:packages/conventional-changelog
-      del-cli:
-        specifier: ^7.0.0
-        version: 7.0.0
       eslint:
         specifier: ^9.30.1
         version: 9.30.1(jiti@2.4.2)
@@ -801,21 +798,25 @@ packages:
     resolution: {integrity: sha512-YhXGf0FXa72bEt4F7eTVKx5X3zWpbAOPnaA/dZ6/g8tGhw1m9IFjrabVHFjzcx3dQny4MgA59EhyElkDvpUe8A==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@oxlint/linux-arm64-musl@1.6.0':
     resolution: {integrity: sha512-T3JDhx8mjGjvh5INsPZJrlKHmZsecgDYvtvussKRdkc1Nnn7WC+jH9sh5qlmYvwzvmetlPVNezAoNvmGO9vtMg==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@oxlint/linux-x64-gnu@1.6.0':
     resolution: {integrity: sha512-Dx7ghtAl8aXBdqofJpi338At6lkeCtTfoinTYQXd9/TEJx+f+zCGNlQO6nJz3ydJBX48FDuOFKkNC+lUlWrd8w==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@oxlint/linux-x64-musl@1.6.0':
     resolution: {integrity: sha512-7KvMGdWmAZtAtg6IjoEJHKxTXdAcrHnUnqfgs0JpXst7trquV2mxBeRZusQXwxpu4HCSomKMvJfsp1qKaqSFDg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@oxlint/win32-arm64@1.6.0':
     resolution: {integrity: sha512-iSGC9RwX+dl7o5KFr5aH7Gq3nFbkq/3Gda6mxNPMvNkWrgXdIyiINxpyD8hJu566M+QSv1wEAu934BZotFDyoQ==}
@@ -889,56 +890,67 @@ packages:
     resolution: {integrity: sha512-EPlb95nUsz6Dd9Qy13fI5kUPXNSljaG9FiJ4YUGU1O/Q77i5DYFW5KR8g1OzTcdZUqQQ1KdDqsTohdFVwCwjqg==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.53.2':
     resolution: {integrity: sha512-BOmnVW+khAUX+YZvNfa0tGTEMVVEerOxN0pDk2E6N6DsEIa2Ctj48FOMfNDdrwinocKaC7YXUZ1pHlKpnkja/Q==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.53.2':
     resolution: {integrity: sha512-Xt2byDZ+6OVNuREgBXr4+CZDJtrVso5woFtpKdGPhpTPHcNG7D8YXeQzpNbFRxzTVqJf7kvPMCub/pcGUWgBjA==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.53.2':
     resolution: {integrity: sha512-+LdZSldy/I9N8+klim/Y1HsKbJ3BbInHav5qE9Iy77dtHC/pibw1SR/fXlWyAk0ThnpRKoODwnAuSjqxFRDHUQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.53.2':
     resolution: {integrity: sha512-8ms8sjmyc1jWJS6WdNSA23rEfdjWB30LH8Wqj0Cqvv7qSHnvw6kgMMXRdop6hkmGPlyYBdRPkjJnj3KCUHV/uQ==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-gnu@4.53.2':
     resolution: {integrity: sha512-3HRQLUQbpBDMmzoxPJYd3W6vrVHOo2cVW8RUo87Xz0JPJcBLBr5kZ1pGcQAhdZgX9VV7NbGNipah1omKKe23/g==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.53.2':
     resolution: {integrity: sha512-fMjKi+ojnmIvhk34gZP94vjogXNNUKMEYs+EDaB/5TG/wUkoeua7p7VCHnE6T2Tx+iaghAqQX8teQzcvrYpaQA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.53.2':
     resolution: {integrity: sha512-XuGFGU+VwUUV5kLvoAdi0Wz5Xbh2SrjIxCtZj6Wq8MDp4bflb/+ThZsVxokM7n0pcbkEr2h5/pzqzDYI7cCgLQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.53.2':
     resolution: {integrity: sha512-w6yjZF0P+NGzWR3AXWX9zc0DNEGdtvykB03uhonSHMRa+oWA6novflo2WaJr6JZakG2ucsyb+rvhrKac6NIy+w==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.53.2':
     resolution: {integrity: sha512-yo8d6tdfdeBArzC7T/PnHd7OypfI9cbuZzPnzLJIyKYFhAQ8SvlkKtKBMbXDxe1h03Rcr7u++nFS7tqXz87Gtw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.53.2':
     resolution: {integrity: sha512-ah59c1YkCxKExPP8O9PwOvs+XRLKwh/mV+3YdKqQ5AMQ0r4M4ZDuOrpWkUaqO7fzAHdINzV9tEVu8vNw48z0lA==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openharmony-arm64@4.53.2':
     resolution: {integrity: sha512-4VEd19Wmhr+Zy7hbUsFZ6YXEiP48hE//KPLCSVNY5RMGX2/7HZ+QkN55a3atM1C/BZCGIgqN+xrVgtdak2S9+A==}
@@ -974,10 +986,6 @@ packages:
 
   '@simple-libs/stream-utils@1.1.0':
     resolution: {integrity: sha512-6rsHTjodIn/t90lv5snQjRPVtOosM7Vp0AKdrObymq45ojlgVwnpAqdc+0OBBrpEiy31zZ6/TKeIVqV1HwvnuQ==}
-    engines: {node: '>=18'}
-
-  '@sindresorhus/merge-streams@2.3.0':
-    resolution: {integrity: sha512-LtoMMhxAlorcGhmFYI+LhPgbPZCkgP6ra1YL604EeF6U98pLlQ3iWIGMdWSC+vWmPBWBNgmDBAhnAobLROJmwg==}
     engines: {node: '>=18'}
 
   '@standard-schema/spec@1.0.0':
@@ -1446,15 +1454,6 @@ packages:
   define-properties@1.2.1:
     resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
     engines: {node: '>= 0.4'}
-
-  del-cli@7.0.0:
-    resolution: {integrity: sha512-fRl4pWJYu9WFQH8jXdQUYvcD0IMtij9WEc7qmB7xOyJEweNJNuE7iKmqNeoOT1DbBUjtRjxlw8Y63qKBI/NQ1g==}
-    engines: {node: '>=18'}
-    hasBin: true
-
-  del@8.0.1:
-    resolution: {integrity: sha512-gPqh0mKTPvaUZGAuHbrBUYKZWBNAeHG7TU3QH5EhVwPMyKvmfJaNXhcD2jTcXsJRRcffuho4vaYweu80dRrMGA==}
-    engines: {node: '>=18'}
 
   detect-file@1.0.0:
     resolution: {integrity: sha512-DtCOLG98P007x7wiiOmfI0fi3eIKyWiLTGJ2MDnVi/E04lWGbf+JzrRHMm0rgIIZJGtHpKpbVgLWHrv8xXpc3Q==}
@@ -1956,10 +1955,6 @@ packages:
     resolution: {integrity: sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==}
     engines: {node: '>= 0.4'}
 
-  globby@14.1.0:
-    resolution: {integrity: sha512-0Ia46fDOaT7k4og1PDW4YbodWWr3scS2vAr2lTbsplOt2WkKp0vQbkI9wKis/T5LV/dqPjO3bpS/z6GTJB82LA==}
-    engines: {node: '>=18'}
-
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
     engines: {node: '>= 0.4'}
@@ -2152,14 +2147,6 @@ packages:
   is-obj@2.0.0:
     resolution: {integrity: sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==}
     engines: {node: '>=8'}
-
-  is-path-cwd@3.0.0:
-    resolution: {integrity: sha512-kyiNFFLU0Ampr6SDZitD/DwUo4Zs1nSdnygUBqsu3LooL00Qvb5j+UnvApUn/TTj1J3OuE6BTdQ5rudKmU2ZaA==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
-
-  is-path-inside@4.0.0:
-    resolution: {integrity: sha512-lJJV/5dYS+RcL8uQdBDW9c9uWFLLBNRyFhnAKXw5tVqLlKZ4RMGZKv+YQ/IA3OhD+RpbJa1LLFM1FQPGyIXvOA==}
-    engines: {node: '>=12'}
 
   is-plain-obj@2.1.0:
     resolution: {integrity: sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==}
@@ -2390,10 +2377,6 @@ packages:
     resolution: {integrity: sha512-pxQJQzB6djGPXh08dacEloMFopsOqGVRKFPYvPOt9XDZ1HasbgDZA74CJGreSU4G3Ak7EFJGoiH2auq+yXISgA==}
     engines: {node: '>=18'}
 
-  meow@14.0.0:
-    resolution: {integrity: sha512-JhC3R1f6dbspVtmF3vKjAWz1EVIvwFrGGPLSdU6rK79xBwHWTuHoLnRX/t1/zHS1Ch1Y2UtIrih7DAHuH9JFJA==}
-    engines: {node: '>=20'}
-
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
@@ -2532,10 +2515,6 @@ packages:
     resolution: {integrity: sha512-wPrq66Llhl7/4AGC6I+cqxT07LhXvWL08LNXz1fENOw0Ap4sRZZ/gZpTTJ5jpurzzzfS2W/Ge9BY3LgLjCShcw==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
-  p-map@7.0.3:
-    resolution: {integrity: sha512-VkndIv2fIB99swvQoA65bm+fsmt6UNdGeIB0oxBs+WhAhdh08QA04JXpI7rbB9r08/nkbysKoya9rtDERYOYMA==}
-    engines: {node: '>=18'}
-
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
@@ -2573,10 +2552,6 @@ packages:
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
 
-  path-type@6.0.0:
-    resolution: {integrity: sha512-Vj7sf++t5pBD637NSfkxpHSMfWaeig5+DKWLhcqIYx6mWQz5hdJTGDVMQiJcw1ZYkhs7AazKDGpRVji1LJCZUQ==}
-    engines: {node: '>=18'}
-
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
@@ -2602,10 +2577,6 @@ packages:
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
-
-  presentable-error@0.0.1:
-    resolution: {integrity: sha512-E6rsNU1QNJgB3sjj7OANinGncFKuK+164sLXw1/CqBjj/EkXSoSdHCtWQGBNlREIGLnL7IEUEGa08YFVUbrhVg==}
-    engines: {node: '>=16'}
 
   prettier@3.6.2:
     resolution: {integrity: sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==}
@@ -2777,10 +2748,6 @@ packages:
   simple-git-hooks@2.13.0:
     resolution: {integrity: sha512-N+goiLxlkHJlyaYEglFypzVNMaNplPAk5syu0+OPp/Bk6dwVoXF6FfOw2vO0Dp+JHsBaI+w6cm8TnFl2Hw6tDA==}
     hasBin: true
-
-  slash@5.1.0:
-    resolution: {integrity: sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==}
-    engines: {node: '>=14.16'}
 
   sort-keys@4.2.0:
     resolution: {integrity: sha512-aUYIEU/UviqPgc8mHR6IW1EGxkAXpeRETYcrzg8cLAvUPZcpAlleSXHV2mY7G12GphSH6Gzv+4MMVSSkbdteHg==}
@@ -2979,10 +2946,6 @@ packages:
 
   unicorn-magic@0.1.0:
     resolution: {integrity: sha512-lRfVq8fE8gz6QMBuDM6a+LO3IAzTi05H6gCVaUpir2E1Rwpo4ZUog45KpNXKC/Mn3Yb9UDuHumeFTo9iV/D9FQ==}
-    engines: {node: '>=18'}
-
-  unicorn-magic@0.3.0:
-    resolution: {integrity: sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==}
     engines: {node: '>=18'}
 
   universalify@2.0.1:
@@ -3799,8 +3762,6 @@ snapshots:
     dependencies:
       '@types/node': 22.16.2
 
-  '@sindresorhus/merge-streams@2.3.0': {}
-
   '@standard-schema/spec@1.0.0': {}
 
   '@stylistic/eslint-plugin@5.1.0(eslint@9.30.1(jiti@2.4.2))':
@@ -4384,22 +4345,6 @@ snapshots:
       define-data-property: 1.1.4
       has-property-descriptors: 1.0.2
       object-keys: 1.1.1
-
-  del-cli@7.0.0:
-    dependencies:
-      del: 8.0.1
-      meow: 14.0.0
-      presentable-error: 0.0.1
-
-  del@8.0.1:
-    dependencies:
-      globby: 14.1.0
-      is-glob: 4.0.3
-      is-path-cwd: 3.0.0
-      is-path-inside: 4.0.0
-      p-map: 7.0.3
-      presentable-error: 0.0.1
-      slash: 5.1.0
 
   detect-file@1.0.0: {}
 
@@ -5028,15 +4973,6 @@ snapshots:
       define-properties: 1.2.1
       gopd: 1.2.0
 
-  globby@14.1.0:
-    dependencies:
-      '@sindresorhus/merge-streams': 2.3.0
-      fast-glob: 3.3.3
-      ignore: 7.0.5
-      path-type: 6.0.0
-      slash: 5.1.0
-      unicorn-magic: 0.3.0
-
   gopd@1.2.0: {}
 
   graceful-fs@4.2.11: {}
@@ -5227,10 +5163,6 @@ snapshots:
   is-number@7.0.0: {}
 
   is-obj@2.0.0: {}
-
-  is-path-cwd@3.0.0: {}
-
-  is-path-inside@4.0.0: {}
 
   is-plain-obj@2.1.0: {}
 
@@ -5438,8 +5370,6 @@ snapshots:
 
   meow@13.2.0: {}
 
-  meow@14.0.0: {}
-
   merge2@1.4.1: {}
 
   merge@2.1.1: {}
@@ -5595,8 +5525,6 @@ snapshots:
     dependencies:
       p-limit: 4.0.0
 
-  p-map@7.0.3: {}
-
   parent-module@1.0.1:
     dependencies:
       callsites: 3.1.0
@@ -5626,8 +5554,6 @@ snapshots:
 
   path-parse@1.0.7: {}
 
-  path-type@6.0.0: {}
-
   pathe@2.0.3: {}
 
   picocolors@1.1.1: {}
@@ -5645,8 +5571,6 @@ snapshots:
       source-map-js: 1.2.1
 
   prelude-ls@1.2.1: {}
-
-  presentable-error@0.0.1: {}
 
   prettier@3.6.2: {}
 
@@ -5860,8 +5784,6 @@ snapshots:
   signal-exit@4.1.0: {}
 
   simple-git-hooks@2.13.0: {}
-
-  slash@5.1.0: {}
 
   sort-keys@4.2.0:
     dependencies:
@@ -6083,8 +6005,6 @@ snapshots:
   undici-types@6.21.0: {}
 
   unicorn-magic@0.1.0: {}
-
-  unicorn-magic@0.3.0: {}
 
   universalify@2.0.1: {}
 

--- a/tools/del.mjs
+++ b/tools/del.mjs
@@ -1,0 +1,10 @@
+import { rmSync } from 'fs'
+
+const paths = process.argv.slice(2)
+
+for (const p of paths) {
+  rmSync(p, {
+    recursive: true,
+    force: true
+  })
+}


### PR DESCRIPTION
## Summary
- Replace `del-cli` dependency with Node.js built-in `fs.rmSync` in clean scripts
- Remove `del-cli` from `devDependencies`
- Uses `{ recursive: true, force: true }` flags for equivalent behavior

This aligns with the [e18e](https://e18e.dev/) ecosystem cleanup initiative — `del-cli` wraps `fs.rmSync` which has been stable since Node.js 14.14.0.

## Test plan
- [ ] Verify `npm test` / `pnpm test` passes
- [ ] Verify clean scripts work correctly
- [ ] Verify no remaining references to `del-cli` in source

🤖 Generated with [Claude Code](https://claude.com/claude-code)