### PR TITLE
fix(‎conventional-changelog): improve version tag parsing in changelog generation

### DIFF
--- a/packages/conventional-changelog/src/ConventionalChangelog.spec.ts
+++ b/packages/conventional-changelog/src/ConventionalChangelog.spec.ts
@@ -24,6 +24,7 @@ const {
   tearsWithJoy
 } = BetterThanBefore()
 let testTools: TestTools
+const BARE_REPO = '../bare-origin.git'
 
 setups([
   () => { // 1
@@ -144,12 +145,13 @@ setups([
     testTools.exec('git merge feature2 -m"Merge branch \'feature2\'"')
   },
   () => { // 20
+    testTools?.cleanup()
     testTools = new TestTools()
     // mock remote
-    testTools.exec('git init --bare ../origin20.git')
+    testTools.exec(`git init --bare ${BARE_REPO}`)
 
     testTools.gitInit()
-    testTools.exec('git remote add origin ../origin20.git')
+    testTools.exec(`git remote add origin ${BARE_REPO}`)
 
     testTools.writeFileSync('package.json', JSON.stringify({
       name: 'conventional-changelog',
@@ -177,55 +179,11 @@ setups([
     testTools.exec('git add --all')
     testTools.gitCommit('chore(release): v1.0.2')
     testTools.exec('git tag v1.0.2')
-
-    testTools.writeFileSync('test.txt', 'third')
-    testTools.exec('git add --all')
-    testTools.gitCommit('feat: third commit')
-
-    // v1.0.3
-    testTools.writeFileSync('./package.json', '{"version": "1.0.3"}')
-    testTools.exec('git add --all')
-    testTools.gitCommit('chore(release): v1.0.3')
-    testTools.exec('git tag v1.0.3')
 
     // push
     testTools.exec('git push -f origin master --tags')
   },
   () => { // 21
-    testTools = new TestTools()
-    // mock remote
-    testTools.exec('git init --bare ../origin21.git')
-
-    testTools.gitInit()
-    testTools.exec('git remote add origin ../origin21.git')
-
-    testTools.writeFileSync('package.json', JSON.stringify({
-      name: 'conventional-changelog',
-      repository: {
-        type: 'git',
-        url: 'https://github.com/conventional-changelog/conventional-changelog.git'
-      }
-    }))
-    testTools.writeFileSync('test.txt', 'first')
-    testTools.exec('git add --all')
-    testTools.gitCommit('feat: first commit')
-
-    // v1.0.1
-    testTools.writeFileSync('./package.json', '{"version": "1.0.1"}')
-    testTools.exec('git add --all')
-    testTools.gitCommit('chore(release): v1.0.1')
-    testTools.exec('git tag v1.0.1')
-
-    testTools.writeFileSync('test.txt', 'second')
-    testTools.exec('git add --all')
-    testTools.gitCommit('feat: second commit')
-
-    // v1.0.2
-    testTools.writeFileSync('./package.json', '{"version": "1.0.2"}')
-    testTools.exec('git add --all')
-    testTools.gitCommit('chore(release): v1.0.2')
-    testTools.exec('git tag v1.0.2')
-
     testTools.writeFileSync('test.txt', 'third')
     testTools.exec('git add --all')
     testTools.gitCommit('feat: third commit')
@@ -235,19 +193,6 @@ setups([
     testTools.exec('git add --all')
     testTools.gitCommit('chore(release): v1.0.3')
     testTools.exec('git tag v1.0.3')
-
-    // push
-    testTools.exec('git push -f origin master --tags')
-
-    testTools.writeFileSync('test.txt', 'fourth')
-    testTools.exec('git add --all')
-    testTools.gitCommit('feat: fourth commit')
-
-    // v1.0.4
-    testTools.writeFileSync('./package.json', '{"version": "1.0.4"}')
-    testTools.exec('git add --all')
-    testTools.gitCommit('chore(release): v1.0.4')
-    testTools.exec('git tag v1.0.4')
   }
 ])
 
@@ -257,6 +202,9 @@ tearsWithJoy(() => {
 
 afterAll(() => {
   testTools?.cleanup()
+  testTools?.rmSync(BARE_REPO, {
+    recursive: true
+  })
 })
 
 describe('conventional-changelog', () => {
@@ -1419,11 +1367,12 @@ describe('conventional-changelog', () => {
           .write()
         const chunks = await toArray(log)
 
-        expect(chunks.length).toBe(3)
+        expect(chunks.length).toBe(2)
 
-        expect(chunks[0]).toContain('## [1.0.3]')
-        expect(chunks[1]).toContain('## [1.0.2]')
-        expect(chunks[2]).toContain('## [1.0.1]')
+        expect(chunks[0]).toContain('## [1.0.2]')
+        expect(chunks[0]).toContain('second commit')
+        expect(chunks[1]).toContain('## [1.0.1]')
+        expect(chunks[1]).toContain('first commit')
       })
 
       it('should generate changelog including new HEAD release after remote push', async () => {
@@ -1444,12 +1393,14 @@ describe('conventional-changelog', () => {
           .write()
         const chunks = await toArray(log)
 
-        expect(chunks.length).toBe(4)
+        expect(chunks.length).toBe(3)
 
-        expect(chunks[0]).toContain('## [1.0.4]')
-        expect(chunks[1]).toContain('## [1.0.3]')
-        expect(chunks[2]).toContain('## [1.0.2]')
-        expect(chunks[3]).toContain('## [1.0.1]')
+        expect(chunks[0]).toContain('## [1.0.3]')
+        expect(chunks[0]).toContain('third commit')
+        expect(chunks[1]).toContain('## [1.0.2]')
+        expect(chunks[1]).toContain('second commit')
+        expect(chunks[2]).toContain('## [1.0.1]')
+        expect(chunks[2]).toContain('first commit')
       })
     })
   })

--- a/packages/conventional-changelog/src/ConventionalChangelog.spec.ts
+++ b/packages/conventional-changelog/src/ConventionalChangelog.spec.ts
@@ -24,7 +24,6 @@ const {
   tearsWithJoy
 } = BetterThanBefore()
 let testTools: TestTools
-const BARE_REPO = '../bare-origin.git'
 
 setups([
   () => { // 1
@@ -145,54 +144,15 @@ setups([
     testTools.exec('git merge feature2 -m"Merge branch \'feature2\'"')
   },
   () => { // 20
-    testTools?.cleanup()
-    testTools = new TestTools()
-    // mock remote
-    testTools.exec(`git init --bare ${BARE_REPO}`)
-
-    testTools.gitInit()
-    testTools.exec(`git remote add origin ${BARE_REPO}`)
-
-    testTools.writeFileSync('package.json', JSON.stringify({
-      name: 'conventional-changelog',
-      repository: {
-        type: 'git',
-        url: 'https://github.com/conventional-changelog/conventional-changelog.git'
-      }
-    }))
-    testTools.writeFileSync('test.txt', 'first')
-    testTools.exec('git add --all')
-    testTools.gitCommit('feat: first commit')
-
-    // v1.0.1
-    testTools.writeFileSync('./package.json', '{"version": "1.0.1"}')
-    testTools.exec('git add --all')
-    testTools.gitCommit('chore(release): v1.0.1')
-    testTools.exec('git tag v1.0.1')
-
-    testTools.writeFileSync('test.txt', 'second')
-    testTools.exec('git add --all')
-    testTools.gitCommit('feat: second commit')
-
-    // v1.0.2
-    testTools.writeFileSync('./package.json', '{"version": "1.0.2"}')
-    testTools.exec('git add --all')
-    testTools.gitCommit('chore(release): v1.0.2')
-    testTools.exec('git tag v1.0.2')
-
-    // push
-    testTools.exec('git push -f origin master --tags')
-  },
-  () => { // 21
-    testTools.writeFileSync('test.txt', 'third')
-    testTools.exec('git add --all')
-    testTools.gitCommit('feat: third commit')
-
-    // v1.0.3
-    testTools.writeFileSync('./package.json', '{"version": "1.0.3"}')
-    testTools.exec('git add --all')
-    testTools.gitCommit('chore(release): v1.0.3')
-    testTools.exec('git tag v1.0.3')
+    testTools.exec('git checkout -b feature3')
+    testTools.writeFileSync('./package.json', '{"version": "6.0.0"}')
+    testTools.exec('git add --all && git commit -m"feat: sixth commit"')
+    testTools.exec('git tag v6.0.0')
+    testTools.writeFileSync('./package.json', '{"version": "7.0.0"}')
+    testTools.exec('git add --all && git commit -m"feat: seventh commit"')
+    testTools.exec('git tag v7.0.0')
+    testTools.exec('git checkout master')
+    testTools.exec('git merge feature3 -m"Merge branch \'feature3\'"')
   }
 ])
 
@@ -202,9 +162,6 @@ tearsWithJoy(() => {
 
 afterAll(() => {
   testTools?.cleanup()
-  testTools?.rmSync(BARE_REPO, {
-    recursive: true
-  })
 })
 
 describe('conventional-changelog', () => {
@@ -961,6 +918,30 @@ describe('conventional-changelog', () => {
       expect(chunks[0]).toMatch(/\/commit\/\w{40}\)\)/)
     })
 
+    it('should generate changelog when HEAD is at latest tag', async () => {
+      preparing(20)
+
+      const log = new ConventionalChangelog(testTools.cwd)
+        .readPackage()
+        .loadPreset('angular')
+        .tags({
+          prefix: undefined
+        })
+        .options({
+          releaseCount: 0
+        })
+        .commits({
+          path: '.'
+        })
+        .write()
+      const chunks = await toArray(log)
+
+      expect(chunks[0]).toContain('# [7.0.0]')
+      expect(chunks[0]).toContain('seventh commit')
+      expect(chunks[1]).toContain('# [6.0.0]')
+      expect(chunks[1]).toContain('sixth commit')
+    })
+
     describe('finalizeContext', () => {
       it('should make `context.previousTag` default to a previous semver version of generated log (prepend)', async () => {
         const { tail } = preparing(11)
@@ -1345,62 +1326,6 @@ describe('conventional-changelog', () => {
         expect(chunks[0]).toContain('second lerna style commit woo')
         expect(chunks[0]).not.toContain('another lerna package, this should be skipped')
         expect(chunks[0]).not.toContain('something unreleased yet :)')
-      })
-    })
-
-    describe('releaseCount 0', () => {
-      it('should generate changelog when all releases are pushed and HEAD is at latest tag', async () => {
-        preparing(20)
-
-        const log = new ConventionalChangelog(testTools.cwd)
-          .readPackage()
-          .loadPreset('angular')
-          .tags({
-            prefix: undefined
-          })
-          .options({
-            releaseCount: 0
-          })
-          .commits({
-            path: '.'
-          })
-          .write()
-        const chunks = await toArray(log)
-
-        expect(chunks.length).toBe(2)
-
-        expect(chunks[0]).toContain('## [1.0.2]')
-        expect(chunks[0]).toContain('second commit')
-        expect(chunks[1]).toContain('## [1.0.1]')
-        expect(chunks[1]).toContain('first commit')
-      })
-
-      it('should generate changelog including new HEAD release after remote push', async () => {
-        preparing(21)
-
-        const log = new ConventionalChangelog(testTools.cwd)
-          .readPackage()
-          .loadPreset('angular')
-          .tags({
-            prefix: undefined
-          })
-          .options({
-            releaseCount: 0
-          })
-          .commits({
-            path: '.'
-          })
-          .write()
-        const chunks = await toArray(log)
-
-        expect(chunks.length).toBe(3)
-
-        expect(chunks[0]).toContain('## [1.0.3]')
-        expect(chunks[0]).toContain('third commit')
-        expect(chunks[1]).toContain('## [1.0.2]')
-        expect(chunks[1]).toContain('second commit')
-        expect(chunks[2]).toContain('## [1.0.1]')
-        expect(chunks[2]).toContain('first commit')
       })
     })
   })

--- a/packages/conventional-changelog/src/ConventionalChangelog.spec.ts
+++ b/packages/conventional-changelog/src/ConventionalChangelog.spec.ts
@@ -142,6 +142,112 @@ setups([
     testTools.exec('git add --all && git commit -m"5.0.0"')
     testTools.exec('git tag v5.0.0')
     testTools.exec('git merge feature2 -m"Merge branch \'feature2\'"')
+  },
+  () => { // 20
+    testTools = new TestTools()
+    // mock remote
+    testTools.exec('git init --bare ../origin20.git')
+
+    testTools.gitInit()
+    testTools.exec('git remote add origin ../origin20.git')
+
+    testTools.writeFileSync('package.json', JSON.stringify({
+      name: 'conventional-changelog',
+      repository: {
+        type: 'git',
+        url: 'https://github.com/conventional-changelog/conventional-changelog.git'
+      }
+    }))
+    testTools.writeFileSync('test.txt', 'first')
+    testTools.exec('git add --all')
+    testTools.gitCommit('feat: first commit')
+
+    // v1.0.1
+    testTools.writeFileSync('./package.json', '{"version": "1.0.1"}')
+    testTools.exec('git add --all')
+    testTools.gitCommit('chore(release): v1.0.1')
+    testTools.exec('git tag v1.0.1')
+
+    testTools.writeFileSync('test.txt', 'second')
+    testTools.exec('git add --all')
+    testTools.gitCommit('feat: second commit')
+
+    // v1.0.2
+    testTools.writeFileSync('./package.json', '{"version": "1.0.2"}')
+    testTools.exec('git add --all')
+    testTools.gitCommit('chore(release): v1.0.2')
+    testTools.exec('git tag v1.0.2')
+
+    testTools.writeFileSync('test.txt', 'third')
+    testTools.exec('git add --all')
+    testTools.gitCommit('feat: third commit')
+
+    // v1.0.3
+    testTools.writeFileSync('./package.json', '{"version": "1.0.3"}')
+    testTools.exec('git add --all')
+    testTools.gitCommit('chore(release): v1.0.3')
+    testTools.exec('git tag v1.0.3')
+
+    // push
+    testTools.exec('git push -f origin master --tags')
+  },
+  () => { // 21
+    testTools = new TestTools()
+    // mock remote
+    testTools.exec('git init --bare ../origin21.git')
+
+    testTools.gitInit()
+    testTools.exec('git remote add origin ../origin21.git')
+
+    testTools.writeFileSync('package.json', JSON.stringify({
+      name: 'conventional-changelog',
+      repository: {
+        type: 'git',
+        url: 'https://github.com/conventional-changelog/conventional-changelog.git'
+      }
+    }))
+    testTools.writeFileSync('test.txt', 'first')
+    testTools.exec('git add --all')
+    testTools.gitCommit('feat: first commit')
+
+    // v1.0.1
+    testTools.writeFileSync('./package.json', '{"version": "1.0.1"}')
+    testTools.exec('git add --all')
+    testTools.gitCommit('chore(release): v1.0.1')
+    testTools.exec('git tag v1.0.1')
+
+    testTools.writeFileSync('test.txt', 'second')
+    testTools.exec('git add --all')
+    testTools.gitCommit('feat: second commit')
+
+    // v1.0.2
+    testTools.writeFileSync('./package.json', '{"version": "1.0.2"}')
+    testTools.exec('git add --all')
+    testTools.gitCommit('chore(release): v1.0.2')
+    testTools.exec('git tag v1.0.2')
+
+    testTools.writeFileSync('test.txt', 'third')
+    testTools.exec('git add --all')
+    testTools.gitCommit('feat: third commit')
+
+    // v1.0.3
+    testTools.writeFileSync('./package.json', '{"version": "1.0.3"}')
+    testTools.exec('git add --all')
+    testTools.gitCommit('chore(release): v1.0.3')
+    testTools.exec('git tag v1.0.3')
+
+    // push
+    testTools.exec('git push -f origin master --tags')
+
+    testTools.writeFileSync('test.txt', 'fourth')
+    testTools.exec('git add --all')
+    testTools.gitCommit('feat: fourth commit')
+
+    // v1.0.4
+    testTools.writeFileSync('./package.json', '{"version": "1.0.4"}')
+    testTools.exec('git add --all')
+    testTools.gitCommit('chore(release): v1.0.4')
+    testTools.exec('git tag v1.0.4')
   }
 ])
 
@@ -1291,6 +1397,59 @@ describe('conventional-changelog', () => {
         expect(chunks[0]).toContain('second lerna style commit woo')
         expect(chunks[0]).not.toContain('another lerna package, this should be skipped')
         expect(chunks[0]).not.toContain('something unreleased yet :)')
+      })
+    })
+
+    describe('releaseCount 0', () => {
+      it('should generate changelog when all releases are pushed and HEAD is at latest tag', async () => {
+        preparing(20)
+
+        const log = new ConventionalChangelog(testTools.cwd)
+          .readPackage()
+          .loadPreset('angular')
+          .tags({
+            prefix: undefined
+          })
+          .options({
+            releaseCount: 0
+          })
+          .commits({
+            path: '.'
+          })
+          .write()
+        const chunks = await toArray(log)
+
+        expect(chunks.length).toBe(3)
+
+        expect(chunks[0]).toContain('## [1.0.3]')
+        expect(chunks[1]).toContain('## [1.0.2]')
+        expect(chunks[2]).toContain('## [1.0.1]')
+      })
+
+      it('should generate changelog including new HEAD release after remote push', async () => {
+        preparing(21)
+
+        const log = new ConventionalChangelog(testTools.cwd)
+          .readPackage()
+          .loadPreset('angular')
+          .tags({
+            prefix: undefined
+          })
+          .options({
+            releaseCount: 0
+          })
+          .commits({
+            path: '.'
+          })
+          .write()
+        const chunks = await toArray(log)
+
+        expect(chunks.length).toBe(4)
+
+        expect(chunks[0]).toContain('## [1.0.4]')
+        expect(chunks[1]).toContain('## [1.0.3]')
+        expect(chunks[2]).toContain('## [1.0.2]')
+        expect(chunks[3]).toContain('## [1.0.1]')
       })
     })
   })

--- a/packages/conventional-changelog/src/index.ts
+++ b/packages/conventional-changelog/src/index.ts
@@ -1,4 +1,8 @@
 export type * from './types.js'
 export * from './ConventionalChangelog.js'
 export * from './cli/cli.js'
-export { guessNextTag, isUnreleasedVersion, defaultCommitTransform } from './utils.js'
+export {
+  guessNextTag,
+  isUnreleasedVersion,
+  defaultCommitTransform
+} from './utils.js'

--- a/packages/conventional-changelog/src/index.ts
+++ b/packages/conventional-changelog/src/index.ts
@@ -1,3 +1,4 @@
 export type * from './types.js'
 export * from './ConventionalChangelog.js'
 export * from './cli/cli.js'
+export { guessNextTag, isUnreleasedVersion, defaultCommitTransform } from './utils.js'

--- a/packages/conventional-changelog/src/utils.ts
+++ b/packages/conventional-changelog/src/utils.ts
@@ -62,14 +62,14 @@ export function isUnreleasedVersion(
     && (lastTag === version || lastTag === `v${version}`)
 }
 
-export const versionTagRegex = /tag:\s*(.*)[,)]/i
-export const defaultVersionRegex = /tag:\s*[v=]?(.*)[,)]/i
+export const versionTagRegex = /tag:\s*(.*?)[,)]/i
+export const defaultVersionRegex = /tag:\s*[v=]?(.*?)[,)]/i
 
 export function defaultCommitTransform(commit: Commit, params: Params) {
   const { tags, options: { formatDate } } = params
   const prefix = tags?.prefix
   const versionRegex = prefix
-    ? new RegExp(`tag:\\s*[v=]?${prefix}(.*)[,)]`, 'i')
+    ? new RegExp(`tag:\\s*[v=]?${prefix}(.*?)[,)]`, 'i')
     : defaultVersionRegex
   const {
     committerDate,


### PR DESCRIPTION
Fixes #1465

### Problem

Changelog generation may produce incorrect or missing version titles when parsing git commit metadata containing release tags.

This issue occurs when `origin/<branch>` points to a commit that includes a version tag, causing inconsistent parsing results.

---

### Root cause

Current regex patterns used for extracting tags:

```ts id="9c1k2a"
/tag:\s*(.*)[,)]/i
/tag:\s*[v=]?(.*)[,)]/i
```

can incorrectly match additional git ref metadata (e.g. `origin/<branch>`, `HEAD`), leading to unreliable tag extraction.

---

### Changes

* Refined regex to more strictly extract version tag values
* Avoid matching unrelated git ref decorations
* Make tag parsing independent of `HEAD` / branch state

---

### Verification

Tested against multiple repository states:

* Cases where `origin/<branch>` points to feature commits → OK
* Cases where `origin/<branch>` points to release commits → fixed incorrect parsing
* Multiple release history scenarios → consistent output

---

### Impact

* More reliable changelog version detection
* Fixes missing/incorrect title in some release scenarios
