### PR TITLE
feat(conventional-changelog-conventionalcommits)!: support commit type effects

### DIFF
--- a/packages/conventional-changelog-conventionalcommits/README.md
+++ b/packages/conventional-changelog-conventionalcommits/README.md
@@ -83,12 +83,21 @@ See [conventional-changelog-config-spec](https://github.com/conventional-changel
 |--------|-------------|
 | ignoreCommits | Regular expression to match and exclude raw commits before parsing. |
 | issuePrefixes | Array of issue prefixes parsed as issue references. Defaults to `['#']`. |
-| types | Array of commit type objects defining sections, hidden types, and optional scope-specific type handling. Default value is available via the `DEFAULT_COMMIT_TYPES` export. |
+| types | Array of commit type objects defining sections, release effects, and optional scope-specific type handling. Default value is available via the `DEFAULT_COMMIT_TYPES` export. |
 | scope | String or array of scope names to filter commits. Only commits with matching scopes will be included. When `scopeOnly` is `false` (default), commits without any scope are also included. |
 | scopeOnly | When `true` and `scope` is specified, excludes commits that have no scope. When `false` (default), includes both scoped and unscooped commits when filtering by scope. |
 | preMajor | When `true`, breaking changes and features are downgraded by one semver level before the first major release. |
-| bumpStrict | When `true`, version bumps occur only for breaking changes or non-hidden commit types. When `false` (default), any commit can trigger a version bump. |
 | formatIssueUrl | Function that formats issue reference URLs. Receives `(context, reference)`. |
 | formatCommitUrl | Function that formats commit URLs. Receives `(context, commit)`. |
 | formatCompareUrl | Function that formats release comparison URLs. Receives `(context)`. |
 | formatUserUrl | Function that formats user mention URLs. Receives `(context, user)`. |
+
+Each item in `types` can define an `effect`:
+
+| Effect | Changelog | Version bump |
+|--------|-----------|--------------|
+| `bump` | Included | Included |
+| `changelog` | Included | Ignored |
+| `hidden` | Hidden | Ignored |
+
+`effect` defaults to `bump` when omitted. Breaking changes always trigger a major bump and are included in the changelog regardless of the type effect.

--- a/packages/conventional-changelog-conventionalcommits/src/constants.js
+++ b/packages/conventional-changelog-conventionalcommits/src/constants.js
@@ -1,57 +1,62 @@
 export const DEFAULT_COMMIT_TYPES = Object.freeze([
   {
     type: 'feat',
-    section: 'Features'
+    section: 'Features',
+    effect: 'bump'
   },
   {
     type: 'feature',
-    section: 'Features'
+    section: 'Features',
+    effect: 'bump'
   },
   {
     type: 'fix',
-    section: 'Bug Fixes'
+    section: 'Bug Fixes',
+    effect: 'bump'
   },
   {
     type: 'perf',
-    section: 'Performance Improvements'
+    section: 'Performance Improvements',
+    effect: 'bump'
   },
   {
     type: 'revert',
-    section: 'Reverts'
+    section: 'Reverts',
+    effect: 'bump'
   },
   {
     type: 'docs',
     section: 'Documentation',
-    hidden: true
+    effect: 'hidden'
   },
   {
     type: 'style',
     section: 'Styles',
-    hidden: true
+    effect: 'hidden'
   },
   {
     type: 'chore',
     section: 'Miscellaneous Chores',
-    hidden: true
+    effect: 'hidden'
   },
   {
     type: 'refactor',
     section: 'Code Refactoring',
-    hidden: true
+    effect: 'hidden'
   },
   {
     type: 'test',
     section: 'Tests',
-    hidden: true
+    effect: 'hidden'
   },
   {
     type: 'build',
     section: 'Build System',
-    hidden: true
+    effect: 'hidden'
   },
   {
     type: 'ci',
     section: 'Continuous Integration',
-    hidden: true
+    effect: 'hidden'
   }
 ].map(Object.freeze))

--- a/packages/conventional-changelog-conventionalcommits/src/index.d.ts
+++ b/packages/conventional-changelog-conventionalcommits/src/index.d.ts
@@ -1,7 +1,7 @@
 export interface CommitType {
   type: string
   section?: string
-  hidden?: boolean
+  effect?: 'bump' | 'changelog' | 'hidden'
   scope?: string
 }
 
@@ -17,7 +17,6 @@ export interface PresetConfig {
   scope?: string | string[]
   scopeOnly?: boolean
   preMajor?: boolean
-  bumpStrict?: boolean
   formatIssueUrl?: (context: Context, reference: Reference) => string
   formatCommitUrl?: (context: Context, commit: Commit) => string
   formatCompareUrl?: (context: Context) => string

--- a/packages/conventional-changelog-conventionalcommits/src/utils.js
+++ b/packages/conventional-changelog-conventionalcommits/src/utils.js
@@ -31,3 +31,23 @@ export function matchScope(config = {}, commit) {
     || (scopeOnly && includesScope)
     || (!scopeOnly && (!commit.scope || includesScope))
 }
+
+export function findTypeEntry(types, commit) {
+  const typeKey = (commit.revert ? 'revert' : commit.type || '').toLowerCase()
+
+  return types.find((entry) => {
+    if (entry.type !== typeKey) {
+      return false
+    }
+
+    if (entry.scope && entry.scope !== commit.scope) {
+      return false
+    }
+
+    return true
+  })
+}
+
+export function isTypeEffect(type, effect) {
+  return (type.effect || 'bump') === effect
+}

--- a/packages/conventional-changelog-conventionalcommits/src/whatBump.js
+++ b/packages/conventional-changelog-conventionalcommits/src/whatBump.js
@@ -1,52 +1,51 @@
 import { DEFAULT_COMMIT_TYPES } from './constants.js'
-import { matchScope } from './utils.js'
+import {
+  findTypeEntry,
+  isTypeEffect,
+  matchScope
+} from './utils.js'
 
 export function createWhatBump(config = {}) {
-  const {
-    types = DEFAULT_COMMIT_TYPES,
-    bumpStrict = false
-  } = config
-  const hiddenTypes = bumpStrict && types.reduce((hiddenTypes, type) => {
-    if (type.hidden) {
-      hiddenTypes.push(type.type)
-    }
-
-    return hiddenTypes
-  }, [])
+  const { types = DEFAULT_COMMIT_TYPES } = config
 
   return function whatBump(commits) {
-    let level = 2
+    let level = null
     let breakings = 0
     let features = 0
-    let bugfixes = 0
 
     commits.forEach((commit) => {
       if (!matchScope(config, commit)) {
         return
       }
 
+      const entry = findTypeEntry(types, commit)
+
       if (commit.notes.length > 0) {
         breakings += commit.notes.length
         level = 0
       } else
-        if (commit.type === 'feat' || commit.type === 'feature') {
-          features += 1
+        if (entry && isTypeEffect(entry, 'bump')) {
+          if (level === null) {
+            level = 2
+          }
 
-          if (level === 2) {
-            level = 1
+          if (commit.type === 'feat' || commit.type === 'feature') {
+            features += 1
+
+            if (level > 1) {
+              level = 1
+            }
           }
-        } else
-          if (bumpStrict && !hiddenTypes.includes(commit.type)) {
-            bugfixes += 1
-          }
+        }
     })
+
+    if (level === null) {
+      return null
+    }
 
     if (config?.preMajor && level < 2) {
       level++
-    } else
-      if (bumpStrict && level === 2 && !breakings && !features && !bugfixes) {
-        return null
-      }
+    }
 
     return {
       level,

--- a/packages/conventional-changelog-conventionalcommits/src/writer.js
+++ b/packages/conventional-changelog-conventionalcommits/src/writer.js
@@ -1,7 +1,11 @@
 import compareFunc from 'compare-func'
 import { link } from '@conventional-changelog/template'
 import { DEFAULT_COMMIT_TYPES } from './constants.js'
-import { matchScope } from './utils.js'
+import {
+  findTypeEntry,
+  isTypeEffect,
+  matchScope
+} from './utils.js'
 import {
   template,
   headerPartial,
@@ -20,7 +24,7 @@ export function createWriterOpts(config) {
     ...format,
     ...config
   }
-  const commitGroupOrder = finalConfig.types.flatMap(t => t.section).filter(t => t)
+  const commitGroupOrder = finalConfig.types.map(t => t.section).filter(Boolean)
 
   return {
     template,
@@ -50,7 +54,7 @@ export function createWriterOpts(config) {
 
       if (
         // breaking changes attached to any type are still displayed.
-        discard && (entry === undefined || entry.hidden)
+        discard && (entry === undefined || isTypeEffect(entry, 'hidden'))
         || !matchScope(finalConfig, commit)
       ) {
         return undefined
@@ -124,20 +128,4 @@ export function createWriterOpts(config) {
     noteGroupsSort: 'title',
     notesSort: compareFunc
   }
-}
-
-function findTypeEntry(types, commit) {
-  const typeKey = (commit.revert ? 'revert' : commit.type || '').toLowerCase()
-
-  return types.find((entry) => {
-    if (entry.type !== typeKey) {
-      return false
-    }
-
-    if (entry.scope && entry.scope !== commit.scope) {
-      return false
-    }
-
-    return true
-  })
 }

--- a/packages/conventional-changelog-conventionalcommits/test/index.spec.js
+++ b/packages/conventional-changelog-conventionalcommits/test/index.spec.js
@@ -216,7 +216,7 @@ describe('conventional-changelog-conventionalcommits', () => {
           commitType.type === 'chore'
             ? {
               ...commitType,
-              hidden: false
+              effect: 'changelog'
             }
             : commitType
         ))
@@ -555,23 +555,29 @@ describe('conventional-changelog-conventionalcommits', () => {
     expect(chunks[0]).not.toContain('[@nano')
   })
 
-  describe('bumpStrict parameter', () => {
-    it('should not bump version when bumpStrict is true and only hidden types are present', () => {
+  describe('type effects', () => {
+    it('should not bump version when only changelog or hidden types are present', () => {
       const config = preset({
-        bumpStrict: true,
         types: [
           {
             type: 'feat',
-            section: 'Features'
+            section: 'Features',
+            effect: 'bump'
           },
           {
             type: 'fix',
-            section: 'Bug Fixes'
+            section: 'Bug Fixes',
+            effect: 'bump'
           },
           {
             type: 'chore',
             section: 'Chores',
-            hidden: true
+            effect: 'changelog'
+          },
+          {
+            type: 'docs',
+            section: 'Documentation',
+            effect: 'hidden'
           }
         ]
       })
@@ -586,6 +592,11 @@ describe('conventional-changelog-conventionalcommits', () => {
           type: 'chore',
           scope: 'release',
           notes: []
+        },
+        {
+          type: 'docs',
+          scope: 'readme',
+          notes: []
         }
       ]
       const result = whatBump(commits)
@@ -593,22 +604,23 @@ describe('conventional-changelog-conventionalcommits', () => {
       expect(result).toBe(null)
     })
 
-    it('should bump version when bumpStrict is true and non-hidden types are present', () => {
+    it('should bump version when bump effect types are present', () => {
       const config = preset({
-        bumpStrict: true,
         types: [
           {
             type: 'feat',
-            section: 'Features'
+            section: 'Features',
+            effect: 'bump'
           },
           {
             type: 'fix',
-            section: 'Bug Fixes'
+            section: 'Bug Fixes',
+            effect: 'bump'
           },
           {
             type: 'chore',
             section: 'Chores',
-            hidden: true
+            effect: 'changelog'
           }
         ]
       })


### PR DESCRIPTION
BREAKING CHANGE: the commit type `effect` property replaces the `hidden` commit type property and the `bumpStrict` preset option for controlling changelog visibility and version bumps.

Fixes #1476.