### PR TITLE
feat(conventional-commits-parser): support RegExp in noteKeywords, issuePrefixes, and referenceActions

### DIFF
--- a/packages/conventional-commits-parser/README.md
+++ b/packages/conventional-commits-parser/README.md
@@ -256,19 +256,19 @@ Used to define what capturing group of `headerPattern` captures what header part
 
 #### referenceActions
 
-Type: `string[]`,
+Type: `(string | RegExp)[]`,
 Default: `['close', 'closes', 'closed', 'fix', 'fixes', 'fixed', 'resolve', 'resolves', 'resolved']`
 
-Keywords to reference an issue. This value is case **insensitive**.
+Keywords to reference an issue. This value is case **insensitive**. String values are escaped for use in a regex, while `RegExp` values are used as-is.
 
 Set it to `null` to reference an issue without any action.
 
 #### issuePrefixes
 
-Type: `string[]`,
+Type: `(string | RegExp)[]`,
 Default: `['#']`
 
-The prefixes of an issue. EG: In `gh-123` `gh-` is the prefix.
+The prefixes of an issue. EG: In `gh-123` `gh-` is the prefix. String values are escaped for use in a regex, while `RegExp` values are used as-is.
 
 #### issuePrefixesCaseSensitive
 
@@ -279,10 +279,10 @@ Used to define if `issuePrefixes` should be considered case sensitive.
 
 #### noteKeywords
 
-Type: `string[]`,
+Type: `(string | RegExp)[]`,
 Default: `['BREAKING CHANGE', 'BREAKING-CHANGE']`
 
-Keywords for important notes. This value is case **insensitive**.
+Keywords for important notes. This value is case **insensitive**. String values are escaped for use in a regex, while `RegExp` values are used as-is.
 
 #### notesPattern
 

--- a/packages/conventional-commits-parser/src/regex.ts
+++ b/packages/conventional-commits-parser/src/regex.ts
@@ -9,22 +9,22 @@ function escape(string: string) {
   return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
 }
 
-function join(parts: string[], joiner: string) {
+function joinOr(parts: (string | RegExp)[]) {
   return parts
-    .map(val => escape(val.trim()))
+    .map(val => (typeof val === 'string' ? escape(val.trim()) : val.source))
     .filter(Boolean)
-    .join(joiner)
+    .join('|')
 }
 
 function getNotesRegex(
-  noteKeywords: string[] | undefined,
+  noteKeywords: (string | RegExp)[] | undefined,
   notesPattern: ((text: string) => RegExp) | undefined
 ) {
   if (!noteKeywords) {
     return nomatchRegex
   }
 
-  const noteKeywordsSelection = join(noteKeywords, '|')
+  const noteKeywordsSelection = joinOr(noteKeywords)
 
   if (!notesPattern) {
     return new RegExp(`^[\\s|*]*(${noteKeywordsSelection})[:\\s]+(.*)`, 'i')
@@ -34,7 +34,7 @@ function getNotesRegex(
 }
 
 function getReferencePartsRegex(
-  issuePrefixes: string[] | undefined,
+  issuePrefixes: (string | RegExp)[] | undefined,
   issuePrefixesCaseSensitive: boolean | undefined
 ) {
   if (!issuePrefixes) {
@@ -43,18 +43,18 @@ function getReferencePartsRegex(
 
   const flags = issuePrefixesCaseSensitive ? 'g' : 'gi'
 
-  return new RegExp(`(?:.*?)??\\s*([\\w-\\.\\/]*?)??(${join(issuePrefixes, '|')})([\\w-]+)(?=\\s|$|[,;)\\]])`, flags)
+  return new RegExp(`(?:.*?)??\\s*([\\w-\\.\\/]*?)??(${joinOr(issuePrefixes)})([\\w-]+)(?=\\s|$|[,;)\\]])`, flags)
 }
 
 function getReferencesRegex(
-  referenceActions: string[] | undefined
+  referenceActions: (string | RegExp)[] | undefined
 ) {
   if (!referenceActions) {
     // matches everything
     return /()(.+)/gi
   }
 
-  const joinedKeywords = join(referenceActions, '|')
+  const joinedKeywords = joinOr(referenceActions)
 
   return new RegExp(`(${joinedKeywords})(?:\\s+(.*?))(?=(?:${joinedKeywords})|$)`, 'gi')
 }

--- a/packages/conventional-commits-parser/src/types.ts
+++ b/packages/conventional-commits-parser/src/types.ts
@@ -41,7 +41,7 @@ export interface ParserOptions {
   /**
    * Keywords for important notes. This value is case **insensitive**.
    */
-  noteKeywords?: string[]
+  noteKeywords?: (string | RegExp)[]
   /**
    * A function that takes `noteKeywordsSelection` and returns a `RegExp` to be matched against the notes.
    */
@@ -49,7 +49,7 @@ export interface ParserOptions {
   /**
    * The prefixes of an issue. EG: In `gh-123` `gh-` is the prefix.
    */
-  issuePrefixes?: string[]
+  issuePrefixes?: (string | RegExp)[]
   /**
    * Used to define if `issuePrefixes` should be considered case sensitive.
    */
@@ -57,7 +57,7 @@ export interface ParserOptions {
   /**
    * Keywords to reference an issue. This value is case **insensitive**.
    */
-  referenceActions?: string[]
+  referenceActions?: (string | RegExp)[]
 }
 
 export interface ParserStreamOptions extends ParserOptions {


### PR DESCRIPTION
Allow passing RegExp values alongside strings in noteKeywords, issuePrefixes, and referenceActions options. String values are escaped for safe use in regex, while RegExp values are used as-is via their source property.

closes #1436