### PR TITLE
fix(conventional-commits-parser,template): keep footers out of breaking notes

### DIFF
--- a/packages/conventional-changelog-conventionalcommits/test/index.spec.js
+++ b/packages/conventional-changelog-conventionalcommits/test/index.spec.js
@@ -92,6 +92,13 @@ setups([
   },
   () => {
     testTools.gitCommit(['fix: replace `@nano_kit/router` with `@nano_kit/router2`'])
+  },
+  () => {
+    testTools.gitCommit([
+      'feat!: support commit type effects',
+      'BREAKING CHANGE: effect replaces hidden.',
+      'Fixes #1476.'
+    ])
   }
 ])
 
@@ -553,6 +560,20 @@ describe('conventional-changelog-conventionalcommits', () => {
 
     expect(chunks[0]).toContain('`@nano_kit/router`')
     expect(chunks[0]).not.toContain('[@nano')
+  })
+
+  it('should not include closing references in breaking change notes', async () => {
+    preparing(13)
+
+    const log = new ConventionalChangelog(testTools.cwd)
+      .readPackage()
+      .config(preset())
+      .write()
+    const chunks = await toArray(log)
+
+    expect(chunks[0]).toContain('effect replaces hidden.')
+    expect(chunks[0]).toContain(', closes [#1476](https://github.com/conventional-changelog/conventional-changelog/issues/1476)')
+    expect(chunks[0]).not.toContain('Fixes #1476')
   })
 
   describe('type effects', () => {

--- a/packages/conventional-commits-parser/src/CommitParser.spec.ts
+++ b/packages/conventional-commits-parser/src/CommitParser.spec.ts
@@ -87,6 +87,166 @@ describe('conventional-commits-parser', () => {
         ])
       })
 
+      it('should stop note text before reference footer ending with a period', () => {
+        const commit = 'feat!: support type effects\n'
+          + '\n'
+          + 'BREAKING CHANGE: effect replaces hidden.\n'
+          + '\n'
+          + 'Fixes #1476.'
+        const result = parser.parse(commit)
+
+        expect(result.notes).toEqual([
+          {
+            title: 'BREAKING CHANGE',
+            text: 'effect replaces hidden.'
+          }
+        ])
+        expect(result.references).toEqual([
+          {
+            action: 'Fixes',
+            issue: '1476',
+            owner: null,
+            prefix: '#',
+            raw: '#1476',
+            repository: null
+          }
+        ])
+      })
+
+      it('should keep reference-like sentences in note text', () => {
+        const commit = 'feat!: support type effects\n'
+          + '\n'
+          + 'BREAKING CHANGE: effect replaces hidden.\n'
+          + 'This fixes #1476.\n'
+          + 'Consumers need to update their config.'
+        const result = parser.parse(commit)
+
+        expect(result.notes).toEqual([
+          {
+            title: 'BREAKING CHANGE',
+            text: 'effect replaces hidden.\nThis fixes #1476.\nConsumers need to update their config.'
+          }
+        ])
+        expect(result.references).toEqual([
+          {
+            action: 'fixes',
+            issue: '1476',
+            owner: null,
+            prefix: '#',
+            raw: '#1476',
+            repository: null
+          }
+        ])
+      })
+
+      it('should stop note text before the next footer token', () => {
+        const commit = 'feat!: support type effects\n'
+          + '\n'
+          + 'BREAKING CHANGE: effect replaces hidden.\n'
+          + '\n'
+          + 'Reviewed-by: Z'
+        const result = parser.parse(commit)
+
+        expect(result.notes).toEqual([
+          {
+            title: 'BREAKING CHANGE',
+            text: 'effect replaces hidden.'
+          }
+        ])
+        expect(result.footer).toBe('BREAKING CHANGE: effect replaces hidden.\n\nReviewed-by: Z')
+      })
+
+      it('should parse next custom note before checking footer tokens', () => {
+        const parser = new CommitParser({
+          noteKeywords: ['SECURITY', 'DEPRECATION']
+        })
+        const result = parser.parse(
+          'feat: support custom notes\n'
+          + '\n'
+          + 'SECURITY: token validation was hardened.\n'
+          + '\n'
+          + 'DEPRECATION: legacy token fallback will be removed.'
+        )
+
+        expect(result.notes).toEqual([
+          {
+            title: 'SECURITY',
+            text: 'token validation was hardened.'
+          },
+          {
+            title: 'DEPRECATION',
+            text: 'legacy token fallback will be removed.'
+          }
+        ])
+      })
+
+      it('should parse trailer footers without references (#773)', () => {
+        const result = parser.parse(
+          'test: this is a test\n'
+          + '\n'
+          + 'this is the body of the commit\n'
+          + '\n'
+          + 'Foo: Foo: this is a trailer\n'
+          + 'Bar: This is the footer of the commit'
+        )
+
+        expect(result.body).toBe('this is the body of the commit')
+        expect(result.footer).toBe('Foo: Foo: this is a trailer\nBar: This is the footer of the commit')
+      })
+
+      it('should not cut breaking change notes at inline references (#819)', () => {
+        const result = parser.parse(
+          'feat: add some cool new stuff\n'
+          + '\n'
+          + 'BREAKING CHANGE: We removed some boring old stuff in\n'
+          + 'order to make room for the new stuff. We went back and\n'
+          + 'forth on whether or not to do this in #4, so if you want\n'
+          + 'more information you should check out that discussion.'
+        )
+
+        expect(result.notes).toEqual([
+          {
+            title: 'BREAKING CHANGE',
+            text: 'We removed some boring old stuff in\n'
+              + 'order to make room for the new stuff. We went back and\n'
+              + 'forth on whether or not to do this in #4, so if you want\n'
+              + 'more information you should check out that discussion.'
+          }
+        ])
+        expect(result.references).toEqual([
+          {
+            action: null,
+            issue: '4',
+            owner: null,
+            prefix: '#',
+            raw: 'forth on whether or not to do this in #4',
+            repository: null
+          }
+        ])
+      })
+
+      it('should not include trailers after breaking change notes (#428)', () => {
+        const result = parser.parse(
+          'feat!: add some cool new stuff\n'
+          + '\n'
+          + 'BREAKING CHANGE: this changes the API.\n'
+          + '\n'
+          + 'Co-authored-by: Someone <someone@example.com>'
+        )
+
+        expect(result.notes).toEqual([
+          {
+            title: 'BREAKING CHANGE',
+            text: 'this changes the API.'
+          }
+        ])
+        expect(result.footer).toBe(
+          'BREAKING CHANGE: this changes the API.\n'
+          + '\n'
+          + 'Co-authored-by: Someone <someone@example.com>'
+        )
+      })
+
       it('should deduplicate references when the same issue appears multiple times', () => {
         const commit = 'feat(ng-list): Allow custom separator\n'
           + 'Closes #123\nCloses #123\nFixes #123\n'

--- a/packages/conventional-commits-parser/src/CommitParser.ts
+++ b/packages/conventional-commits-parser/src/CommitParser.ts
@@ -251,7 +251,7 @@ export class CommitParser {
     }
 
     const matches = this.currentLine().match(regexes.notes)
-    let references: CommitReference[]
+    let isFooterToken: boolean
 
     if (matches) {
       const note: CommitNote = {
@@ -272,18 +272,20 @@ export class CommitParser {
           return true
         }
 
-        references = this.parseReferences(this.currentLine())
+        isFooterToken = regexes.footerToken.test(this.currentLine())
 
-        if (references.length) {
-          commit.references.push(...references)
-        } else {
+        commit.references.push(
+          ...this.parseReferences(this.currentLine())
+        )
+
+        if (!isFooterToken) {
           note.text = appendLine(note.text, this.currentLine())
         }
 
         commit.footer = appendLine(commit.footer, this.currentLine())
         this.nextLine()
 
-        if (references.length) {
+        if (isFooterToken) {
           break
         }
       }
@@ -295,19 +297,25 @@ export class CommitParser {
   }
 
   private parseBodyAndFooter(isBody: boolean) {
-    const { commit } = this
+    const {
+      commit,
+      regexes
+    } = this
 
     if (!this.isLineAvailable()) {
       return isBody
     }
 
-    const references = this.parseReferences(this.currentLine())
-    const isStillBody = !references.length && isBody
+    const isFooterToken = regexes.footerToken.test(this.currentLine())
+    const isStillBody = !isFooterToken && isBody
+
+    commit.references.push(
+      ...this.parseReferences(this.currentLine())
+    )
 
     if (isStillBody) {
       commit.body = appendLine(commit.body, this.currentLine())
     } else {
-      commit.references.push(...references)
       commit.footer = appendLine(commit.footer, this.currentLine())
     }
 

--- a/packages/conventional-commits-parser/src/regex.spec.ts
+++ b/packages/conventional-commits-parser/src/regex.spec.ts
@@ -112,6 +112,48 @@ describe('conventional-commits-parser', () => {
         })
       })
 
+      describe('footerToken', () => {
+        it('should match footer tokens with colon separator', () => {
+          const { footerToken } = getParserRegexes()
+
+          expect('Reviewed-by: Z').toMatch(footerToken)
+          expect('BREAKING CHANGE: changed API').toMatch(footerToken)
+          expect('BREAKING-CHANGE: changed API').toMatch(footerToken)
+        })
+
+        it('should match footer tokens with issue separator', () => {
+          const { footerToken } = getParserRegexes({
+            issuePrefixes: ['#']
+          })
+
+          expect('Fixes #1476.').toMatch(footerToken)
+          expect('Kills   #1').toMatch(footerToken)
+          expect('Refs #123').toMatch(footerToken)
+        })
+
+        it('should not match footer tokens with issue separator if issue prefixes are not configured', () => {
+          const { footerToken } = getParserRegexes()
+
+          expect('Fixes #1476.').not.toMatch(footerToken)
+          expect('Refs: #1476.').toMatch(footerToken)
+        })
+
+        it('should match footer tokens with custom issue prefixes', () => {
+          const { footerToken } = getParserRegexes({
+            issuePrefixes: ['gh-']
+          })
+
+          expect('Kills gh-1').toMatch(footerToken)
+        })
+
+        it('should not match footer-like text inside sentences', () => {
+          const { footerToken } = getParserRegexes()
+
+          expect('This fixes #1476.').not.toMatch(footerToken)
+          expect('Reviewed by: Z').not.toMatch(footerToken)
+        })
+      })
+
       describe('references', () => {
         it('should match a simple reference', () => {
           const { references } = getParserRegexes({

--- a/packages/conventional-commits-parser/src/regex.ts
+++ b/packages/conventional-commits-parser/src/regex.ts
@@ -43,7 +43,7 @@ function getReferencePartsRegex(
 
   const flags = issuePrefixesCaseSensitive ? 'g' : 'gi'
 
-  return new RegExp(`(?:.*?)??\\s*([\\w-\\.\\/]*?)??(${joinOr(issuePrefixes)})([\\w-]+)(?=\\s|$|[,;)\\]])`, flags)
+  return new RegExp(`(?:.*?)??\\s*([\\w-\\.\\/]*?)??(${joinOr(issuePrefixes)})([\\w-]+)(?=\\s|$|[,;.)\\]])`, flags)
 }
 
 function getReferencesRegex(
@@ -59,6 +59,16 @@ function getReferencesRegex(
   return new RegExp(`(${joinedKeywords})(?:\\s+(.*?))(?=(?:${joinedKeywords})|$)`, 'gi')
 }
 
+function getFooterTokenRegex(
+  issuePrefixes: (string | RegExp)[] | undefined
+) {
+  const issuePrefixSeparator = issuePrefixes
+    ? `|\\s+(?:${joinOr(issuePrefixes)})`
+    : ''
+
+  return new RegExp(`^\\s*(?:BREAKING CHANGE|[\\w-]+)(?::\\s+${issuePrefixSeparator}).+`, 'i')
+}
+
 /**
  * Make the regexes used to parse a commit.
  * @param options
@@ -70,11 +80,13 @@ export function getParserRegexes(
   const notes = getNotesRegex(options.noteKeywords, options.notesPattern)
   const referenceParts = getReferencePartsRegex(options.issuePrefixes, options.issuePrefixesCaseSensitive)
   const references = getReferencesRegex(options.referenceActions)
+  const footerToken = getFooterTokenRegex(options.issuePrefixes)
 
   return {
     notes,
     referenceParts,
     references,
+    footerToken,
     mentions: /@([\w-]+)/g,
     url: /\b(?:https?):\/\/(?:www\.)?([-a-zA-Z0-9@:%_+.~#?&//=])+\b/
   }

--- a/packages/conventional-commits-parser/src/types.ts
+++ b/packages/conventional-commits-parser/src/types.ts
@@ -71,6 +71,7 @@ export interface ParserRegexes {
   notes: RegExp
   referenceParts: RegExp
   references: RegExp
+  footerToken: RegExp
   mentions: RegExp
   url: RegExp
 }

--- a/packages/template/src/elements.ts
+++ b/packages/template/src/elements.ts
@@ -62,8 +62,16 @@ export function list<T>(
     array,
     (item) => {
       const rendered = toString(callback(item)).trim()
+      const itemText = rendered
+        .split(/\r?\n/)
+        .map((line, index) => (
+          index > 0 && line
+            ? `  ${line}`
+            : line
+        ))
+        .join('\n')
 
-      return rendered ? `* ${rendered}` : ''
+      return rendered ? `* ${itemText}` : ''
     }
   )
 }

--- a/packages/template/src/templates.spec.ts
+++ b/packages/template/src/templates.spec.ts
@@ -11,6 +11,7 @@ import {
   commitPartial,
   footerPartial
 } from './templates.js'
+import { list } from './elements.js'
 
 let templateContext: any
 
@@ -19,6 +20,18 @@ function render(context: any) {
 }
 
 describe('@conventional-changelog/template', () => {
+  describe('elements', () => {
+    describe('list', () => {
+      it('should render multiline items as a single list item', () => {
+        const log = list([
+          'first line\nsecond line\n\nthird line'
+        ], item => item)
+
+        expect(log).toBe('* first line\n  second line\n\n  third line')
+      })
+    })
+  })
+
   describe('templates', () => {
     describe('compareUrl', () => {
       it('should encode tag names as URL path segments', () => {


### PR DESCRIPTION
Fixes #428.

Fixes #773.

Fixes #819.