### PR TITLE
fix(conventional-changelog,conventional-changelog-writer,conventional-changelog-conventionalcommits,template): use current host url paths

### DIFF
--- a/packages/conventional-changelog-angular/src/writer.js
+++ b/packages/conventional-changelog-angular/src/writer.js
@@ -21,7 +21,7 @@ const formatReferences = createReferencesFormatter({
 
     // without a repository url there is nothing to link to
     return repositoryUrl
-      ? url(repositoryUrl, 'issues', reference.issue)
+      ? url(repositoryUrl, context.issue || 'issues', reference.issue)
       : ''
   },
   formatUserUrl: (context, user) => (context.host

--- a/packages/conventional-changelog-angular/test/index.spec.js
+++ b/packages/conventional-changelog-angular/test/index.spec.js
@@ -171,6 +171,24 @@ describe('conventional-changelog-angular', () => {
     expect(chunks.length).toBe(1)
   })
 
+  it('should use the host issue path for references in the subject', async () => {
+    preparing(2)
+
+    const log = new ConventionalChangelog(testTools.cwd)
+      .readPackage()
+      .context({
+        host: 'https://gitlab.com',
+        owner: 'b',
+        repository: 'a',
+        issue: '-/issues'
+      })
+      .config(preset())
+      .write()
+    const chunks = await toArray(log)
+
+    expect(chunks[0]).toContain('[#133](https://gitlab.com/b/a/-/issues/133)')
+  })
+
   it('should remove the issues that already appear in the subject', async () => {
     preparing(3)
 

--- a/packages/conventional-changelog-conventionalcommits/src/format.js
+++ b/packages/conventional-changelog-conventionalcommits/src/format.js
@@ -18,7 +18,7 @@ export function formatNoteIcon(context, title) {
 export function formatIssueUrl(context, reference) {
   return url(
     referenceRepositoryUrl(context, reference),
-    'issues',
+    context.issue || 'issues',
     reference.issue
   )
 }

--- a/packages/conventional-changelog-writer/src/context.ts
+++ b/packages/conventional-changelog-writer/src/context.ts
@@ -120,6 +120,7 @@ export function getFinalContext<Commit extends CommitKnownProps = CommitKnownPro
   const finalContext: FinalTemplateContext<Commit> = {
     commit: 'commits',
     issue: 'issues',
+    compare: 'compare',
     date: options.formatDate(new Date()),
     headerPartial: options.headerPartial,
     preamblePartial: options.preamblePartial,

--- a/packages/conventional-changelog/src/ConventionalChangelog.spec.ts
+++ b/packages/conventional-changelog/src/ConventionalChangelog.spec.ts
@@ -625,7 +625,7 @@ describe('conventional-changelog', () => {
       expect(chunks.length).toBe(1)
 
       expect(chunks[0]).toContain('](bitbucket/b/a/commits/')
-      expect(chunks[0]).toContain('closes [#1](bitbucket/b/a/issue/1)')
+      expect(chunks[0]).toContain('closes [#1](bitbucket/b/a/issues/1)')
     })
 
     it('should read gitlab\'s host configs', async () => {
@@ -643,8 +643,29 @@ describe('conventional-changelog', () => {
 
       expect(chunks.length).toBe(1)
 
-      expect(chunks[0]).toContain('](gitlab/b/a/commit/')
-      expect(chunks[0]).toContain('closes [#1](gitlab/b/a/issues/1)')
+      expect(chunks[0]).toContain('](gitlab/b/a/-/commit/')
+      expect(chunks[0]).toContain('closes [#1](gitlab/b/a/-/issues/1)')
+    })
+
+    it('should use gitlab\'s comparison url', async () => {
+      preparing(5)
+
+      const log = new ConventionalChangelog(testTools.cwd)
+        .readPackage()
+        .loadPreset('angular')
+        .context({
+          host: 'gitlab',
+          owner: 'b',
+          repository: 'a',
+          version: '2.0.0',
+          linkCompare: true,
+          previousTag: 'v1.0.0',
+          currentTag: 'v2.0.0'
+        })
+        .write()
+      const chunks = await toArray(log)
+
+      expect(chunks[0]).toContain('(gitlab/b/a/-/compare/v1.0.0...v2.0.0)')
     })
 
     it('should transform the commit', async () => {

--- a/packages/conventional-changelog/src/ConventionalChangelog.ts
+++ b/packages/conventional-changelog/src/ConventionalChangelog.ts
@@ -136,6 +136,7 @@ export class ConventionalChangelog {
     if (hostOptions) {
       finalContext.issue ||= hostOptions.issue
       finalContext.commit ||= hostOptions.commit
+      finalContext.compare ||= hostOptions.compare
     }
 
     if (isUnreleasedVersion(semverTags, finalContext.version) && options.outputUnreleased) {

--- a/packages/conventional-changelog/src/hosts/bitbucket.ts
+++ b/packages/conventional-changelog/src/hosts/bitbucket.ts
@@ -1,6 +1,7 @@
 export const bitbucket = {
-  issue: 'issue',
+  issue: 'issues',
   commit: 'commits',
+  compare: 'compare',
   referenceActions: [
     'close',
     'closes',

--- a/packages/conventional-changelog/src/hosts/github.ts
+++ b/packages/conventional-changelog/src/hosts/github.ts
@@ -1,6 +1,7 @@
 export const github = {
   issue: 'issues',
   commit: 'commit',
+  compare: 'compare',
   referenceActions: [
     'close',
     'closes',

--- a/packages/conventional-changelog/src/hosts/gitlab.ts
+++ b/packages/conventional-changelog/src/hosts/gitlab.ts
@@ -1,6 +1,8 @@
 export const gitlab = {
-  issue: 'issues',
-  commit: 'commit',
+  // GitLab removed the legacy urls without the `-/` separator in 16.0
+  issue: '-/issues',
+  commit: '-/commit',
+  compare: '-/compare',
   referenceActions: [
     'close',
     'closes',

--- a/packages/conventional-changelog/src/types.ts
+++ b/packages/conventional-changelog/src/types.ts
@@ -34,6 +34,7 @@ export type CommitTransformFunction = (commit: Commit, params: Params) => Partia
 export interface HostOptions {
   issue: string
   commit: string
+  compare: string
   referenceActions: string[]
   issuePrefixes: string[]
 }

--- a/packages/template/src/templates.ts
+++ b/packages/template/src/templates.ts
@@ -67,7 +67,7 @@ export function compareUrl<Commit extends CommitKnownProps = CommitKnownProps>(
 
   return url(
     repositoryUrl(context),
-    'compare',
+    context.compare || 'compare',
     `${previousTag}...${currentTag}`
   )
 }

--- a/packages/template/src/types/context.ts
+++ b/packages/template/src/types/context.ts
@@ -52,6 +52,10 @@ export interface TemplateContext<Commit extends CommitKnownProps = CommitKnownPr
    */
   issue?: string
   /**
+   * Release comparison base url path.
+   */
+  compare?: string
+  /**
    * Repository name.
    * Eg: `'conventional-changelog-writer'`
    */


### PR DESCRIPTION
GitLab removed the urls without the `-/` separator in 16.0, so every link generated for GitLab points at a legacy path. The redirects are still in place today, but they are meant to go away — and these links are baked into changelog files forever.

### What changed

- Host configs carry a `compare` path next to `issue` and `commit`; GitLab uses `-/issues`, `-/commit` and `-/compare`. The comparison path used to be hardcoded inside `compareUrl`.
- Both presets read the issue path from the context instead of hardcoding `issues`. The conventionalcommits preset ignored the host config entirely, which is why GitLab issue links stayed legacy and why the two presets disagreed on Bitbucket. The angular preset had the same problem for references inside a subject.
- Bitbucket's config used `issue`, a legacy singular path; current Bitbucket issue urls are plural.

### Output changes

GitLab gets `/-/commit/…`, `/-/issues/…` and `/-/compare/…` in place of the legacy paths. Bitbucket issue links become `/issues/N` instead of `/issue/N` in the angular preset. GitHub output is unchanged.

Bitbucket comparison links stay wrong: that route is `branches/compare/<to>%0D<from>`, which a path segment cannot express. Fixing it needs host configs that carry formatter functions rather than paths — a separate change.

Fixes #986.
