### PR TITLE
test: remove duplicate repository fields from fixtures

### DIFF
--- a/packages/conventional-changelog-angular/test/fixtures/_ghe-host.json
+++ b/packages/conventional-changelog-angular/test/fixtures/_ghe-host.json
@@ -1,5 +1,4 @@
 {
-  "repository": "ghe",
   "version": "v3.0.0",
   "repository": "https://github.internal.example.com/conventional-changelog/internal"
 }

--- a/packages/conventional-changelog-angular/test/fixtures/_known-host.json
+++ b/packages/conventional-changelog-angular/test/fixtures/_known-host.json
@@ -1,5 +1,4 @@
 {
-  "repository": "known",
   "version": "v2.0.0",
   "repository": "https://github.com/conventional-changelog/example"
 }

--- a/packages/conventional-changelog-conventionalcommits/test/fixtures/_ghe-host.json
+++ b/packages/conventional-changelog-conventionalcommits/test/fixtures/_ghe-host.json
@@ -1,5 +1,4 @@
 {
-  "repository": "ghe",
   "version": "v3.0.0",
   "repository": "https://github.internal.example.com/conventional-changelog/internal"
 }

--- a/packages/conventional-changelog-conventionalcommits/test/fixtures/_known-host.json
+++ b/packages/conventional-changelog-conventionalcommits/test/fixtures/_known-host.json
@@ -1,5 +1,4 @@
 {
-  "repository": "known",
   "version": "v2.0.0",
   "repository": "https://github.com/conventional-changelog/example"
 }


### PR DESCRIPTION
Fixes #623

## Summary

- remove duplicate `repository` properties from the known-host and GitHub Enterprise test fixtures
- retain the effective repository URLs used by the tests

## Root cause

`JSON.parse` silently retains the final duplicate key, so the earlier values were inert and made the fixtures ambiguous.

## Validation

- `pnpm exec vitest run packages/conventional-changelog-angular/test/index.spec.js packages/conventional-changelog-conventionalcommits/test/index.spec.js`