### PR TITLE
feat(conventional-changelog-angular,conventional-changelog-conventionalcommits,template): format references in breaking change notes

### DIFF
--- a/packages/conventional-changelog-angular/src/writer.js
+++ b/packages/conventional-changelog-angular/src/writer.js
@@ -1,4 +1,9 @@
 import {
+  createReferencesFormatter,
+  referenceRepositoryUrl,
+  url
+} from '@conventional-changelog/template'
+import {
   template,
   headerPartial,
   preamblePartial,
@@ -7,6 +12,21 @@ import {
 } from './templates.js'
 
 const COMMIT_HASH_LENGTH = 7
+const formatReferences = createReferencesFormatter({
+  issuePrefixes: ['#'],
+  issuePattern: /[0-9]+/,
+  formatIssueUrl: (context, reference) => {
+    const repositoryUrl = referenceRepositoryUrl(context, reference)
+
+    // without a repository url there is nothing to link to
+    return repositoryUrl
+      ? url(repositoryUrl, 'issues', reference.issue)
+      : ''
+  },
+  formatUserUrl: (context, user) => (context.host
+    ? url(context.host, user)
+    : '')
+})
 
 function compareNotes(a, b) {
   return (a.title || '').localeCompare(b.title || '')
@@ -27,7 +47,8 @@ export function createWriterOpts() {
 
         return {
           ...note,
-          title: 'BREAKING CHANGES'
+          title: 'BREAKING CHANGES',
+          text: formatReferences(note.text, context)
         }
       })
       let { type } = commit
@@ -64,37 +85,12 @@ export function createWriterOpts() {
       let { subject } = commit
 
       if (typeof subject === 'string') {
-        let url = context.repository
-          ? `${context.host}/${context.owner}/${context.repository}`
-          : context.repoUrl
-
-        if (url) {
-          url = `${url}/issues/`
-          // Issue URLs.
-          subject = subject.replace(/#([0-9]+)/g, (_, issue) => {
-            issues.push(issue)
-            return `[#${issue}](${url}${issue})`
-          })
-        }
-
-        if (context.host) {
-          // User URLs.
-          subject = subject.replace(/`[^`]*`|\B@([a-z0-9](?:-?[a-z0-9/]){0,38})/g, (match, username) => {
-            if (!username) {
-              return match
-            }
-
-            if (username.includes('/')) {
-              return `@${username}`
-            }
-
-            return `[@${username}](${context.host}/${username})`
-          })
-        }
+        // Issue and user URLs.
+        subject = formatReferences(subject, context, issues)
       }
 
       // remove references that already appear in the subject
-      const references = commit.references.filter(reference => !issues.includes(reference.issue))
+      const references = commit.references.filter(reference => !issues.includes(reference.prefix + reference.issue))
 
       return {
         notes,

--- a/packages/conventional-changelog-angular/test/index.spec.js
+++ b/packages/conventional-changelog-angular/test/index.spec.js
@@ -71,6 +71,14 @@ setups([
   },
   () => {
     testTools.gitCommit(['fix: replace `@nano_kit/router` with `@nano_kit/router2`'])
+  },
+  () => {
+    testTools.gitCommit([
+      'feat(api): drop legacy endpoints',
+      'BREAKING CHANGE: see #300 and ask @dlmr for details.',
+      'Already formatted: [#301](https://tracker.example/301).',
+      'Code span: `#302`.'
+    ])
   }
 ])
 
@@ -335,5 +343,33 @@ describe('conventional-changelog-angular', () => {
 
     expect(chunks[0]).toContain('`@nano_kit/router`')
     expect(chunks[0]).not.toContain('[@nano')
+  })
+
+  it('should format references in breaking change notes', async () => {
+    preparing(11)
+
+    const log = new ConventionalChangelog(testTools.cwd)
+      .readPackage()
+      .config(preset())
+      .write()
+    const chunks = await toArray(log)
+
+    expect(chunks[0]).toContain('see [#300](https://github.com/conventional-changelog/conventional-changelog/issues/300)')
+    expect(chunks[0]).toContain('ask [@dlmr](https://github.com/dlmr) for details.')
+  })
+
+  it('should keep already formatted references in breaking change notes as is', async () => {
+    preparing(11)
+
+    const log = new ConventionalChangelog(testTools.cwd)
+      .readPackage()
+      .config(preset())
+      .write()
+    const chunks = await toArray(log)
+
+    expect(chunks[0]).toContain('Already formatted: [#301](https://tracker.example/301).')
+    expect(chunks[0]).toContain('Code span: `#302`.')
+    expect(chunks[0]).not.toContain('https://github.com/conventional-changelog/conventional-changelog/issues/301')
+    expect(chunks[0]).not.toContain('https://github.com/conventional-changelog/conventional-changelog/issues/302')
   })
 })

--- a/packages/conventional-changelog-conventionalcommits/src/writer.js
+++ b/packages/conventional-changelog-conventionalcommits/src/writer.js
@@ -1,4 +1,4 @@
-import { link } from '@conventional-changelog/template'
+import { createReferencesFormatter } from '@conventional-changelog/template'
 import { DEFAULT_COMMIT_TYPES } from './constants.js'
 import {
   findTypeEntry,
@@ -30,6 +30,7 @@ export function createWriterOpts(config) {
     ...config
   }
   const commitGroupOrder = finalConfig.types.map(t => t.section).filter(Boolean)
+  const formatReferences = createReferencesFormatter(finalConfig)
 
   return {
     template,
@@ -54,7 +55,8 @@ export function createWriterOpts(config) {
 
         return {
           ...note,
-          title: 'BREAKING CHANGES'
+          title: 'BREAKING CHANGES',
+          text: formatReferences(note.text, context)
         }
       })
 
@@ -78,35 +80,8 @@ export function createWriterOpts(config) {
       let { subject } = commit
 
       if (typeof subject === 'string') {
-        // Issue URLs.
-        const issueRegEx = `(${finalConfig.issuePrefixes.join('|')})([a-z0-9]+)`
-        const re = new RegExp(issueRegEx, 'g')
-
-        subject = subject.replace(re, (_, prefix, issue) => {
-          issues.push(prefix + issue)
-
-          const issueUrl = finalConfig.formatIssueUrl(context, {
-            issue,
-            prefix
-          })
-
-          return link(`${prefix}${issue}`, issueUrl)
-        })
-        // User URLs.
-        subject = subject.replace(/`[^`]*`|\B@([a-z0-9](?:-?[a-z0-9/]){0,38})/g, (match, user) => {
-          if (!user) {
-            return match
-          }
-
-          // TODO: investigate why this code exists.
-          if (user.includes('/')) {
-            return `@${user}`
-          }
-
-          const usernameUrl = finalConfig.formatUserUrl(context, user)
-
-          return link(`@${user}`, usernameUrl)
-        })
+        // Issue and user URLs.
+        subject = formatReferences(subject, context, issues)
       }
 
       // remove references that already appear in the subject

--- a/packages/conventional-changelog-conventionalcommits/test/index.spec.js
+++ b/packages/conventional-changelog-conventionalcommits/test/index.spec.js
@@ -99,6 +99,20 @@ setups([
       'BREAKING CHANGE: effect replaces hidden.',
       'Fixes #1476.'
     ])
+  },
+  () => {
+    testTools.gitCommit([
+      'feat(api): drop legacy endpoints',
+      'BREAKING CHANGE: EXAMPLE-100 describes the migration, ask @dlmr for details.',
+      'Already formatted: [EXAMPLE-101](https://tracker.example/EXAMPLE-101).',
+      'Plain url: https://tracker.example/EXAMPLE-102.',
+      'Code span: `EXAMPLE-103`.',
+      'Code block:',
+      '```js',
+      'migrate(\'EXAMPLE-104\')',
+      '```'
+    ])
+    testTools.gitCommit(['feat(api): keep `EXAMPLE-200` as is'])
   }
 ])
 
@@ -320,6 +334,60 @@ describe('conventional-changelog-conventionalcommits', () => {
     const chunks = await toArray(log)
 
     expect(chunks[0]).toContain('[EXAMPLE-1](https://example.com/browse/EXAMPLE-1)')
+  })
+
+  it('should format references in breaking change notes', async () => {
+    preparing(14)
+
+    const log = new ConventionalChangelog(testTools.cwd)
+      .readPackage()
+      .config(preset({
+        formatIssueUrl: (_context, reference) => `https://example.com/browse/${reference.prefix}${reference.issue}`,
+        issuePrefixes: ['EXAMPLE-']
+      }))
+      .write()
+    const chunks = await toArray(log)
+
+    expect(chunks[0]).toContain('[EXAMPLE-100](https://example.com/browse/EXAMPLE-100) describes the migration')
+    expect(chunks[0]).toContain('ask [@dlmr](https://github.com/dlmr) for details.')
+  })
+
+  it('should keep already formatted references in breaking change notes as is', async () => {
+    preparing(14)
+
+    const log = new ConventionalChangelog(testTools.cwd)
+      .readPackage()
+      .config(preset({
+        formatIssueUrl: (_context, reference) => `https://example.com/browse/${reference.prefix}${reference.issue}`,
+        issuePrefixes: ['EXAMPLE-']
+      }))
+      .write()
+    const chunks = await toArray(log)
+
+    expect(chunks[0]).toContain('Already formatted: [EXAMPLE-101](https://tracker.example/EXAMPLE-101).')
+    expect(chunks[0]).toContain('Plain url: https://tracker.example/EXAMPLE-102.')
+    expect(chunks[0]).toContain('Code span: `EXAMPLE-103`.')
+    expect(chunks[0]).toContain('migrate(\'EXAMPLE-104\')')
+    expect(chunks[0]).not.toContain('https://example.com/browse/EXAMPLE-101')
+    expect(chunks[0]).not.toContain('https://example.com/browse/EXAMPLE-102')
+    expect(chunks[0]).not.toContain('https://example.com/browse/EXAMPLE-103')
+    expect(chunks[0]).not.toContain('https://example.com/browse/EXAMPLE-104')
+  })
+
+  it('should keep references inside code spans in subject as is', async () => {
+    preparing(14)
+
+    const log = new ConventionalChangelog(testTools.cwd)
+      .readPackage()
+      .config(preset({
+        formatIssueUrl: (_context, reference) => `https://example.com/browse/${reference.prefix}${reference.issue}`,
+        issuePrefixes: ['EXAMPLE-']
+      }))
+      .write()
+    const chunks = await toArray(log)
+
+    expect(chunks[0]).toContain('keep `EXAMPLE-200` as is')
+    expect(chunks[0]).not.toContain('https://example.com/browse/EXAMPLE-200')
   })
 
   it('should replace #[a-z0-9]+ with issue URL by default', async () => {
@@ -546,7 +614,7 @@ describe('conventional-changelog-conventionalcommits', () => {
       .write()
     const chunks = await toArray(log)
 
-    expect(chunks[0]).toMatch(/incredible new flag FIXES: #33\r?\n/)
+    expect(chunks[0]).toMatch(/incredible new flag FIXES: \[#33]\(https:\/\/github\.com\/conventional-changelog\/conventional-changelog\/issues\/33\)\r?\n/)
   })
 
   it('parses both default (Revert "<subject>") and custom (revert: <subject>) revert commits', async () => {

--- a/packages/template/src/index.ts
+++ b/packages/template/src/index.ts
@@ -1,3 +1,4 @@
 export type * from './types/index.js'
 export * from './elements.js'
+export * from './references.js'
 export * from './templates.js'

--- a/packages/template/src/references.spec.ts
+++ b/packages/template/src/references.spec.ts
@@ -1,0 +1,147 @@
+import {
+  describe,
+  it,
+  expect
+} from 'vitest'
+import { createReferencesFormatter } from './references.js'
+
+const context = {} as any
+
+function createFormatter(options = {}) {
+  return createReferencesFormatter({
+    issuePrefixes: ['#'],
+    formatIssueUrl: (_context, reference) => `https://tracker/${reference.prefix}${reference.issue}`,
+    formatUserUrl: (_context, user) => `https://host/${user}`,
+    ...options
+  })
+}
+
+describe('@conventional-changelog/template', () => {
+  describe('references', () => {
+    describe('createReferencesFormatter', () => {
+      it('should format issue and user references', () => {
+        const format = createFormatter()
+
+        expect(format('see #1 by @dlmr', context)).toBe(
+          'see [#1](https://tracker/#1) by [@dlmr](https://host/dlmr)'
+        )
+      })
+
+      it('should collect formatted issue references', () => {
+        const format = createFormatter()
+        const references: string[] = []
+
+        format('see #1 and #2', context, references)
+
+        expect(references).toEqual(['#1', '#2'])
+      })
+
+      it('should keep formatted Markdown segments as is', () => {
+        const format = createFormatter()
+
+        expect(format('[#1](https://tracker/1)', context)).toBe('[#1](https://tracker/1)')
+        expect(format('[#1][ticket]', context)).toBe('[#1][ticket]')
+        expect(format('`#1`', context)).toBe('`#1`')
+        expect(format('````#1````', context)).toBe('````#1````')
+        expect(format('```js\n// #1\n```', context)).toBe('```js\n// #1\n```')
+        expect(format('~~~js\n// #1\n~~~', context)).toBe('~~~js\n// #1\n~~~')
+        expect(format('https://tracker/issues/#1', context)).toBe('https://tracker/issues/#1')
+      })
+
+      it('should keep parentheses and brackets in links as is', () => {
+        const format = createFormatter()
+
+        expect(format('[x](https://tracker/a_(b)/issues/#1)', context)).toBe(
+          '[x](https://tracker/a_(b)/issues/#1)'
+        )
+        expect(format('[see #1 [details]](https://tracker/1)', context)).toBe(
+          '[see #1 [details]](https://tracker/1)'
+        )
+        expect(format('https://tracker/a_(b)/issues/#1', context)).toBe(
+          'https://tracker/a_(b)/issues/#1'
+        )
+      })
+
+      it('should keep a code block with CRLF line endings as is', () => {
+        const format = createFormatter()
+
+        expect(format('```js\r\n// #1\r\n```\r\n', context)).toBe('```js\r\n// #1\r\n```\r\n')
+      })
+
+      it('should keep an indented code block as is', () => {
+        const format = createFormatter()
+
+        expect(format('- item\n  ```js\n  // #1\n  ```', context)).toBe(
+          '- item\n  ```js\n  // #1\n  ```'
+        )
+      })
+
+      it('should not close a code block by a fence with a trailing text', () => {
+        const format = createFormatter()
+
+        expect(format('```js\n// #1\n```not a closing fence\n// #2\n```', context)).toBe(
+          '```js\n// #1\n```not a closing fence\n// #2\n```'
+        )
+      })
+
+      it('should format a long text with backticks in a reasonable time', () => {
+        const format = createFormatter()
+        const text = '`'.repeat(8000) + 'a'.repeat(8000)
+        const startedAt = performance.now()
+
+        format(text, context)
+
+        expect(performance.now() - startedAt).toBeLessThan(1000)
+      })
+
+      it('should keep an unbalanced backtick effect within its line', () => {
+        const format = createFormatter()
+
+        expect(format('unbalanced ` and #1\n#2 on the next line', context)).toBe(
+          'unbalanced ` and [#1](https://tracker/#1)\n[#2](https://tracker/#2) on the next line'
+        )
+      })
+
+      it('should keep a reference as is without an url', () => {
+        const format = createFormatter({
+          formatIssueUrl: () => '',
+          formatUserUrl: () => ''
+        })
+
+        expect(format('see #1 by @dlmr', context)).toBe('see #1 by @dlmr')
+      })
+
+      it('should keep a scoped package name as is', () => {
+        const format = createFormatter()
+
+        expect(format('drop @scope/package', context)).toBe('drop @scope/package')
+      })
+
+      it('should escape issue prefixes and support regex prefixes', () => {
+        const format = createFormatter({
+          issuePrefixes: ['(gh)', /jira-/]
+        })
+
+        expect(format('see (gh)1 and jira-2', context)).toBe(
+          'see [(gh)1](https://tracker/(gh)1) and [jira-2](https://tracker/jira-2)'
+        )
+      })
+
+      it('should not format issue references without prefixes', () => {
+        const format = createFormatter({
+          issuePrefixes: []
+        })
+
+        expect(format('word 1 by @dlmr', context)).toBe('word 1 by [@dlmr](https://host/dlmr)')
+      })
+
+      it('should support a custom issue pattern', () => {
+        const format = createFormatter({
+          issuePattern: /[0-9]+/
+        })
+
+        expect(format('see #1a2b', context)).toBe('see [#1](https://tracker/#1)a2b')
+      })
+    })
+  })
+})

--- a/packages/template/src/references.ts
+++ b/packages/template/src/references.ts
@@ -1,0 +1,147 @@
+import type {
+  CommitKnownProps,
+  FinalTemplateContext
+} from './types/index.js'
+import { link } from './elements.js'
+
+/**
+ * Markdown segments to keep as is: replacing references inside them
+ * would break already formatted links, code samples and urls.
+ */
+const protectedSegments = [
+  /\[(?:[^[\]]|\[[^[\]]*])*]\((?:[^()\n]|\([^()\n]*\))*\)/, // [text](url)
+  /\[[^\]]*]\[[^\]]*]/, // [text][ref]
+  // the lookahead makes the delimiter length atomic, without it a long run
+  // of backticks makes the regex engine retry every possible delimiter length
+  /^[ \t]*(?=(?<fence>`{3,}|~{3,}))\k<fence>[\s\S]*?^[ \t]*\k<fence>[ \t]*\r?$/, // ```code block```
+  /(?=(?<code>`+))\k<code>[^\n]*?\k<code>/, // `code span`
+  /https?:\/\/(?:[^\s()]|\([^\s()]*\))+/ // https://url
+]
+const userMention = /\B@(?<user>[a-z0-9](?:-?[a-z0-9/]){0,38})/
+const defaultIssuePattern = /[a-z0-9]+/
+
+export interface IssueReference {
+  /**
+   * Issue prefix. EG: In `gh-123` `gh-` is the prefix.
+   */
+  prefix: string
+  /**
+   * Issue id. EG: In `gh-123` `123` is the id.
+   */
+  issue: string
+}
+
+export interface ReferencesFormatterOptions<Commit extends CommitKnownProps = CommitKnownProps> {
+  /**
+   * The prefixes of an issue. EG: In `gh-123` `gh-` is the prefix.
+   * Prefixes are matched in the given order, so a prefix which starts
+   * with another one should be placed first.
+   */
+  issuePrefixes?: (string | RegExp)[]
+  /**
+   * Pattern of an issue id. EG: In `gh-123` `123` is the id.
+   */
+  issuePattern?: RegExp
+  /**
+   * Builds an issue URL. Empty result leaves the reference as is.
+   */
+  formatIssueUrl(context: FinalTemplateContext<Commit>, reference: IssueReference): string
+  /**
+   * Builds a user URL. Empty result leaves the mention as is.
+   */
+  formatUserUrl(context: FinalTemplateContext<Commit>, user: string): string
+}
+
+export type ReferencesFormatter<Commit extends CommitKnownProps = CommitKnownProps> = (
+  text: string,
+  context: FinalTemplateContext<Commit>,
+  references?: string[]
+) => string
+
+/**
+ * Escapes a string to use it as a part of a regex.
+ * @param string
+ * @returns Escaped string.
+ */
+function escapeRegExp(string: string) {
+  return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+/**
+ * Builds a regex which matches issue and user references
+ * outside of the protected Markdown segments.
+ * @param issuePrefixes
+ * @param issuePattern
+ * @returns Regex with `prefix`, `issue` and `user` groups.
+ */
+function referencesRegex(
+  issuePrefixes: (string | RegExp)[] = [],
+  issuePattern: RegExp = defaultIssuePattern
+) {
+  const prefixes = issuePrefixes
+    .map(prefix => (typeof prefix === 'string' ? escapeRegExp(prefix) : prefix.source))
+    .join('|')
+  const patterns = [
+    ...protectedSegments.map(segment => segment.source),
+    // without prefixes every word would be matched as an issue reference
+    prefixes && `(?<prefix>${prefixes})(?<issue>${issuePattern.source})`,
+    userMention.source
+  ]
+
+  return new RegExp(patterns.filter(Boolean).join('|'), 'gm')
+}
+
+/**
+ * Creates a text formatter for the given options.
+ *
+ * Regexes from the options are inlined into a single multiline regex,
+ * so their flags are ignored, `^` and `$` match line boundaries,
+ * and they should not contain capturing groups, backreferences or named groups.
+ * @param options - Formatter options.
+ * @returns Formatter which replaces issue and user references in a text with links.
+ */
+export function createReferencesFormatter<Commit extends CommitKnownProps = CommitKnownProps>(
+  options: ReferencesFormatterOptions<Commit>
+): ReferencesFormatter<Commit> {
+  const regex = referencesRegex(options.issuePrefixes, options.issuePattern)
+
+  return (text, context, references) => text.replace(regex, (match, ...args) => {
+    const {
+      prefix,
+      issue,
+      user
+    } = args.at(-1) as Partial<IssueReference & { user: string }>
+
+    if (issue) {
+      const issueUrl = options.formatIssueUrl(context, {
+        prefix: prefix as string,
+        issue
+      })
+
+      if (!issueUrl) {
+        return match
+      }
+
+      references?.push(match)
+
+      return link(match, issueUrl)
+    }
+
+    if (user) {
+      // TODO: investigate why this code exists.
+      if (user.includes('/')) {
+        return match
+      }
+
+      const userUrl = options.formatUserUrl(context, user)
+
+      if (!userUrl) {
+        return match
+      }
+
+      return link(match, userUrl)
+    }
+
+    return match
+  })
+}

--- a/website/src/content/docs/presets/conventional-commits/options.mdx
+++ b/website/src/content/docs/presets/conventional-commits/options.mdx
@@ -48,7 +48,7 @@ generator.config(createPreset({ /* options */ }))
 | --- | --- | --- | --- |
 | `types` | `CommitType[]` | [default types](#types) | Commit types to recognize, the section each appears under, and its visibility. |
 | `ignoreCommits` | `RegExp` | | Skip commits whose message matches this pattern. |
-| `issuePrefixes` | `string[]` | `['#']` | Prefixes recognized as issue references and linkified in subjects. |
+| `issuePrefixes` | `string[]` | `['#']` | Prefixes recognized as issue references and linkified in subjects and breaking change notes. |
 | `scope` | `string \| string[]` | | Only include commits for the given scope(s) (or commits with no scope, unless `scopeOnly` is `true`); the scope is stripped from the output.|
 | `scopeOnly` | `boolean` | `false` | With `scope`, also exclude commits that have no scope. |
 | `preMajor` | `boolean` | `false` | Treat the project as pre-1.0 when recommending a version bump. |

--- a/website/src/content/docs/template/index.mdx
+++ b/website/src/content/docs/template/index.mdx
@@ -83,6 +83,44 @@ compareUrl(context)    // 'https://github.com/acme/app/compare/v1.0.0...v1.1.0'
 | `referenceRepositoryUrl(context, reference)` | The base URL for an issue reference (which may live in another repo). |
 | `reference(commitReference)` | The reference text, e.g. `#42`. |
 
+## References formatter
+
+`createReferencesFormatter` builds a function which turns issue references and user mentions inside a free-form text — a commit subject or a breaking change note — into Markdown links. Already formatted Markdown is left untouched: inline and reference links, bare URLs, fenced code blocks and single-line code spans.
+
+```js
+import { createReferencesFormatter } from '@conventional-changelog/template'
+
+const formatReferences = createReferencesFormatter({
+  issuePrefixes: ['#'],
+  formatIssueUrl: (context, reference) => `https://tracker/${reference.prefix}${reference.issue}`,
+  formatUserUrl: (context, user) => `https://host/${user}`
+})
+
+formatReferences('see #1 by @dlmr', context)
+// 'see [#1](https://tracker/#1) by [@dlmr](https://host/dlmr)'
+
+formatReferences('`#1`', context)
+// '`#1`'
+```
+
+| Option | Description |
+| --- | --- |
+| `issuePrefixes` | Issue prefixes, strings or regexes. Strings are escaped. Prefixes are matched in the given order, so `['jira-', 'j']` — not the other way round. Without prefixes issue references are not formatted. |
+| `issuePattern` | Issue id pattern, `/[a-z0-9]+/` by default. |
+| `formatIssueUrl(context, reference)` | Issue URL. An empty result leaves the reference as is. |
+| `formatUserUrl(context, user)` | User URL. An empty result leaves the mention as is. |
+
+Regexes from the options are inlined into a single multiline regex, so their flags are ignored, `^` and `$` match line boundaries, and they should not contain capturing groups, backreferences or named groups.
+
+The formatter takes an optional third argument — an array to collect the formatted issue references into, which presets use to drop references already shown in the subject:
+
+```js
+const issues = []
+
+formatReferences('fix #1', context, issues)
+// issues: ['#1']
+```
+
 ## Default template and partials
 
 `template`, `headerPartial`, `preamblePartial`, `commitPartial`, and `footerPartial` are the render functions the [writer](/changelog-writer/api/#options) uses by default. Import them to reuse or wrap, or compose your own partial from the helpers:


### PR DESCRIPTION
Issue references inside `BREAKING CHANGE` notes were never linkified: both
presets formatted commit subjects only. A custom `issuePrefixes` /
`formatIssueUrl` — a Jira tracker, for example — worked everywhere except the
breaking change section.

### What changed

- `@conventional-changelog/template` exports `createReferencesFormatter`, a
  single implementation of reference and mention linkification for presets.
- Both presets use it for note text and subjects instead of their own inline
  regexes.
- Already formatted Markdown is left alone: inline and reference links, bare
  urls, fenced code blocks (backticks and tildes, indented ones too) and
  single-line code spans.

### Output changes

- Notes with the default `#` prefix are linked now, so regenerating a changelog
  produces a diff even without a custom config.
- References and mentions inside code spans, links and urls in subjects are no
  longer replaced: a subject like ``fix: support `#region` `` used to get a
  link inside the code span.
- The angular preset deduplicates references by prefix and id instead of the
  bare id, so a `GH-7` reference is no longer dropped when the subject mentions
  `#7`.

Fixes #631.
