### PR TITLE
fix(conventional-changelog-angular,conventional-changelog-conventionalcommits): skip mention linkification inside inline code

### DIFF
--- a/packages/conventional-changelog-angular/src/writer.js
+++ b/packages/conventional-changelog-angular/src/writer.js
@@ -73,7 +73,11 @@ export function createWriterOpts() {
 
         if (context.host) {
           // User URLs.
-          subject = subject.replace(/\B@([a-z0-9](?:-?[a-z0-9/]){0,38})/g, (_, username) => {
+          subject = subject.replace(/`[^`]*`|\B@([a-z0-9](?:-?[a-z0-9/]){0,38})/g, (match, username) => {
+            if (!username) {
+              return match
+            }
+
             if (username.includes('/')) {
               return `@${username}`
             }

--- a/packages/conventional-changelog-angular/test/index.spec.js
+++ b/packages/conventional-changelog-angular/test/index.spec.js
@@ -63,6 +63,9 @@ setups([
   () => {
     testTools.gitCommit(['Revert \\"feat: default revert format\\"', 'This reverts commit 1234567.'])
     testTools.gitCommit(['revert: feat: custom revert format', 'This reverts commit 5678910.'])
+  },
+  () => {
+    testTools.gitCommit(['fix: replace `@nano_kit/router` with `@nano_kit/router2`'])
   }
 ])
 
@@ -290,5 +293,18 @@ describe('conventional-changelog-angular', () => {
     expect(chunks[0]).toMatch('default revert format')
 
     expect(chunks.length).toBe(1)
+  })
+
+  it('should not replace @mention inside backtick-wrapped code', async () => {
+    preparing(10)
+
+    const log = new ConventionalChangelog(testTools.cwd)
+      .readPackage()
+      .config(preset())
+      .write()
+    const chunks = await toArray(log)
+
+    expect(chunks[0]).toContain('`@nano_kit/router`')
+    expect(chunks[0]).not.toContain('[@nano')
   })
 })

--- a/packages/conventional-changelog-conventionalcommits/src/writer.js
+++ b/packages/conventional-changelog-conventionalcommits/src/writer.js
@@ -113,7 +113,11 @@ export function createWriterOpts(config) {
           return `[${prefix}${issue}](${url})`
         })
         // User URLs.
-        subject = subject.replace(/\B@([a-z0-9](?:-?[a-z0-9/]){0,38})/g, (_, user) => {
+        subject = subject.replace(/`[^`]*`|\B@([a-z0-9](?:-?[a-z0-9/]){0,38})/g, (match, user) => {
+          if (!user) {
+            return match
+          }
+
           // TODO: investigate why this code exists.
           if (user.includes('/')) {
             return `@${user}`

--- a/packages/conventional-changelog-conventionalcommits/test/index.spec.js
+++ b/packages/conventional-changelog-conventionalcommits/test/index.spec.js
@@ -84,6 +84,9 @@ setups([
   },
   () => {
     testTools.gitCommit(['chore: release at different version', 'Release-As: v3.0.2'])
+  },
+  () => {
+    testTools.gitCommit(['fix: replace `@nano_kit/router` with `@nano_kit/router2`'])
   }
 ])
 
@@ -517,6 +520,19 @@ describe('conventional-changelog-conventionalcommits', () => {
     const chunks = await toArray(log)
 
     expect(chunks[0]).toMatch(/release at different version/)
+  })
+
+  it('should not replace @mention inside backtick-wrapped code', async () => {
+    preparing(12)
+
+    const log = new ConventionalChangelog(testTools.cwd)
+      .readPackage()
+      .config(preset())
+      .write()
+    const chunks = await toArray(log)
+
+    expect(chunks[0]).toContain('`@nano_kit/router`')
+    expect(chunks[0]).not.toContain('[@nano')
   })
 
   describe('bumpStrict parameter', () => {


### PR DESCRIPTION
Backtick-wrapped code spans (e.g. `@scope/package`) are no longer transformed into user profile links in the generated changelog.