### PR TITLE
fix(conventional-commits-parser): do not treat indented lines as footers

### DIFF
--- a/packages/conventional-commits-parser/src/CommitParser.spec.ts
+++ b/packages/conventional-commits-parser/src/CommitParser.spec.ts
@@ -247,6 +247,48 @@ describe('conventional-commits-parser', () => {
         )
       })
 
+      it('should not treat indented `key: value` lines as footers (#1512)', () => {
+        const result = parser.parse(
+          'chore(deps): bump foo from 1.0.0 to 2.0.0\n'
+          + '\n'
+          + 'Bumps foo from 1.0.0 to 2.0.0.\n'
+          + '\n'
+          + '---\n'
+          + 'updated-dependencies:\n'
+          + '- dependency-name: "foo"\n'
+          + '  dependency-version: 2.0.0\n'
+          + '  dependency-type: direct:development\n'
+          + '...\n'
+          + '\n'
+          + 'Signed-off-by: dependabot[bot] <support@github.com>'
+        )
+
+        expect(result.body).toBe(
+          'Bumps foo from 1.0.0 to 2.0.0.\n'
+          + '\n'
+          + '---\n'
+          + 'updated-dependencies:\n'
+          + '- dependency-name: "foo"\n'
+          + '  dependency-version: 2.0.0\n'
+          + '  dependency-type: direct:development\n'
+          + '...'
+        )
+        expect(result.footer).toBe('Signed-off-by: dependabot[bot] <support@github.com>')
+      })
+
+      it('should parse `-field-` meta markers with the default field pattern', () => {
+        const result = parser.parse(
+          'My commit message\n'
+          + '-hash-\n'
+          + '9b1aff905b638aa274a5fc8f88662df446d374bd\n'
+          + '-git-tags-\n'
+          + 'v1.0.0'
+        )
+
+        expect(result.hash).toBe('9b1aff905b638aa274a5fc8f88662df446d374bd')
+        expect(result['git-tags']).toBe('v1.0.0')
+      })
+
       it('should deduplicate references when the same issue appears multiple times', () => {
         const commit = 'feat(ng-list): Allow custom separator\n'
           + 'Closes #123\nCloses #123\nFixes #123\n'
@@ -369,7 +411,7 @@ describe('conventional-commits-parser', () => {
             },
             {
               title: 'BREAKING AMEND',
-              text: 'An awesome breaking change\n\n\n```\ncode here\n```'
+              text: 'An awesome breaking change\n\n\n```\ncode here\n```\n\n    Kills   #1'
             }
           ],
           references: [

--- a/packages/conventional-commits-parser/src/options.ts
+++ b/packages/conventional-commits-parser/src/options.ts
@@ -22,5 +22,7 @@ export const defaultOptions: ParserOptions = {
   ],
   revertPattern: /^Revert\s"([\s\S]*)"\s*This reverts commit (\w*)\.?/,
   revertCorrespondence: ['header', 'hash'],
-  fieldPattern: /^-(.*?)-$/
+  // The field name must contain at least one word character so that
+  // YAML document markers like `---` are not treated as field markers.
+  fieldPattern: /^-(?=.*\w)(.*?)-$/
 }

--- a/packages/conventional-commits-parser/src/regex.spec.ts
+++ b/packages/conventional-commits-parser/src/regex.spec.ts
@@ -152,6 +152,13 @@ describe('conventional-commits-parser', () => {
           expect('This fixes #1476.').not.toMatch(footerToken)
           expect('Reviewed by: Z').not.toMatch(footerToken)
         })
+
+        it('should not match indented `key: value` lines (#1512)', () => {
+          const { footerToken } = getParserRegexes()
+
+          expect('  dependency-version: 2.0.0').not.toMatch(footerToken)
+          expect('  dependency-type: direct:development').not.toMatch(footerToken)
+        })
       })
 
       describe('references', () => {

--- a/packages/conventional-commits-parser/src/regex.ts
+++ b/packages/conventional-commits-parser/src/regex.ts
@@ -66,7 +66,9 @@ function getFooterTokenRegex(
     ? `|\\s+(?:${joinOr(issuePrefixes)})`
     : ''
 
-  return new RegExp(`^\\s*(?:BREAKING CHANGE|[\\w-]+)(?::\\s+${issuePrefixSeparator}).+`, 'i')
+  // Footers follow the git trailer convention: the token starts at the
+  // beginning of the line, indented `key: value` lines are not footers.
+  return new RegExp(`^(?:BREAKING CHANGE|[\\w-]+)(?::\\s+${issuePrefixSeparator}).+`, 'i')
 }
 
 /**

--- a/website/src/content/docs/commits-parser/api.mdx
+++ b/website/src/content/docs/commits-parser/api.mdx
@@ -98,7 +98,7 @@ The same options configure all three functions. Defaults come from the [`default
 | `mergeCorrespondence` | `string[]` | | Names for the merge pattern's capture groups. |
 | `revertPattern` | `RegExp` | `/^Revert\s"([\s\S]*)"\s*This reverts commit (\w*)\.?/` | Detects revert commits. |
 | `revertCorrespondence` | `string[]` | `['header', 'hash']` | Names for the revert pattern's capture groups. |
-| `fieldPattern` | `RegExp` | `/^-(.*?)-$/` | Matches custom `-field-` blocks in the body. |
+| `fieldPattern` | `RegExp` | `/^-(?=.*\w)(.*?)-$/` | Matches custom `-field-` blocks in the body. |
 | `noteKeywords` | `(string \| RegExp)[]` | `['BREAKING CHANGE', 'BREAKING-CHANGE']` | Keywords that start a note. Case-insensitive. |
 | `notesPattern` | `(text) => RegExp` | | Builds the note-matching regex from the note keywords. |
 | `issuePrefixes` | `(string \| RegExp)[]` | `['#']` | Prefixes that mark an issue reference. |


### PR DESCRIPTION
Fixes #1512.

PR #1485 introduced the `footerToken` regex starting with `^\s*`, which made indented YAML `key: value` lines in Dependabot commit messages (e.g. `  dependency-version: 2.0.0`) match as footer tokens, truncating the body. This broke commitlint's `footer-leading-blank` rule on Dependabot commits.

## Changes

- **`footerToken`**: removed the leading `\s*`. Footers follow the git trailer convention — the token starts at the beginning of the line, indented lines are continuations, not new trailers.
- **default `fieldPattern`**: changed from `/^-(.*?)-$/` to `/^-(?=.*\w)(.*?)-$/`. The old default matched the YAML document marker `---` (capturing `-`), swallowing everything after it into a meta field. The lookahead requires at least one word character in the field name, so the capture is identical to the old behavior for any real field name (`-hash-`, `-gitTags-`, `- committerEmail-`, ...) and only lines with no word characters at all (`---`, `-...-`) no longer match.

With both fixes, the full Dependabot commit message from the issue parses correctly out of the box: the YAML block stays in `body`, and `footer` contains only the `Signed-off-by` trailer.

## Behavior change note

The `should keep spaces` test expectation was updated: an indented footer-token-like line (`    Kills   #1`) no longer terminates a preceding note's text — it stays in the note body, matching git trailer semantics. References are still extracted and the footer is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)