### PR TITLE
feat(conventional-changelog-angular,conventional-changelog-conventionalcommits,template): group notes by their keyword

### DIFF
--- a/packages/conventional-changelog-angular/src/whatBump.js
+++ b/packages/conventional-changelog-angular/src/whatBump.js
@@ -1,11 +1,17 @@
+import { isBreakingNote } from '@conventional-changelog/template'
+
 export function whatBump(commits) {
   let level = 2
   let breakings = 0
   let features = 0
 
   commits.forEach((commit) => {
-    if (commit.notes.length > 0) {
-      breakings += commit.notes.length
+    // only breaking change notes affect the version,
+    // any other note keyword is just a changelog section
+    const breakingNotes = commit.notes.filter(isBreakingNote)
+
+    if (breakingNotes.length > 0) {
+      breakings += breakingNotes.length
       level = 0
     } else if (commit.type === 'feat') {
       features += 1

--- a/packages/conventional-changelog-angular/src/writer.js
+++ b/packages/conventional-changelog-angular/src/writer.js
@@ -1,5 +1,6 @@
 import {
   createReferencesFormatter,
+  noteTitle,
   referenceRepositoryUrl,
   url
 } from '@conventional-changelog/template'
@@ -47,7 +48,7 @@ export function createWriterOpts() {
 
         return {
           ...note,
-          title: 'BREAKING CHANGES',
+          title: noteTitle(note.title),
           text: formatReferences(note.text, context)
         }
       })

--- a/packages/conventional-changelog-angular/test/index.spec.js
+++ b/packages/conventional-changelog-angular/test/index.spec.js
@@ -79,6 +79,9 @@ setups([
       'Already formatted: [#301](https://tracker.example/301).',
       'Code span: `#302`.'
     ])
+  },
+  () => {
+    testTools.gitCommit(['fix(api): patch a hole', 'SECURITY: fixed an XSS in the renderer'])
   }
 ])
 
@@ -358,6 +361,23 @@ describe('conventional-changelog-angular', () => {
     expect(chunks[0]).toContain('ask [@dlmr](https://github.com/dlmr) for details.')
   })
 
+  it('should group notes by their keyword', async () => {
+    preparing(12)
+
+    const log = new ConventionalChangelog(testTools.cwd)
+      .readPackage()
+      .config(preset())
+      .commits({}, {
+        noteKeywords: ['BREAKING CHANGE', 'SECURITY']
+      })
+      .write()
+    const chunks = await toArray(log)
+
+    expect(chunks[0]).toContain('### SECURITY')
+    expect(chunks[0]).toContain('### BREAKING CHANGES')
+    expect(chunks[0]).toContain('**api:** fixed an XSS in the renderer')
+  })
+
   it('should keep already formatted references in breaking change notes as is', async () => {
     preparing(11)
 
@@ -371,5 +391,46 @@ describe('conventional-changelog-angular', () => {
     expect(chunks[0]).toContain('Code span: `#302`.')
     expect(chunks[0]).not.toContain('https://github.com/conventional-changelog/conventional-changelog/issues/301')
     expect(chunks[0]).not.toContain('https://github.com/conventional-changelog/conventional-changelog/issues/302')
+  })
+
+  describe('whatBump', () => {
+    it('should bump major version for breaking change notes', () => {
+      const { whatBump } = preset()
+      const result = whatBump([
+        {
+          type: 'fix',
+          notes: [{
+            title: 'BREAKING CHANGE',
+            text: 'the config format has changed'
+          }]
+        }
+      ])
+
+      expect(result.level).toBe(0)
+      expect(result.reason).toBe('There is 1 BREAKING CHANGE and 0 features')
+    })
+
+    it('should not bump major version for other note keywords', () => {
+      const { whatBump } = preset()
+      const result = whatBump([
+        {
+          type: 'fix',
+          notes: [{
+            title: 'SECURITY',
+            text: 'fixed an XSS in the renderer'
+          }]
+        },
+        {
+          type: 'feat',
+          notes: [{
+            title: 'Security',
+            text: 'fixed a prototype pollution'
+          }]
+        }
+      ])
+
+      expect(result.level).toBe(1)
+      expect(result.reason).toBe('There are 0 BREAKING CHANGES and 1 features')
+    })
   })
 })

--- a/packages/conventional-changelog-conventionalcommits/src/constants.js
+++ b/packages/conventional-changelog-conventionalcommits/src/constants.js
@@ -1,3 +1,5 @@
+export const BREAKING_HEADER_PATTERN = /^(\w*)(?:\((.*)\))?!: (.*)$/
+
 export const DEFAULT_COMMIT_TYPES = Object.freeze([
   {
     type: 'feat',

--- a/packages/conventional-changelog-conventionalcommits/src/format.js
+++ b/packages/conventional-changelog-conventionalcommits/src/format.js
@@ -1,9 +1,19 @@
 import {
+  BREAKING_CHANGES_TITLE,
   compareUrl,
+  noteTitle,
   referenceRepositoryUrl,
   repositoryUrl,
   url
 } from '@conventional-changelog/template'
+
+export function formatNoteTitle(context, title) {
+  return noteTitle(title)
+}
+
+export function formatNoteIcon(context, title) {
+  return title === BREAKING_CHANGES_TITLE ? '⚠' : ''
+}
 
 export function formatIssueUrl(context, reference) {
   return url(

--- a/packages/conventional-changelog-conventionalcommits/src/index.d.ts
+++ b/packages/conventional-changelog-conventionalcommits/src/index.d.ts
@@ -21,6 +21,8 @@ export interface PresetConfig {
   formatCommitUrl?: (context: Context, commit: Commit) => string
   formatCompareUrl?: (context: Context) => string
   formatUserUrl?: (context: Context, user: string) => string
+  formatNoteTitle?: (context: Context, title: string) => string
+  formatNoteIcon?: (context: Context, title: string) => string
 }
 
 export default function createPreset(config?: PresetConfig): {}

--- a/packages/conventional-changelog-conventionalcommits/src/parser.js
+++ b/packages/conventional-changelog-conventionalcommits/src/parser.js
@@ -1,13 +1,16 @@
+import { BREAKING_CHANGE_KEYWORDS } from '@conventional-changelog/template'
+import { BREAKING_HEADER_PATTERN } from './constants.js'
+
 export function createParserOpts(config) {
   return {
     headerPattern: /^(\w*)(?:\((.*)\))?!?: (.*)$/,
-    breakingHeaderPattern: /^(\w*)(?:\((.*)\))?!: (.*)$/,
+    breakingHeaderPattern: BREAKING_HEADER_PATTERN,
     headerCorrespondence: [
       'type',
       'scope',
       'subject'
     ],
-    noteKeywords: ['BREAKING CHANGE', 'BREAKING-CHANGE'],
+    noteKeywords: BREAKING_CHANGE_KEYWORDS,
     revertPattern: /^(?:Revert|revert:)\s"?([\s\S]+?)"?\s*This reverts commit (\w*)\./i,
     revertCorrespondence: ['header', 'hash'],
     issuePrefixes: config?.issuePrefixes || ['#']

--- a/packages/conventional-changelog-conventionalcommits/src/templates.js
+++ b/packages/conventional-changelog-conventionalcommits/src/templates.js
@@ -112,7 +112,7 @@ export function template(context) {
     each(
       noteGroups,
       group => segments(
-        heading(3, words('⚠', group.title)),
+        heading(3, words(this.formatNoteIcon(context, group.title), group.title)),
         list(
           group.notes,
           note => words(

--- a/packages/conventional-changelog-conventionalcommits/src/utils.js
+++ b/packages/conventional-changelog-conventionalcommits/src/utils.js
@@ -1,3 +1,30 @@
+import {
+  BREAKING_CHANGE_KEYWORDS,
+  isBreakingNote
+} from '@conventional-changelog/template'
+import { BREAKING_HEADER_PATTERN } from './constants.js'
+
+/**
+ * Get commit notes with the breaking change declared by `!` in the header.
+ * The parser adds that note only if the commit has no notes at all,
+ * so a footer of any other keyword hides the breaking change.
+ * @param commit
+ * @returns Commit notes.
+ */
+export function getNotes(commit) {
+  if (commit.notes.some(isBreakingNote) || !BREAKING_HEADER_PATTERN.test(commit.header || '')) {
+    return commit.notes
+  }
+
+  return [
+    {
+      title: BREAKING_CHANGE_KEYWORDS[0],
+      text: commit.subject || ''
+    },
+    ...commit.notes
+  ]
+}
+
 function hasIntersection(a, b) {
   if (!a || !b) {
     return false

--- a/packages/conventional-changelog-conventionalcommits/src/whatBump.js
+++ b/packages/conventional-changelog-conventionalcommits/src/whatBump.js
@@ -1,6 +1,8 @@
+import { isBreakingNote } from '@conventional-changelog/template'
 import { DEFAULT_COMMIT_TYPES } from './constants.js'
 import {
   findTypeEntry,
+  getNotes,
   isTypeEffect,
   matchScope
 } from './utils.js'
@@ -19,9 +21,12 @@ export function createWhatBump(config = {}) {
       }
 
       const entry = findTypeEntry(types, commit)
+      // only breaking change notes affect the version,
+      // any other note keyword is just a changelog section
+      const breakingNotes = getNotes(commit).filter(isBreakingNote)
 
-      if (commit.notes.length > 0) {
-        breakings += commit.notes.length
+      if (breakingNotes.length > 0) {
+        breakings += breakingNotes.length
         level = 0
       } else
         if (entry && isTypeEffect(entry, 'bump')) {

--- a/packages/conventional-changelog-conventionalcommits/src/writer.js
+++ b/packages/conventional-changelog-conventionalcommits/src/writer.js
@@ -2,6 +2,7 @@ import { createReferencesFormatter } from '@conventional-changelog/template'
 import { DEFAULT_COMMIT_TYPES } from './constants.js'
 import {
   findTypeEntry,
+  getNotes,
   isTypeEffect,
   matchScope
 } from './utils.js'
@@ -33,7 +34,7 @@ export function createWriterOpts(config) {
   const formatReferences = createReferencesFormatter(finalConfig)
 
   return {
-    template,
+    template: template.bind(finalConfig),
     headerPartial: headerPartial.bind(finalConfig),
     preamblePartial: preamblePartial.bind(finalConfig),
     commitPartial: commitPartial.bind(finalConfig),
@@ -50,18 +51,18 @@ export function createWriterOpts(config) {
         discard = false
       }
 
-      const notes = commit.notes.map((note) => {
+      const notes = getNotes(commit).map((note) => {
         discard = false
 
         return {
           ...note,
-          title: 'BREAKING CHANGES',
+          title: finalConfig.formatNoteTitle(context, note.title),
           text: formatReferences(note.text, context)
         }
       })
 
       if (
-        // breaking changes attached to any type are still displayed.
+        // notes attached to any type are still displayed.
         discard && (entry === undefined || isTypeEffect(entry, 'hidden'))
         || !matchScope(finalConfig, commit)
       ) {

--- a/packages/conventional-changelog-conventionalcommits/test/index.spec.js
+++ b/packages/conventional-changelog-conventionalcommits/test/index.spec.js
@@ -113,6 +113,11 @@ setups([
       '```'
     ])
     testTools.gitCommit(['feat(api): keep `EXAMPLE-200` as is'])
+  },
+  () => {
+    testTools.gitCommit(['fix(api): patch a hole', 'SECURITY: fixed an XSS in the renderer'])
+    testTools.gitCommit(['fix(api): patch another hole', 'Security: fixed a prototype pollution'])
+    testTools.gitCommit(['feat(api)!: remove the legacy client', 'SECURITY: dropped the vulnerable dependency'])
   }
 ])
 
@@ -388,6 +393,64 @@ describe('conventional-changelog-conventionalcommits', () => {
 
     expect(chunks[0]).toContain('keep `EXAMPLE-200` as is')
     expect(chunks[0]).not.toContain('https://example.com/browse/EXAMPLE-200')
+  })
+
+  it('should group notes by their keyword', async () => {
+    preparing(15)
+
+    const log = new ConventionalChangelog(testTools.cwd)
+      .readPackage()
+      .config(preset())
+      .commits({}, {
+        noteKeywords: ['BREAKING CHANGE', 'BREAKING-CHANGE', 'SECURITY']
+      })
+      .write()
+    const chunks = await toArray(log)
+
+    expect(chunks[0]).toContain('### SECURITY')
+    expect(chunks[0]).toContain('### ⚠ BREAKING CHANGES')
+    // both `SECURITY` and `Security` keywords are grouped together
+    expect(chunks[0]).toContain('**api:** fixed an XSS in the renderer')
+    expect(chunks[0]).toContain('**api:** fixed a prototype pollution')
+    expect(chunks[0]).not.toContain('### Security')
+  })
+
+  it('should keep the breaking change declared by `!` next to notes of other keywords', async () => {
+    preparing(15)
+
+    const log = new ConventionalChangelog(testTools.cwd)
+      .readPackage()
+      .config(preset())
+      .commits({}, {
+        noteKeywords: ['BREAKING CHANGE', 'BREAKING-CHANGE', 'SECURITY']
+      })
+      .write()
+    const chunks = await toArray(log)
+
+    // the breaking change is a note of its own, without a commit link
+    expect(chunks[0]).toMatch(/\* \*\*api:\*\* remove the legacy client\r?\n/)
+    expect(chunks[0]).toContain('**api:** dropped the vulnerable dependency')
+  })
+
+  it('should support custom note titles and icons', async () => {
+    preparing(15)
+
+    const log = new ConventionalChangelog(testTools.cwd)
+      .readPackage()
+      .config(preset({
+        formatNoteTitle: (_context, title) => (title.toUpperCase() === 'SECURITY'
+          ? 'Security fixes'
+          : 'BREAKING CHANGES'),
+        formatNoteIcon: (_context, title) => (title === 'Security fixes' ? '🔒' : '⚠')
+      }))
+      .commits({}, {
+        noteKeywords: ['BREAKING CHANGE', 'BREAKING-CHANGE', 'SECURITY']
+      })
+      .write()
+    const chunks = await toArray(log)
+
+    expect(chunks[0]).toContain('### 🔒 Security fixes')
+    expect(chunks[0]).toContain('### ⚠ BREAKING CHANGES')
   })
 
   it('should replace #[a-z0-9]+ with issue URL by default', async () => {
@@ -667,6 +730,65 @@ describe('conventional-changelog-conventionalcommits', () => {
     expect(chunks[0]).toContain('effect replaces hidden.')
     expect(chunks[0]).toContain(', closes [#1476](https://github.com/conventional-changelog/conventional-changelog/issues/1476)')
     expect(chunks[0]).not.toContain('Fixes #1476')
+  })
+
+  describe('whatBump', () => {
+    it('should bump major version for breaking change notes', () => {
+      const { whatBump } = preset()
+      const result = whatBump([
+        {
+          type: 'fix',
+          notes: [{
+            title: 'BREAKING CHANGE',
+            text: 'the config format has changed'
+          }]
+        }
+      ])
+
+      expect(result.level).toBe(0)
+      expect(result.reason).toBe('There is 1 BREAKING CHANGE and 0 features')
+    })
+
+    it('should not bump major version for other note keywords', () => {
+      const { whatBump } = preset()
+      const result = whatBump([
+        {
+          type: 'fix',
+          notes: [{
+            title: 'SECURITY',
+            text: 'fixed an XSS in the renderer'
+          }]
+        },
+        {
+          type: 'feat',
+          notes: [{
+            title: 'Security',
+            text: 'fixed a prototype pollution'
+          }]
+        }
+      ])
+
+      expect(result.level).toBe(1)
+      expect(result.reason).toBe('There are 0 BREAKING CHANGES and 1 features')
+    })
+
+    it('should bump major version for `!` next to notes of other keywords', () => {
+      const { whatBump } = preset()
+      const result = whatBump([
+        {
+          type: 'feat',
+          header: 'feat(api)!: remove the legacy client',
+          subject: 'remove the legacy client',
+          notes: [{
+            title: 'SECURITY',
+            text: 'dropped the vulnerable dependency'
+          }]
+        }
+      ])
+
+      expect(result.level).toBe(0)
+      expect(result.reason).toBe('There is 1 BREAKING CHANGE and 0 features')
+    })
   })
 
   describe('type effects', () => {

--- a/packages/template/src/templates.spec.ts
+++ b/packages/template/src/templates.spec.ts
@@ -7,6 +7,7 @@ import {
 import {
   template,
   compareUrl,
+  noteTitle,
   headerPartial,
   preamblePartial,
   commitPartial,
@@ -34,6 +35,19 @@ describe('@conventional-changelog/template', () => {
   })
 
   describe('templates', () => {
+    describe('noteTitle', () => {
+      it('should merge breaking change keywords into a single title', () => {
+        expect(noteTitle('BREAKING CHANGE')).toBe('BREAKING CHANGES')
+        expect(noteTitle('BREAKING-CHANGE')).toBe('BREAKING CHANGES')
+        expect(noteTitle('breaking change')).toBe('BREAKING CHANGES')
+      })
+
+      it('should uppercase any other keyword', () => {
+        expect(noteTitle('Security')).toBe('SECURITY')
+        expect(noteTitle('SECURITY')).toBe('SECURITY')
+      })
+    })
+
     describe('compareUrl', () => {
       it('should encode tag names as URL path segments', () => {
         const log = compareUrl({

--- a/packages/template/src/templates.ts
+++ b/packages/template/src/templates.ts
@@ -1,6 +1,7 @@
 import type {
   FinalTemplateContext,
   CommitKnownProps,
+  CommitNote,
   CommitReference,
   TransformedCommit
 } from './types/index.js'
@@ -69,6 +70,33 @@ export function compareUrl<Commit extends CommitKnownProps = CommitKnownProps>(
     'compare',
     `${previousTag}...${currentTag}`
   )
+}
+
+export const BREAKING_CHANGE_KEYWORDS = ['BREAKING CHANGE', 'BREAKING-CHANGE']
+export const BREAKING_CHANGES_TITLE = 'BREAKING CHANGES'
+
+/**
+ * Renders a note group title.
+ * Breaking change keywords are merged into a single title,
+ * every other keyword is uppercased to group its spellings together.
+ * @param title - Note title as it was written in a commit.
+ * @returns Note group title.
+ */
+export function noteTitle(title: string) {
+  const upperCaseTitle = title.toUpperCase()
+
+  return BREAKING_CHANGE_KEYWORDS.includes(upperCaseTitle)
+    ? BREAKING_CHANGES_TITLE
+    : upperCaseTitle
+}
+
+/**
+ * Checks if a note is a breaking change note.
+ * @param note - Commit note.
+ * @returns Is it a breaking change note.
+ */
+export function isBreakingNote(note: CommitNote) {
+  return noteTitle(note.title) === BREAKING_CHANGES_TITLE
 }
 
 /**

--- a/website/src/content/docs/presets/conventional-commits/options.mdx
+++ b/website/src/content/docs/presets/conventional-commits/options.mdx
@@ -56,6 +56,8 @@ generator.config(createPreset({ /* options */ }))
 | `formatCommitUrl` | `(context, commit) => string` | git-host style | Build the URL for a commit hash. |
 | `formatCompareUrl` | `(context) => string` | git-host style | Build the version comparison URL in the release heading. |
 | `formatUserUrl` | `(context, user) => string` | git-host style | Build the URL for an `@user` mention. |
+| `formatNoteTitle` | `(context, title) => string` | see [note groups](#note-groups) | Build the heading for a note group. |
+| `formatNoteIcon` | `(context, title) => string` | `⚠` for breaking changes | Build the icon shown before a note group heading. |
 
 ## `types`
 
@@ -127,6 +129,45 @@ createPreset({ scope: ['api', 'core'] })
 ```
 
 A commit may declare multiple comma-separated scopes (`feat(api,core): …`); it matches if any of them is in `scope`.
+
+## Note groups
+
+Footers listed in the parser's [`noteKeywords`](/commits-parser/api/) become notes, and notes are grouped by their keyword above the commit sections. Out of the box the preset recognizes `BREAKING CHANGE` and `BREAKING-CHANGE`, but you can add your own:
+
+```js
+new ConventionalChangelog()
+  .config(createPreset())
+  .commits({}, { noteKeywords: ['BREAKING CHANGE', 'BREAKING-CHANGE', 'SECURITY'] })
+```
+
+```md
+### ⚠ BREAKING CHANGES
+
+* the config format has changed
+
+### SECURITY
+
+* fixed an XSS in the renderer
+```
+
+`BREAKING CHANGE` and `BREAKING-CHANGE` are merged into one group, and any other keyword becomes a group of its own, uppercased so that `SECURITY` and `Security` end up together. Groups are sorted by title.
+
+Both parts of the heading are configurable — the title and the icon before it:
+
+```js
+import { noteTitle } from '@conventional-changelog/template'
+
+createPreset({
+  formatNoteTitle: (context, title) => (title.toUpperCase() === 'SECURITY'
+    ? 'Security fixes'
+    : noteTitle(title)),
+  formatNoteIcon: (context, title) => (title === 'Security fixes' ? '🔒' : '⚠')
+})
+```
+
+`formatNoteTitle` receives the keyword as it was written in the commit and its result is what notes are grouped by, so returning the same title for two keywords merges them. `formatNoteIcon` receives that result. The default `formatNoteTitle` is exported as `noteTitle` from [`@conventional-changelog/template`](/template/).
+
+Only breaking changes affect the [recommended version bump](/version-bump/) — a `SECURITY` footer gets its own changelog section, but it does not make the release a major one.
 
 ## `preMajor`
 

--- a/website/src/content/docs/template/index.mdx
+++ b/website/src/content/docs/template/index.mdx
@@ -82,6 +82,7 @@ compareUrl(context)    // 'https://github.com/acme/app/compare/v1.0.0...v1.1.0'
 | `compareUrl(context)` | The `previousTag...currentTag` comparison URL. |
 | `referenceRepositoryUrl(context, reference)` | The base URL for an issue reference (which may live in another repo). |
 | `reference(commitReference)` | The reference text, e.g. `#42`. |
+| `noteTitle(title)` | The note group title: breaking change keywords merged into `BREAKING CHANGES`, any other keyword uppercased. |
 
 ## References formatter
 


### PR DESCRIPTION
Both presets replaced the title of every note with `BREAKING CHANGES`. Adding a keyword to the parser's `noteKeywords` — which the Conventional Commits spec explicitly allows — therefore produced a changelog where unrelated footers were listed as breaking changes, and a `SECURITY:` footer silently made the release a major one.

### What changed

- `@conventional-changelog/template` exports `noteTitle` and `isBreakingNote`: `BREAKING CHANGE` and `BREAKING-CHANGE` are merged into one group, any other keyword is uppercased so its spellings group together.
- Both presets use it for note titles, and their `whatBump` counts only breaking notes, so a `feat` carrying a `SECURITY` note is a minor release again.
- The conventionalcommits preset gets two options, `formatNoteTitle` and `formatNoteIcon`. The icon is kept out of the title so that groups still sort by name. This is why the preset's `template` export is now bound to the config, like its other partials already were.
- A `feat!:` commit that also carries a footer of another keyword keeps its breaking change: the parser adds the note for the `!` shorthand only when the commit has no notes at all, so the preset restores it.

```md
### ⚠ BREAKING CHANGES

* the config format has changed

### SECURITY

* fixed an XSS in the renderer
```

### Compatibility

Without custom `noteKeywords` nothing changes: the only notes are breaking ones, they land in the same group under the same heading, and the recommended bump is the same. The difference appears only for configurations that were affected by the bug.

Fixes #815.
