### PR TITLE
fix(conventional-changelog-conventionalcommits): render non-closing references separately

### DIFF
--- a/packages/conventional-changelog-conventionalcommits/src/templates.js
+++ b/packages/conventional-changelog-conventionalcommits/src/templates.js
@@ -32,6 +32,23 @@ export function headerPartial(context) {
   )
 }
 
+function renderReferences(context, references, filter) {
+  return each(
+    references?.filter(filter),
+    (commitReference) => {
+      if (context.linkReferences) {
+        return link(
+          reference(commitReference),
+          this.formatIssueUrl(context, commitReference)
+        )
+      }
+
+      return reference(commitReference)
+    },
+    ' '
+  )
+}
+
 export function commitPartial(context, commit) {
   const { linkReferences } = context
   const {
@@ -47,19 +64,17 @@ export function commitPartial(context, commit) {
       ? `(${link(shortHash, this.formatCommitUrl(context, commit))})`
       : shortHash
     : ''
-  const renderedReferences = each(
+  const closingReferences = renderReferences.call(
+    this,
+    context,
     references,
-    (linkReference) => {
-      if (linkReferences) {
-        return link(
-          reference(linkReference),
-          this.formatIssueUrl(context, linkReference)
-        )
-      }
-
-      return reference(linkReference)
-    },
-    ' '
+    commitReference => commitReference.action
+  )
+  const otherReferences = renderReferences.call(
+    this,
+    context,
+    references,
+    commitReference => !commitReference.action
   )
 
   return strings(
@@ -68,7 +83,8 @@ export function commitPartial(context, commit) {
       subject || header || '',
       commitLink
     ),
-    renderedReferences && `, closes ${renderedReferences}`
+    closingReferences && `, closes ${closingReferences}`,
+    otherReferences && `, references ${otherReferences}`
   )
 }
 

--- a/packages/conventional-changelog-conventionalcommits/test/index.spec.js
+++ b/packages/conventional-changelog-conventionalcommits/test/index.spec.js
@@ -244,6 +244,20 @@ describe('conventional-changelog-conventionalcommits', () => {
     expect(chunks[0]).toContain('[conventional-changelog/standard-version#358](https://github.com/conventional-changelog/standard-version/issues/358)')
   })
 
+  it('should render only closing action references under closes', async () => {
+    preparing(1)
+
+    const log = new ConventionalChangelog(testTools.cwd)
+      .readPackage()
+      .config(preset())
+      .write()
+    const chunks = await toArray(log)
+
+    expect(chunks[0]).toContain(', closes [#1](https://github.com/conventional-changelog/conventional-changelog/issues/1) [#2](https://github.com/conventional-changelog/conventional-changelog/issues/2)')
+    expect(chunks[0]).toContain(', references [#1](https://github.com/conventional-changelog/conventional-changelog/issues/1) [conventional-changelog/standard-version#358](https://github.com/conventional-changelog/standard-version/issues/358)')
+    expect(chunks[0]).not.toContain(', closes [#1](https://github.com/conventional-changelog/conventional-changelog/issues/1) [conventional-changelog/standard-version#358]')
+  })
+
   it('should properly format external repository issues given a `formatIssueUrl`', async () => {
     preparing(1)
 
@@ -473,8 +487,9 @@ describe('conventional-changelog-conventionalcommits', () => {
       .write()
     const chunks = await toArray(log)
 
-    expect(chunks[0]).toContain('closes [#99]')
+    expect(chunks[0]).toContain('references [#99]')
     expect(chunks[0]).toContain('[#100]')
+    expect(chunks[0]).not.toContain('closes [#99]')
     expect(chunks[0]).toContain('this completely changes the API')
   })
 

--- a/packages/conventional-changelog-writer/src/writers.spec.ts
+++ b/packages/conventional-changelog-writer/src/writers.spec.ts
@@ -30,19 +30,25 @@ const commits = [
     references: [
       {
         action: 'Closes',
+        owner: null,
         repository: null,
+        prefix: '#',
         issue: '1',
         raw: '#1'
       },
       {
         action: 'Closes',
+        owner: null,
         repository: null,
+        prefix: '#',
         issue: '2',
         raw: '#2'
       },
       {
         action: 'Closes',
+        owner: null,
         repository: null,
+        prefix: '#',
         issue: '3',
         raw: '#3'
       }

--- a/packages/template/src/types/commit.ts
+++ b/packages/template/src/types/commit.ts
@@ -1,10 +1,12 @@
 import type { AnyObject } from './utils.js'
 
 export interface CommitReference {
-  owner?: string | null
-  repository?: string | null
-  prefix?: string | null
-  issue?: string | number | null
+  raw: string
+  action: string | null
+  owner: string | null
+  repository: string | null
+  issue: string
+  prefix: string
 }
 
 export interface CommitNote {


### PR DESCRIPTION
Fixes https://github.com/conventional-changelog/conventional-changelog/issues/1461
Closes https://github.com/conventional-changelog/conventional-changelog/pull/1462