### PR TITLE
ci: add manual release trigger to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,25 @@
 name: Release
 on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Force specific version
+        type: string
+      as:
+        description: Release type
+        type: choice
+        options:
+          - ''
+          - major
+          - minor
+          - patch
+          - prerelease
+      prerelease:
+        description: Pre-release identifier (e.g. alpha, beta)
+        type: string
+      by-project:
+        description: 'Per-package release options (JSON, e.g. {"pkg-name":{"as":"minor"}})'
+        type: string
   issue_comment:
     types: [created, deleted]
   push:
@@ -34,6 +54,10 @@ jobs:
         with:
           workflow: pull-request
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          bump-version: ${{ inputs.version }}
+          bump-as: ${{ inputs.as }}
+          bump-prerelease: ${{ inputs.prerelease }}
+          bump-by-project: ${{ inputs['by-project'] }}
   release:
     runs-on: ubuntu-latest
     name: Release


### PR DESCRIPTION
Adds a `workflow_dispatch` trigger to the release workflow so a release can be forced manually through the same release pull request flow:

- `version` — force a specific version
- `as` — release type (`major` / `minor` / `patch` / `prerelease`)
- `prerelease` — pre-release identifier
- `by-project` — per-package options for the independent monorepo, e.g. `{"@conventional-changelog/git-client":{"as":"minor"}}`

Inputs are forwarded to the `pull-request` job as `bump-*` options; on regular pushes the `inputs` context is empty, so the existing flow is unaffected.

Motivation: #1520 changed both `conventional-changelog` and `@conventional-changelog/git-client`, but the commit scope only mentioned the former — so the release attributed nothing to `git-client` and it was never published, while the released `conventional-changelog` depends on its new export. A manual trigger makes it possible to force the missing release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)