### PR TITLE
fix(conventional-commits-parser): require colon and line start for note keywords

### DIFF
--- a/packages/conventional-commits-parser/src/CommitParser.spec.ts
+++ b/packages/conventional-commits-parser/src/CommitParser.spec.ts
@@ -276,6 +276,33 @@ describe('conventional-commits-parser', () => {
         expect(result.footer).toBe('Signed-off-by: dependabot[bot] <support@github.com>')
       })
 
+      it('should not treat note keywords stranded by word-wrap as notes (#1515)', () => {
+        const result = parser.parse(
+          'docs(repo): use commit subjects for 5.0.0 \n'
+          + 'breaking changes #DS-2683\n'
+          + '\n'
+          + '- rewrite the 5.0.0 breaking changes entries in the web, web-react, and\n'
+          + '  design-tokens changelogs to use the concise commit subject instead of\n'
+          + '  the verbose breaking-change footer taken from the commit body\n'
+          + '- remove leaked co-author trailers from the breaking-change notes\n'
+          + '- collapse duplicate entries produced by commits carrying multiple\n'
+          + '  breaking-change footers'
+        )
+
+        expect(result.notes).toEqual([])
+      })
+
+      it('should not treat note keywords without a colon as notes (#1515)', () => {
+        const result = parser.parse(
+          'feat: something\n'
+          + '\n'
+          + 'BREAKING CHANGE was discussed but this commit contains none.'
+        )
+
+        expect(result.notes).toEqual([])
+        expect(result.body).toBe('BREAKING CHANGE was discussed but this commit contains none.')
+      })
+
       it('should parse `-field-` meta markers with the default field pattern', () => {
         const result = parser.parse(
           'My commit message\n'
@@ -402,18 +429,23 @@ describe('conventional-commits-parser', () => {
         )).toEqual({
           merge: null,
           header: ' feat(scope): broadcast $destroy event on scope destruction ',
-          body: ' perf testing shows that in chrome this change adds 5-15% overhead \n\n when destroying 10k nested scopes where each scope has a $destroy listener ',
-          footer: '         BREAKING AMEND: some breaking change         \n\n   BREAKING AMEND: An awesome breaking change\n\n\n```\ncode here\n```\n\n    Kills   #1',
-          notes: [
-            {
-              title: 'BREAKING AMEND',
-              text: 'some breaking change         '
-            },
-            {
-              title: 'BREAKING AMEND',
-              text: 'An awesome breaking change\n\n\n```\ncode here\n```\n\n    Kills   #1'
-            }
-          ],
+          // indented note keywords and footer tokens are not notes/footers,
+          // they stay in the body
+          body: ' perf testing shows that in chrome this change adds 5-15% overhead \n'
+            + '\n'
+            + ' when destroying 10k nested scopes where each scope has a $destroy listener \n'
+            + '         BREAKING AMEND: some breaking change         \n'
+            + '\n'
+            + '   BREAKING AMEND: An awesome breaking change\n'
+            + '\n'
+            + '\n'
+            + '```\n'
+            + 'code here\n'
+            + '```\n'
+            + '\n'
+            + '    Kills   #1',
+          footer: null,
+          notes: [],
           references: [
             {
               action: 'Kills',

--- a/packages/conventional-commits-parser/src/regex.spec.ts
+++ b/packages/conventional-commits-parser/src/regex.spec.ts
@@ -83,6 +83,27 @@ describe('conventional-commits-parser', () => {
           expect(match).toBe(null)
         })
 
+        it('should not match keywords without a colon or with leading whitespace (#1515)', () => {
+          const { notes } = getParserRegexes({
+            noteKeywords: ['BREAKING CHANGE', 'BREAKING-CHANGE']
+          })
+
+          expect('breaking-change footers'.match(notes)).toBe(null)
+          expect('  breaking-change footers'.match(notes)).toBe(null)
+          expect('  BREAKING CHANGE: indented'.match(notes)).toBe(null)
+        })
+
+        it('should match keywords prefixed with a `* ` bullet (squash commits)', () => {
+          const { notes } = getParserRegexes({
+            noteKeywords: ['BREAKING CHANGE', 'BREAKING-CHANGE']
+          })
+          const match = '* BREAKING CHANGE: So important.'.match(notes)
+
+          expect(match?.[1]).toBe('BREAKING CHANGE')
+          expect(match?.[2]).toBe('So important.')
+          expect('* BREAKING CHANGE:'.match(notes)?.[2]).toBe('')
+        })
+
         it('should escape regex special chars when used inside `noteKeywords`', () => {
           const noteKeywordsSpecialChars = [
             '[1]',

--- a/packages/conventional-commits-parser/src/regex.ts
+++ b/packages/conventional-commits-parser/src/regex.ts
@@ -27,7 +27,7 @@ function getNotesRegex(
   const noteKeywordsSelection = joinOr(noteKeywords)
 
   if (!notesPattern) {
-    return new RegExp(`^[\\s|*]*(${noteKeywordsSelection})[:\\s]+(.*)`, 'i')
+    return new RegExp(`^(?:\\*\\s+)?(${noteKeywordsSelection}):\\s*(.*)`, 'i')
   }
 
   return notesPattern(noteKeywordsSelection)


### PR DESCRIPTION
Fixes #1515.

The default notes regex accepted bare whitespace as the keyword separator (`[:\s]+`) and any leading whitespace (`^[\s|*]*`), so body text stranded at the start of a line by word-wrap — e.g. `  breaking-change footers` — was parsed as a phantom breaking-change note, forcing unwanted major bumps downstream.

## Changes

The default notes regex changed from `^[\s|*]*(KEYWORDS)[:\s]+(.*)` to `^(?:\*\s+)?(KEYWORDS):\s*(.*)`:

- **Colon is required** after the keyword, per spec item 12: a breaking change footer "MUST consist of the uppercase text BREAKING CHANGE, followed by a colon, space, and description".
- **The keyword must start at the beginning of the line** — notes are a special case of footers (spec items 8–9, git trailer convention), matching the `footerToken` behavior from #1513. Indented keyword lines stay in the body.
- **`* ` bullet prefix is still allowed** to keep supporting notes in squashed commit messages (existing contract, covered by the `should parse important notes that start with asterisks` test).
- `:\s*` (not `:\s+`) keeps the multiline `BREAKING CHANGE:` style (text on the following lines) working.

Custom formats remain supported via the `notesPattern` option.

## Behavior change note

The `should keep spaces` test expectation was updated: indented note-keyword lines (`   BREAKING AMEND: ...`) are no longer notes/footers and stay in the body, consistent with the footer handling change in #1513. References are still extracted from such lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)