### PR TITLE
fix(conventional-changelog-writer): don't crash on a __proto__ commit type

### DIFF
--- a/packages/conventional-changelog-writer/src/context.spec.ts
+++ b/packages/conventional-changelog-writer/src/context.spec.ts
@@ -111,6 +111,57 @@ describe('conventional-changelog-writer', () => {
         ])
       })
 
+      it('should group by a value that is an `Object.prototype` member name', () => {
+        const commits = [
+          {
+            groupBy: '__proto__',
+            content: 'this is a __proto__',
+            notes: []
+          },
+          {
+            groupBy: '__proto__',
+            content: 'this is another __proto__',
+            notes: []
+          },
+          {
+            groupBy: 'constructor',
+            content: 'this is a constructor',
+            notes: []
+          }
+        ]
+        const commitGroups = getCommitGroups(commits, {
+          groupBy: 'groupBy'
+        })
+
+        expect(commitGroups).toEqual([
+          {
+            title: '__proto__',
+            commits: [
+              {
+                groupBy: '__proto__',
+                content: 'this is a __proto__',
+                notes: []
+              },
+              {
+                groupBy: '__proto__',
+                content: 'this is another __proto__',
+                notes: []
+              }
+            ]
+          },
+          {
+            title: 'constructor',
+            commits: [
+              {
+                groupBy: 'constructor',
+                content: 'this is a constructor',
+                notes: []
+              }
+            ]
+          }
+        ])
+      })
+
       it('should group and sort groups', () => {
         const commitGroups = getCommitGroups(commits, {
           groupBy: 'groupBy',

--- a/packages/conventional-changelog-writer/src/context.ts
+++ b/packages/conventional-changelog-writer/src/context.ts
@@ -22,6 +22,11 @@ export function getCommitGroups<Commit extends CommitKnownProps = CommitKnownPro
     commitsSort
   } = options
   const commitGroups: CommitGroup<Commit>[] = []
+  const initialGroups: Record<string, Commit[]> = {}
+
+  // Group keys come from commit messages, so they can be Object.prototype member names.
+  Object.setPrototypeOf(initialGroups, null)
+
   const commitGroupsObj = commits.reduce<Record<string, Commit[]>>((groups, commit) => {
     const key = commit[groupBy] as string || ''
 
@@ -32,7 +37,7 @@ export function getCommitGroups<Commit extends CommitKnownProps = CommitKnownPro
     }
 
     return groups
-  }, {})
+  }, initialGroups)
 
   Object.entries(commitGroupsObj).forEach(([title, commits]) => {
     if (commitsSort) {


### PR DESCRIPTION
A commit type that happens to be an `Object.prototype` member name kills the changelog run. The groups accumulator is a bare `{}`, so `groups['__proto__']` finds the inherited value insted of a group, and pushing to that throws:

```
$ conventional-changelog -p angular
TypeError: Error in conventional-changelog-writer: groups[key].push is not a function
```

Thats off a repo with one commit reading `__proto__: tweak the prototype guard` and a `BREAKING CHANGE:` footer. The footer is what makes it reachable at all. The angular preset drops an unrecognised type unless the commit carries notes, so a plain `__proto__:` commit never gets near the writer. `constructor`, `toString` and the rest of `Object.prototype` do the same.

Null prototype on the accumulator covers it. I kept it an object rather than swapping in a `Map`, so `Object.entries` ordering stays exactly as it was.
