### PR TITLE
fix(conventional-changelog): add conventional-commits-filter to dependencies

### DIFF
--- a/packages/conventional-changelog/package.json
+++ b/packages/conventional-changelog/package.json
@@ -70,6 +70,7 @@
     "argue-cli": "catalog:",
     "conventional-changelog-preset-loader": "workspace:^",
     "conventional-changelog-writer": "workspace:^",
+    "conventional-commits-filter": "workspace:^",
     "conventional-commits-parser": "workspace:^",
     "fd-package-json": "^2.0.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -113,6 +113,9 @@ importers:
       conventional-changelog-writer:
         specifier: workspace:^
         version: link:../conventional-changelog-writer
+      conventional-commits-filter:
+        specifier: workspace:^
+        version: link:../conventional-commits-filter
       conventional-commits-parser:
         specifier: workspace:^
         version: link:../conventional-commits-parser


### PR DESCRIPTION
## Problem

`ConventionalGitClient#loadDeps()` unconditionally dynamic-imports **both** `conventional-commits-parser` and `conventional-commits-filter` whenever `getCommits()` is called — even when `filterReverts` is not used:

https://github.com/conventional-changelog/conventional-changelog/blob/cbd52fb864806d078695e72c2263c1d950e67d5c/packages/git-client/src/ConventionalGitClient.ts#L41-L44

`@conventional-changelog/git-client` declares both packages as **optional `peerDependencies`**. The `conventional-changelog` package already declares `conventional-commits-parser` as a real dependency, but **not** `conventional-commits-filter`. 

https://github.com/conventional-changelog/conventional-changelog/blob/cbd52fb864806d078695e72c2263c1d950e67d5c/packages/conventional-changelog/package.json#L73

So whether the filter package is importable at runtime depends entirely on some *unrelated* package in the consumer's tree providing a real dependency edge to it, and on how npm happens to hoist things.

## Real-world failure

npm 11 prunes lockfile entries whose only incoming edge is an optional peer dependency (npm/cli#9249). Combined with the above, `conventional-changelog` crashes at runtime in perfectly ordinary setups.

Concrete reproduced case (`release-it` + `@release-it/conventional-changelog@11`): after an unrelated commitlint update (`@commitlint/read@21.2.1` requires `git-client@^3`), the tree gets two `git-client` majors; the `git-client@2.7.0` copy nested under `conventional-changelog@7` can only reach `conventional-commits-filter` through optional-peer placeholder entries — which npm 11 silently skips during `npm ci`:

```
ERROR Cannot find package 'conventional-commits-filter' imported from
node_modules/conventional-changelog/node_modules/@conventional-changelog/git-client/dist/ConventionalGitClient.js
```

Measured on the same `package-lock.json`: npm 10 installs 3331 packages, npm 11 installs 3182 — among the dropped ones, every copy of `conventional-commits-filter` reachable from the importing `git-client`. The failure is invisible to `npm ls` and to any CI job that doesn't execute changelog generation, so it only surfaces on release.

## Fix

Declare `conventional-commits-filter` as a real dependency of `conventional-changelog`, exactly mirroring the already-declared `conventional-commits-parser` — both are loaded unconditionally by `loadDeps()` on the `getCommits()` path, so the package's runtime contract is identical for the two.

```diff
     "conventional-changelog-writer": "workspace:^",
+    "conventional-commits-filter": "workspace:^",
     "conventional-commits-parser": "workspace:^",
```
