### PR TITLE
docs: resolve ambiguity about `scope`

### DIFF
--- a/website/src/content/docs/presets/conventional-commits/options.mdx
+++ b/website/src/content/docs/presets/conventional-commits/options.mdx
@@ -49,7 +49,7 @@ generator.config(createPreset({ /* options */ }))
 | `types` | `CommitType[]` | [default types](#types) | Commit types to recognize, the section each appears under, and its visibility. |
 | `ignoreCommits` | `RegExp` | | Skip commits whose message matches this pattern. |
 | `issuePrefixes` | `string[]` | `['#']` | Prefixes recognized as issue references and linkified in subjects. |
-| `scope` | `string \| string[]` | | Only include commits for the given scope(s); the scope is stripped from the output. |
+| `scope` | `string \| string[]` | | Only include commits for the given scope(s) (or commits with no scope, unless `scopeOnly` is `true`); the scope is stripped from the output.|
 | `scopeOnly` | `boolean` | `false` | With `scope`, also exclude commits that have no scope. |
 | `preMajor` | `boolean` | `false` | Treat the project as pre-1.0 when recommending a version bump. |
 | `formatIssueUrl` | `(context, reference) => string` | git-host style | Build the URL for an issue/PR reference. |


### PR DESCRIPTION
“Only include commits with the given scope(s)” is an unqualified statement and sounds like it absolutely would not include commits with no scope.

To me, the `scopeOnly` option below in the table still didn’t make this clear enough I felt 100% sure I knew what you meant, because taken literally, it contradicts the above statement.  And I didn’t realize there was a detailed section below; I only discovered the table.