### PR TITLE
fix(conventional-changelog): do not generate sections for unstable tags when skipUnstable is set

### DIFF
--- a/packages/conventional-changelog/src/ConventionalChangelog.spec.ts
+++ b/packages/conventional-changelog/src/ConventionalChangelog.spec.ts
@@ -153,6 +153,17 @@ setups([
     testTools.exec('git tag v7.0.0')
     testTools.exec('git checkout master')
     testTools.exec('git merge feature3 -m"Merge branch \'feature3\'"')
+  },
+  () => { // 21
+    testTools.gitCommit('feat: prerelease commit')
+    testTools.exec('git tag v8.0.0-rc.1')
+    testTools.gitCommit('feat: stable release commit')
+    testTools.exec('git tag v8.0.0')
+  },
+  () => { // 22
+    testTools.gitCommit('feat: promoted to stable commit')
+    testTools.exec('git tag v9.0.0-rc.1')
+    testTools.exec('git tag v9.0.0')
   }
 ])
 
@@ -1008,6 +1019,50 @@ describe('conventional-changelog', () => {
       expect(chunks[0]).toContain('seventh commit')
       expect(chunks[1]).toContain('# [6.0.0]')
       expect(chunks[1]).toContain('sixth commit')
+    })
+
+    it('should not generate separate sections for unstable tags if `skipUnstable` is set', async () => {
+      preparing(21)
+
+      const log = new ConventionalChangelog(testTools.cwd)
+        .readPackage()
+        .loadPreset('angular')
+        .tags({
+          skipUnstable: true
+        })
+        .options({
+          releaseCount: 2
+        })
+        .write()
+      const chunks = await toArray(log)
+      const changelog = chunks.join('')
+
+      expect(changelog).not.toContain('8.0.0-rc.1')
+      expect(changelog).toContain('# [8.0.0]')
+      expect(changelog).toContain('prerelease commit')
+      expect(changelog).toContain('stable release commit')
+    })
+
+    it('should use stable tag for section if commit also has an unstable tag and `skipUnstable` is set', async () => {
+      preparing(22)
+
+      const log = new ConventionalChangelog(testTools.cwd)
+        .readPackage()
+        .loadPreset('angular')
+        .tags({
+          skipUnstable: true
+        })
+        .options({
+          releaseCount: 2
+        })
+        .write()
+      const chunks = await toArray(log)
+      const changelog = chunks.join('')
+
+      expect(changelog).not.toContain('9.0.0-rc.1')
+      expect(changelog).toContain('# [9.0.0]')
+      expect(changelog).toContain('compare/v8.0.0...v9.0.0')
+      expect(changelog).toContain('promoted to stable commit')
     })
 
     describe('finalizeContext', () => {

--- a/packages/conventional-changelog/src/ConventionalChangelog.ts
+++ b/packages/conventional-changelog/src/ConventionalChangelog.ts
@@ -45,6 +45,7 @@ import {
   guessNextTag,
   isUnreleasedVersion,
   versionTagRegex,
+  matchSemverTag,
   defaultCommitTransform,
   bindLogNamespace
 } from './utils.js'
@@ -173,10 +174,10 @@ export class ConventionalChangelog {
         const lastCommitHash = lastCommit ? lastCommit.hash : null
 
         if ((!context.currentTag || !context.previousTag) && keyCommit) {
-          const matches = keyCommit.gitTags?.match(versionTagRegex)
           const { currentTag } = context
 
-          context.currentTag = currentTag || matches?.[1] // currentTag || matches ? matches[1] : null
+          context.currentTag = currentTag
+            || matchSemverTag(keyCommit.gitTags, versionTagRegex, tag => semverTags.includes(tag))
 
           const index = context.currentTag
             ? semverTags.indexOf(context.currentTag)

--- a/packages/conventional-changelog/src/utils.ts
+++ b/packages/conventional-changelog/src/utils.ts
@@ -1,4 +1,5 @@
 import type { TemplateContext } from 'conventional-changelog-writer'
+import { isPrereleaseVersion } from '@conventional-changelog/git-client'
 import type {
   Logger,
   HostedGitInfo,
@@ -62,14 +63,30 @@ export function isUnreleasedVersion(
     && (lastTag === version || lastTag === `v${version}`)
 }
 
-export const versionTagRegex = /tag:\s*(.*?)[,)]/i
-export const defaultVersionRegex = /tag:\s*[v=]?(.*?)[,)]/i
+export const versionTagRegex = /tag:\s*(.*?)[,)]/gi
+export const defaultVersionRegex = /tag:\s*[v=]?(.*?)[,)]/gi
+
+export function matchSemverTag(
+  gitTags: string | null | undefined,
+  regex: RegExp,
+  predicate: (tag: string) => boolean
+) {
+  if (typeof gitTags === 'string') {
+    for (const [, tag] of gitTags.matchAll(regex)) {
+      if (predicate(tag)) {
+        return tag
+      }
+    }
+  }
+
+  return null
+}
 
 export function defaultCommitTransform(commit: Commit, params: Params) {
   const { tags, options: { formatDate } } = params
   const prefix = tags?.prefix
   const versionRegex = prefix
-    ? new RegExp(`tag:\\s*[v=]?${prefix}(.*?)[,)]`, 'i')
+    ? new RegExp(`tag:\\s*[v=]?${prefix}(.*?)[,)]`, 'gi')
     : defaultVersionRegex
   const {
     committerDate,
@@ -80,13 +97,14 @@ export function defaultCommitTransform(commit: Commit, params: Params) {
       ? formatDate!(committerDate)
       : committerDate
   }
+  const version = matchSemverTag(
+    gitTags,
+    versionRegex,
+    version => !(tags?.skipUnstable && isPrereleaseVersion(version))
+  )
 
-  if (typeof gitTags === 'string') {
-    const matches = gitTags.match(versionRegex)
-
-    if (matches) {
-      patch.version = matches[1]
-    }
+  if (version) {
+    patch.version = version
   }
 
   return patch

--- a/packages/git-client/src/ConventionalGitClient.spec.ts
+++ b/packages/git-client/src/ConventionalGitClient.spec.ts
@@ -221,6 +221,20 @@ describe('git-client', () => {
 
         expect(tags).toEqual(['same/3.1.0'])
       })
+
+      it('should not skip stable tags with build metadata', async () => {
+        testTools.writeFileSync('test15', '')
+        testTools.exec('git add --all && git commit -m"chore: build metadata"')
+        testTools.exec('git tag meta/1.0.0+build.1.2.3-foo')
+
+        const tagsStream = client.getSemverTags({
+          prefix: 'meta/',
+          skipUnstable: true
+        })
+        const tags = await toArray(tagsStream)
+
+        expect(tags).toEqual(['meta/1.0.0+build.1.2.3-foo'])
+      })
     })
 
     describe('getLastSemverTag', () => {

--- a/packages/git-client/src/ConventionalGitClient.ts
+++ b/packages/git-client/src/ConventionalGitClient.ts
@@ -10,6 +10,7 @@ import type {
   GetCommitsParams,
   GetSemverTagsParams
 } from './types.js'
+import { isPrereleaseVersion } from './utils.js'
 import { GitClient } from './GitClient.js'
 
 /**
@@ -94,7 +95,6 @@ export class ConventionalGitClient extends GitClient {
       ...getTagsParams
     } = params
     const tagsStream = this.getTags(getTagsParams)
-    const unstableTagRegex = /\d+\.\d+\.\d+-.+/
     const cleanTag = clean
       ? (tag: string, unprefixed?: string) => semver.clean(unprefixed || tag)
       : (tag: string) => tag
@@ -102,10 +102,6 @@ export class ConventionalGitClient extends GitClient {
     let tag: string | null
 
     for await (tag of tagsStream) {
-      if (skipUnstable && unstableTagRegex.test(tag)) {
-        continue
-      }
-
       if (prefix) {
         const isPrefixed = typeof prefix === 'string'
           ? tag.startsWith(prefix)
@@ -114,7 +110,7 @@ export class ConventionalGitClient extends GitClient {
         if (isPrefixed) {
           unprefixed = tag.replace(prefix, '')
 
-          if (semver.valid(unprefixed)) {
+          if (semver.valid(unprefixed) && !(skipUnstable && isPrereleaseVersion(unprefixed))) {
             tag = cleanTag(tag, unprefixed)
 
             if (tag) {
@@ -122,7 +118,7 @@ export class ConventionalGitClient extends GitClient {
             }
           }
         }
-      } else if (semver.valid(tag)) {
+      } else if (semver.valid(tag) && !(skipUnstable && isPrereleaseVersion(tag))) {
         tag = cleanTag(tag)
 
         if (tag) {

--- a/packages/git-client/src/utils.spec.ts
+++ b/packages/git-client/src/utils.spec.ts
@@ -3,7 +3,10 @@ import {
   it,
   expect
 } from 'vitest'
-import { formatArgs } from './utils.js'
+import {
+  formatArgs,
+  isPrereleaseVersion
+} from './utils.js'
 
 describe('git-client', () => {
   describe('utils', () => {
@@ -19,6 +22,27 @@ describe('git-client', () => {
       it('should skip empty arguments', () => {
         expect(formatArgs('git', 'log', '')).toEqual(['git', 'log'])
         expect(formatArgs('git', 'log', null)).toEqual(['git', 'log'])
+      })
+    })
+
+    describe('isPrereleaseVersion', () => {
+      it('should detect prerelease versions', () => {
+        expect(isPrereleaseVersion('1.0.0-alpha.1')).toBe(true)
+        expect(isPrereleaseVersion('1.0.0-rc.2')).toBe(true)
+        expect(isPrereleaseVersion('v1.0.0-rc.2')).toBe(true)
+      })
+
+      it('should not detect stable versions', () => {
+        expect(isPrereleaseVersion('1.0.0')).toBe(false)
+        expect(isPrereleaseVersion('v1.0.0')).toBe(false)
+      })
+
+      it('should not detect stable versions with build metadata', () => {
+        expect(isPrereleaseVersion('1.0.0+build.1.2.3-foo')).toBe(false)
+      })
+
+      it('should not detect invalid versions', () => {
+        expect(isPrereleaseVersion('not-semver')).toBe(false)
       })
     })
   })

--- a/packages/git-client/src/utils.ts
+++ b/packages/git-client/src/utils.ts
@@ -1,3 +1,4 @@
+import semver from 'semver'
 import type { Arg } from './types.js'
 
 /**
@@ -22,4 +23,13 @@ export function formatArgs(...args: Arg[]): string[] {
  */
 export function toArray<T>(value: T | T[]) {
   return Array.isArray(value) ? value : [value]
+}
+
+/**
+ * Check if version is a prerelease, e.g. 1.0.0-alpha.1, 1.0.0-rc.2.
+ * @param version
+ * @returns True if version is a prerelease.
+ */
+export function isPrereleaseVersion(version: string) {
+  return semver.prerelease(version) !== null
 }


### PR DESCRIPTION
Fixes #1519

## Problem

`--skip-unstable` only filtered the semver tags list used for commit ranges and compare links, but release sections are split by the writer based on `commit.version`, which `defaultCommitTransform` sets from any git tag — including unstable ones. As a result, prerelease tags (e.g. `x.x.x-rc.1`) still produced their own sections in the changelog; the only visible difference was that their headers lost compare links (the tags were missing from `gitSemverTags`).

## Solution

- `@conventional-changelog/git-client`: extracted the unstable version check from `getSemverTags` into an exported `isPrereleaseVersion` utility based on `semver.prerelease()` (instead of the previous substring regex), and moved the `skipUnstable` check after prefix stripping and semver validation.
- `conventional-changelog`: `defaultCommitTransform` no longer sets `commit.version` from an unstable tag when `tags.skipUnstable` is set. All tag decorations of a commit are now scanned (via a new internal `matchSemverTag` helper), so a commit tagged with both a prerelease and a stable tag (e.g. an rc promoted to release) keeps its stable version.
- `finalizeContext` picks the first tag present in `gitSemverTags` when resolving `context.currentTag`, keeping compare links correct for mixed-tag commits.

## Result

With `skipUnstable`, prerelease tags no longer appear as separate sections — their commits are included in the following stable release, and compare links remain correct.

Note on `getSemverTags` behavior: since the unstable check is now semver-based and runs after prefix stripping, stable versions with build metadata (e.g. `1.0.0+build.1.2.3-foo`) and tags whose prefix contains a version-like string are no longer skipped by `skipUnstable`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)