### PR TITLE
docs(conventional-changelog-conventionalcommits): update createPreset usage in documents

### DIFF
--- a/packages/conventional-changelog-conventionalcommits/README.md
+++ b/packages/conventional-changelog-conventionalcommits/README.md
@@ -53,12 +53,11 @@ If you want to use this package directly and pass options, you can use the [Conv
 ```js
 import createPreset from 'conventional-changelog-conventionalcommits'
 
-createPreset({
+const config = createPreset({
   issuePrefixes: ['TEST-'],
   issueUrlFormat: 'https://myBugTracker.com/{{prefix}}{{id}}'
-}).then((config) => {
-  // do something with the config
 })
+// do something with the config
 ```
 
 or json config like that:

--- a/packages/conventional-changelog-conventionalcommits/test/index.spec.js
+++ b/packages/conventional-changelog-conventionalcommits/test/index.spec.js
@@ -536,8 +536,8 @@ describe('conventional-changelog-conventionalcommits', () => {
   })
 
   describe('bumpStrict parameter', () => {
-    it('should not bump version when bumpStrict is true and only hidden types are present', async () => {
-      const config = await preset({
+    it('should not bump version when bumpStrict is true and only hidden types are present', () => {
+      const config = preset({
         bumpStrict: true,
         types: [
           {
@@ -573,8 +573,8 @@ describe('conventional-changelog-conventionalcommits', () => {
       expect(result).toBe(null)
     })
 
-    it('should bump version when bumpStrict is true and non-hidden types are present', async () => {
-      const config = await preset({
+    it('should bump version when bumpStrict is true and non-hidden types are present', () => {
+      const config = preset({
         bumpStrict: true,
         types: [
           {

--- a/packages/conventional-changelog-conventionalcommits/test/index.spec.js
+++ b/packages/conventional-changelog-conventionalcommits/test/index.spec.js
@@ -541,8 +541,8 @@ describe('conventional-changelog-conventionalcommits', () => {
   })
 
   describe('bumpStrict parameter', () => {
-    it('should not bump version when bumpStrict is true and only hidden types are present', async () => {
-      const config = await preset({
+    it('should not bump version when bumpStrict is true and only hidden types are present', () => {
+      const config = preset({
         bumpStrict: true,
         types: [
           {
@@ -578,8 +578,8 @@ describe('conventional-changelog-conventionalcommits', () => {
       expect(result).toBe(null)
     })
 
-    it('should bump version when bumpStrict is true and non-hidden types are present', async () => {
-      const config = await preset({
+    it('should bump version when bumpStrict is true and non-hidden types are present', () => {
+      const config = preset({
         bumpStrict: true,
         types: [
           {


### PR DESCRIPTION
Update conventional-changelog-conventionalcommits usage in documents and tests.  #1453