### PR TITLE
fix(git-client): end the options list before caller provided values

### DIFF
--- a/packages/git-client/src/GitClient.spec.ts
+++ b/packages/git-client/src/GitClient.spec.ts
@@ -190,5 +190,41 @@ describe('git-client', () => {
         expect(await client.getLastTag()).toBe('v18.0.0')
       })
     })
+
+    describe('option-like arguments', () => {
+      const secretFile = 'secret.txt'
+      const secret = 'SUPER_SECRET_VALUE'
+      const pathspecFromFile = `--pathspec-from-file=${secretFile}`
+
+      beforeAll(() => {
+        testTools.writeFileSync(secretFile, secret)
+      })
+
+      it('should not let `checkout` read a file', async () => {
+        await expect(client.checkout(pathspecFromFile)).rejects.toThrow(
+          expect.objectContaining({
+            message: expect.not.stringContaining(secret)
+          })
+        )
+      })
+
+      it('should not let commits range become an option', async () => {
+        const commitsStream = client.getRawCommits({
+          from: '--max-count=1',
+          to: ''
+        })
+
+        await expect(toArray(commitsStream)).rejects.toThrow()
+      })
+
+      it('should not let tags range become an option', async () => {
+        const tagsStream = client.getTags({
+          from: '--max-count=1',
+          to: ''
+        })
+
+        await expect(toArray(tagsStream)).rejects.toThrow()
+      })
+    })
   })
 })

--- a/packages/git-client/src/GitClient.ts
+++ b/packages/git-client/src/GitClient.ts
@@ -22,6 +22,9 @@ import {
 } from './utils.js'
 
 const SCISSOR = '------------------------ >8 ------------------------'
+// Marks the end of the options, so a value which starts with a dash
+// is never parsed as a git option. Unlike `--` it works for revisions too.
+const END_OF_OPTIONS = '--end-of-options'
 
 /**
  * Wrapper around Git CLI.
@@ -112,6 +115,7 @@ export class GitClient {
       merges && '--merges',
       merges === false && '--no-merges',
       firstParent && '--first-parent',
+      END_OF_OPTIONS,
       [from, to].filter(Boolean).join('..'),
       ...path ? ['--', ...toArray(path)] : []
     )
@@ -146,6 +150,7 @@ export class GitClient {
       '--date-order',
       all && '--all',
       since && `--since=${since instanceof Date ? since.toISOString() : since}`,
+      END_OF_OPTIONS,
       [from, to].filter(Boolean).join('..'),
       ...path ? ['--', ...toArray(path)] : []
     )
@@ -329,6 +334,7 @@ export class GitClient {
     let git = this.exec(
       'rev-parse',
       '--verify',
+      END_OF_OPTIONS,
       rev
     )
 
@@ -399,6 +405,7 @@ export class GitClient {
 
   /**
    * Create a new branch.
+   * Name is a value of the `-b` option, so it is never parsed as an option itself.
    * @param branch - Branch name.
    */
   async createBranch(branch: string) {
@@ -429,6 +436,7 @@ export class GitClient {
   async checkout(branch: string) {
     await this.exec(
       'checkout',
+      END_OF_OPTIONS,
       branch
     )
   }


### PR DESCRIPTION
`GitClient` passed caller provided values to git as bare positional arguments, so a value starting with a dash was parsed as a git option.

`checkout('--pathspec-from-file=/tmp/secret')` made git read that file and print every non-matching line in its error output, and `exec` turns stderr into the message of the thrown error, so the contents come back to the caller. A commits or tags range could reach `git log --output=<file>` and write the log to an arbitrary path.

### What changed

`--end-of-options` now precedes the caller provided value in `checkout`, `verify`, `getRawCommits` and `getTags`. Not `--`: in `git checkout` that one means pathspecs follow, so `git checkout -- main` restores a file named `main` instead of switching branches. That is what 993c1fdd fixed by removing it, and restoring it would break branch switching again.

`createBranch` needs nothing — the name there is the value of `-b` and is never parsed as an option, which is why the same commit was right to drop `--` from it. The other methods already end their options where paths or refs follow; `push origin -- branch`, `branch -D -- name` and `config -- key value` were each checked against git.

### Tests

Three cases, each confirmed to fail without the fix: the file read through `checkout`, and an option smuggled into the commits range and into the tags range. `verify` is hardened too but has no test: `rev-parse --verify` exits non-zero on option-only input, so its stdout never reaches the caller either way.
