### PR TITLE
fix: only render "closes" for closing-action references

### DIFF
--- a/packages/conventional-changelog-conventionalcommits/src/templates.js
+++ b/packages/conventional-changelog-conventionalcommits/src/templates.js
@@ -47,22 +47,28 @@ export const commitPartial = `*{{#if scope}} **{{scope}}:**
 {{~/if}}{{~/if}}
 
 {{~!-- commit references --}}
-{{~#if references~}}
+{{~#if closingReferences~}}
   , closes
-  {{~#each references}} {{#if @root.linkReferences~}}
-    [
-    {{~#if this.owner}}
-      {{~this.owner}}/
-    {{~/if}}
-    {{~this.repository}}{{this.prefix}}{{this.issue}}]({{issueUrlFormat}})
-  {{~else}}
-    {{~#if this.owner}}
-      {{~this.owner}}/
-    {{~/if}}
-    {{~this.repository}}{{this.prefix}}{{this.issue}}
-  {{~/if}}{{/each}}
+  {{~#each closingReferences}} {{> reference}}{{/each}}
+{{~/if}}
+{{~#if otherReferences~}}
+  , refs
+  {{~#each otherReferences}} {{> reference}}{{/each}}
 {{~/if}}
 
 `
+
+export const referencePartial = `{{#if @root.linkReferences~}}
+  [
+  {{~#if this.owner}}
+    {{~this.owner}}/
+  {{~/if}}
+  {{~this.repository}}{{this.prefix}}{{this.issue}}]({{issueUrlFormat}})
+{{~else}}
+  {{~#if this.owner}}
+    {{~this.owner}}/
+  {{~/if}}
+  {{~this.repository}}{{this.prefix}}{{this.issue}}
+{{~/if}}`
 
 export const footerPartial = ``

--- a/packages/conventional-changelog-conventionalcommits/src/writer.js
+++ b/packages/conventional-changelog-conventionalcommits/src/writer.js
@@ -5,6 +5,7 @@ import {
   mainTemplate,
   headerPartial,
   commitPartial,
+  referencePartial,
   footerPartial
 } from './templates.js'
 
@@ -53,6 +54,10 @@ export function createWriterOpts(config) {
     commitPartial: commitPartial
       .replace(/{{commitUrlFormat}}/g, commitUrlFormat)
       .replace(/{{issueUrlFormat}}/g, issueUrlFormat),
+    partials: {
+      reference: referencePartial
+        .replace(/{{issueUrlFormat}}/g, issueUrlFormat)
+    },
     footerPartial,
     transform: (commit, context) => {
       let discard = true
@@ -136,6 +141,12 @@ export function createWriterOpts(config) {
 
       // remove references that already appear in the subject
       const references = commit.references.filter(reference => !issues.includes(reference.prefix + reference.issue))
+      // Only references carrying a closing action keyword (closes/fixes/resolves, …)
+      // are rendered under "closes"; bare mentions (action === null) are rendered under
+      // "refs". Printing "closes" for a plain mention is incorrect and, when the changelog
+      // is reused as a PR body, makes GitHub auto-close issues the commit never closed.
+      const closingReferences = references.filter(reference => reference.action)
+      const otherReferences = references.filter(reference => !reference.action)
 
       return {
         notes,
@@ -143,7 +154,9 @@ export function createWriterOpts(config) {
         scope,
         shortHash,
         subject,
-        references
+        references,
+        closingReferences,
+        otherReferences
       }
     },
     groupBy: 'type',

--- a/packages/conventional-changelog-conventionalcommits/test/index.spec.js
+++ b/packages/conventional-changelog-conventionalcommits/test/index.spec.js
@@ -7,6 +7,9 @@ import {
   toArray
 } from '../../../tools/index.ts'
 import preset, { DEFAULT_COMMIT_TYPES } from '../src/index.js'
+import { createParserOpts } from '../src/parser.js'
+import { createWriterOpts } from '../src/writer.js'
+import { CommitParser } from '../../conventional-commits-parser/src/index.ts'
 
 const { setups, preparing, tearsWithJoy } = BetterThanBefore()
 let testTools
@@ -708,5 +711,103 @@ describe('conventional-changelog-conventionalcommits', () => {
       expect(changelog).not.toContain('make it faster')
       expect(changelog).not.toContain('upgrade example from 1 to 2')
     })
+  })
+})
+
+describe('reference grouping at the writer boundary', () => {
+  // Pin the contract directly on the writer transform, not just on the rendered
+  // string: a reference is rendered under "closes" only when the parser marked it
+  // with a closing action. Otherwise reusing the changelog as a PR body would let
+  // GitHub auto-close issues the commit never closed.
+  function transformRefs(references) {
+    const { transform } = createWriterOpts()
+    const commit = {
+      type: 'feat',
+      scope: '',
+      subject: 'some feature',
+      header: 'feat: some feature',
+      hash: 'abcdef0123456789',
+      notes: [],
+      references
+    }
+    const context = {
+      host: 'https://github.com',
+      owner: 'conventional-changelog',
+      repository: 'conventional-changelog'
+    }
+
+    return transform(commit, context)
+  }
+
+  const ref = (action, issue) => ({
+    raw: `#${issue}`,
+    action,
+    owner: null,
+    repository: null,
+    prefix: '#',
+    issue
+  })
+
+  it('renders a closing-action reference under closingReferences', () => {
+    // e.g. "Closes #1"
+    const { closingReferences, otherReferences } = transformRefs([ref('Closes', '1')])
+
+    expect(closingReferences.map(r => r.issue)).toEqual(['1'])
+    expect(otherReferences).toEqual([])
+  })
+
+  it('renders a bare mention under otherReferences', () => {
+    // e.g. "part of #2" -> parser reports action === null
+    const { closingReferences, otherReferences } = transformRefs([ref(null, '2')])
+
+    expect(closingReferences).toEqual([])
+    expect(otherReferences.map(r => r.issue)).toEqual(['2'])
+  })
+
+  it('renders token-footer references (Fixes:/Refs:) under otherReferences', () => {
+    // "Fixes: #3" / "Refs: #4" arrive from the parser with action === null,
+    // so they must not be treated as closing references.
+    const { closingReferences, otherReferences } = transformRefs([ref(null, '3'), ref(null, '4')])
+
+    expect(closingReferences).toEqual([])
+    expect(otherReferences.map(r => r.issue)).toEqual(['3', '4'])
+  })
+
+  it('splits a mix of closing and non-closing references', () => {
+    const { closingReferences, otherReferences } = transformRefs([
+      ref('Closes', '1'),
+      ref(null, '2'),
+      ref(null, '3'),
+      ref(null, '4')
+    ])
+
+    expect(closingReferences.map(r => r.issue)).toEqual(['1'])
+    expect(otherReferences.map(r => r.issue)).toEqual([
+      '2',
+      '3',
+      '4'
+    ])
+  })
+
+  it('grounds the token-footer contract on the real parser: "Fixes:"/"Refs:" yield action === null and group under refs', () => {
+    // The synthetic cases above assume the parser emits action === null for
+    // token-style footers. Pin that assumption against the actual parser so a
+    // future parser change (e.g. treating "Fixes:" as a closing action) fails
+    // here and the auto-close semantics are revisited intentionally. The matching
+    // rendered output is asserted by the "supports multiple lines of footer
+    // information" test (-> "refs [#99]", not "closes [#99]").
+    const parser = new CommitParser(createParserOpts())
+    const commit = parser.parse('feat: complex new feature\n\nFixes: #99\nRefs: #100')
+
+    expect(commit.references.map(r => r.action)).toEqual([null, null])
+
+    const { closingReferences, otherReferences } = createWriterOpts().transform(commit, {
+      host: 'https://github.com',
+      owner: 'conventional-changelog',
+      repository: 'conventional-changelog'
+    })
+
+    expect(closingReferences).toEqual([])
+    expect(otherReferences.map(r => r.issue)).toEqual(['99', '100'])
   })
 })

--- a/packages/conventional-changelog-conventionalcommits/test/index.spec.js
+++ b/packages/conventional-changelog-conventionalcommits/test/index.spec.js
@@ -239,6 +239,24 @@ describe('conventional-changelog-conventionalcommits', () => {
     expect(chunks[0]).toContain('[conventional-changelog/standard-version#358](https://github.com/conventional-changelog/standard-version/issues/358)')
   })
 
+  it('should only render "closes" for references with a closing action keyword', async () => {
+    preparing(1)
+
+    const log = new ConventionalChangelog(testTools.cwd)
+      .readPackage()
+      .config(preset())
+      .write()
+    const chunks = await toArray(log)
+
+    // "closes #1, #2" carries a closing action -> rendered under "closes".
+    expect(chunks[0]).toContain(', closes [#1](https://github.com/conventional-changelog/conventional-changelog/issues/1) [#2](https://github.com/conventional-changelog/conventional-changelog/issues/2)')
+    // "see #1, ...#358" are bare mentions (no closing action) -> rendered under
+    // "refs", never "closes" (otherwise reusing the changelog as a PR body would
+    // make GitHub auto-close issues the commit never closed).
+    expect(chunks[0]).toContain(', refs [#1](https://github.com/conventional-changelog/conventional-changelog/issues/1) [conventional-changelog/standard-version#358](https://github.com/conventional-changelog/standard-version/issues/358)')
+    expect(chunks[0]).not.toContain(', closes [#1](https://github.com/conventional-changelog/conventional-changelog/issues/1) [conventional-changelog/standard-version#358]')
+  })
+
   it('should properly format external repository issues given an `issueUrlFormat`', async () => {
     preparing(1)
 
@@ -468,8 +486,12 @@ describe('conventional-changelog-conventionalcommits', () => {
       .write()
     const chunks = await toArray(log)
 
-    expect(chunks[0]).toContain('closes [#99]')
+    // "Fixes: #99" / "Refs: #100" are token-style footers, not closing-action
+    // references (the parser reports action === null), so they are listed under
+    // "refs" rather than "closes".
+    expect(chunks[0]).toContain('refs [#99]')
     expect(chunks[0]).toContain('[#100]')
+    expect(chunks[0]).not.toContain('closes [#99]')
     expect(chunks[0]).toContain('this completely changes the API')
   })
 


### PR DESCRIPTION
REF https://github.com/conventional-changelog/conventional-changelog/issues/1461