### PR TITLE
fix(conventional-changelog-writer): update handleabars to 4.7.9 for s…

### DIFF
--- a/packages/conventional-changelog-writer/package.json
+++ b/packages/conventional-changelog-writer/package.json
@@ -59,7 +59,7 @@
   "dependencies": {
     "@simple-libs/stream-utils": "^1.2.0",
     "conventional-commits-filter": "workspace:^",
-    "handlebars": "^4.7.7",
+    "handlebars": "^4.7.9",
     "meow": "^13.0.0",
     "semver": "^7.5.2"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -165,7 +165,7 @@ importers:
         specifier: workspace:^
         version: link:../conventional-commits-filter
       handlebars:
-        specifier: ^4.7.7
+        specifier: ^4.7.9
         version: 4.7.9
       meow:
         specifier: ^13.0.0


### PR DESCRIPTION
Fix [CVE-2026-33937](https://nvd.nist.gov/vuln/detail/CVE-2026-33937) exposed by handlebars.js library.