### PR TITLE
feat(git-client): add all option to getTags to walk all refs

### DIFF
--- a/packages/git-client/src/GitClient.spec.ts
+++ b/packages/git-client/src/GitClient.spec.ts
@@ -161,6 +161,22 @@ describe('git-client', () => {
 
         expect(tags).toMatchObject(expect.arrayContaining([expect.stringMatching(/^v\d+\.\d+\.\d+$/)]))
       })
+
+      it('should honour `options.all`', async () => {
+        testTools.exec('git checkout -b all-tags-branch')
+        testTools.gitCommit('feat: commit for tag out of master history')
+        testTools.exec('git tag v19.0.0')
+        testTools.exec('git checkout master')
+        testTools.exec('git branch -D all-tags-branch')
+
+        const tags = await toArray(client.getTags())
+        const allTags = await toArray(client.getTags({
+          all: true
+        }))
+
+        expect(tags).not.toContain('v19.0.0')
+        expect(allTags).toContain('v19.0.0')
+      })
     })
 
     describe('getCurrentBranch', () => {

--- a/packages/git-client/src/GitClient.ts
+++ b/packages/git-client/src/GitClient.ts
@@ -135,7 +135,8 @@ export class GitClient {
       path,
       from = '',
       to = 'HEAD',
-      since
+      since,
+      all
     } = params
     const tagRegex = /tag:\s*(.+?)[,)]/gi
     const stdout = this.execStream(
@@ -143,6 +144,7 @@ export class GitClient {
       '--decorate',
       '--no-color',
       '--date-order',
+      all && '--all',
       since && `--since=${since instanceof Date ? since.toISOString() : since}`,
       [from, to].filter(Boolean).join('..'),
       ...path ? ['--', ...toArray(path)] : []

--- a/packages/git-client/src/types.ts
+++ b/packages/git-client/src/types.ts
@@ -37,7 +37,12 @@ export interface GitLogParams {
   firstParent?: boolean
 }
 
-export interface GitLogTagsParams extends Pick<GitLogParams, 'path' | 'from' | 'to' | 'since'> {}
+export interface GitLogTagsParams extends Pick<GitLogParams, 'path' | 'from' | 'to' | 'since'> {
+  /**
+   * Walk all refs (branches and tags) instead of the current branch history.
+   */
+  all?: boolean
+}
 
 export interface GetCommitsParams extends GitLogParams {
   /**


### PR DESCRIPTION
## Motivation

`getTags` walks the current branch history (`git log --decorate <from>..<to>`), so tags pointing to commits outside of it are invisible. This breaks tag discovery for workflows where release tags live on side branches — e.g. GitHub Action releases in [simple-release/node-gha](https://github.com/TrigenSoftware/simple-release/tree/main/packages/node-gha), where version tags point to bundled commits on the `latest` branch and are never merged back. See a real-world consequence: TrigenSoftware/simple-release-action#25 proposed a duplicated major release because the previous release tag was not reachable from `main`.

## Changes

- `getTags` (and `getSemverTags`/`getLastSemverTag` through it) accepts an `all` option which adds `--all` to the underlying `git log` call, walking all refs (branches and tags) in `--date-order` instead of only the current branch history.

🤖 Generated with [Claude Code](https://claude.com/claude-code)